### PR TITLE
Fix package media asset URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <!-- markdownlint-disable MD033 MD041 -->
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/acolomba/pi-claude-marketplace/main/images/redpi.png" alt="Pi Claude Marketplace logo" width="360">
+  <img src="https://media.githubusercontent.com/media/acolomba/pi-claude-marketplace/refs/heads/main/images/redpi.png" alt="Pi Claude Marketplace logo" width="360">
 </p>
 <!-- markdownlint-enable MD033 MD041 -->
 
@@ -14,7 +14,7 @@ Access Claude plugin marketplaces from Pi Coding Agent.
 <!-- markdownlint-disable MD033 -->
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/acolomba/pi-claude-marketplace/main/demos/marketplace-add-plugin-install.gif" alt="Marketplace install demo" width="720">
+  <img src="https://media.githubusercontent.com/media/acolomba/pi-claude-marketplace/refs/heads/main/demos/marketplace-add-plugin-install.gif" alt="Marketplace install demo" width="720">
 </p>
 <!-- markdownlint-enable MD033 -->
 

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "extensions": [
       "./extensions/pi-claude-marketplace/index.ts"
     ],
-    "image": "https://raw.githubusercontent.com/acolomba/pi-claude-marketplace/main/images/redpi.png"
+    "image": "https://media.githubusercontent.com/media/acolomba/pi-claude-marketplace/refs/heads/main/images/redpi.png"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Switch README logo and demo image URLs to media.githubusercontent.com main-branch refs.
- Switch package pi.image metadata to the same media URL form for the logo.

## Verification
- npm pack --dry-run
- npx markdownlint-cli2 README.md
- git diff --check