### PR TITLE
chore(release): prepare v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
-## [Unreleased]
+## [0.1.2] - 2026-05-13
+
+- Lowered Node.js engine requirement to `>=20.19.0` and downgraded `write-file-atomic` to v7 for broader compatibility.
+- Updated project branding images (SVG/PNG).
+
+## [0.1.1] - 2026-05-13
+
+- Moved @mariozechner packages to @earendil-works packages.
 
 ## [0.1.0] - 2026-05-12
 

--- a/extensions/pi-claude-marketplace/persistence/agents-index-io.ts
+++ b/extensions/pi-claude-marketplace/persistence/agents-index-io.ts
@@ -154,7 +154,7 @@ export async function loadAgentsIndex(loc: ScopedLocations): Promise<LoadedAgent
  * write -- refuses on schema violation rather than persisting bad data
  * (mirrors Phase 2 saveState pre-write Check, state-io.ts line 212).
  * The atomic write itself goes through `atomicWriteJson`, which uses
- * write-file-atomic@^8 (tmp + fsync + rename + concurrent-write queue).
+ * write-file-atomic@^7 (tmp + fsync + rename + concurrent-write queue).
  */
 export async function saveAgentsIndex(loc: ScopedLocations, index: AgentsIndex): Promise<void> {
   if (!AGENTS_INDEX_VALIDATOR.Check(index)) {

--- a/extensions/pi-claude-marketplace/shared/README.md
+++ b/extensions/pi-claude-marketplace/shared/README.md
@@ -15,6 +15,6 @@ Pure-leaves. The 5 ES-5 user-contract marker constants (`shared/markers.ts`), se
 - [x] `markers.ts` -- PRD §6.12 ES-5 prefix constants (Phase 1)
 - [x] `errors.ts` -- `errorMessage`, `appendLeakToError`, `appendLeaks` (Phase 1; verbatim V1 port)
 - [x] `notify.ts` -- `notifySuccess`, `notifyWarning`, `notifyError` (Phase 1)
-- [x] `atomic-json.ts` -- `atomicWriteJson` via `write-file-atomic@^8` (Phase 1)
+- [x] `atomic-json.ts` -- `atomicWriteJson` via `write-file-atomic@^7` (Phase 1)
 - [x] `path-safety.ts` -- `assertPathInside`, `PathContainmentError`, `SymlinkRefusedError` (Phase 1)
 - [ ] `types.ts` -- shared type bundle including `Scope` (Phase 2 -- moves `Scope` from `domain/` to keep `edge/` free of `domain/` imports)

--- a/extensions/pi-claude-marketplace/shared/atomic-json.ts
+++ b/extensions/pi-claude-marketplace/shared/atomic-json.ts
@@ -7,7 +7,7 @@ import writeFileAtomic from "write-file-atomic";
  * Atomic JSON write (D-03 / NFR-1 / AS-1).
  *
  * Replaces V1's hand-rolled `atomicWriteJson` in `fs-utils.ts`. Uses
- * `write-file-atomic@^8` which:
+ * `write-file-atomic@^7` which:
  *   - serializes concurrent writes to the same path through an internal queue
  *   - generates a unique tmp filename in the destination directory
  *   - fsyncs the tmp file AND the parent directory before returning (default)

--- a/images/redpi.png
+++ b/images/redpi.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4a8918e54e021011b9714ec558541916a5108437da2a53a195387177afd15e58
-size 2007
+oid sha256:46e822c5b4f14ca95bded9d65ab284e3369b1ccdb945630e234ed4d76c4cd543
+size 2733

--- a/images/redpi.svg
+++ b/images/redpi.svg
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   width="570"
-   height="430"
-   viewBox="0 0 570 430"
+   width="640"
+   height="550"
+   viewBox="0 0 640 550"
    role="img"
    aria-labelledby="title desc"
    version="1.1"
@@ -30,22 +30,22 @@
      inkscape:pageopacity="0.0"
      inkscape:pagecheckerboard="0"
      inkscape:deskcolor="#d1d1d1"
-     inkscape:zoom="2.12"
-     inkscape:cx="297.16981"
-     inkscape:cy="151.41509"
-     inkscape:window-width="2193"
-     inkscape:window-height="1413"
-     inkscape:window-x="400"
-     inkscape:window-y="31"
-     inkscape:window-maximized="0"
-     inkscape:current-layer="g4"
+     inkscape:zoom="1.22"
+     inkscape:cx="319.67213"
+     inkscape:cy="297.95082"
+     inkscape:current-layer="svg3"
      showgrid="true"
-     inkscape:export-bgcolor="#00000000">
+     inkscape:export-bgcolor="#00000000"
+     inkscape:window-width="1579"
+     inkscape:window-height="980"
+     inkscape:window-x="0"
+     inkscape:window-y="34"
+     inkscape:window-maximized="0">
     <inkscape:grid
        id="grid3"
        units="px"
-       originx="-360"
-       originy="-400"
+       originx="0"
+       originy="0"
        spacingx="10"
        spacingy="10"
        empcolor="#0099e5"
@@ -60,36 +60,41 @@
   <title
      id="title1">Blocky red pi-shaped mascot</title>
   <desc
-     id="desc1">A low-resolution block-style red mascot shaped like the Greek letter pi, with two black square eyes and a transparent background.</desc>
-  <g
-     id="g4"
-     transform="translate(-360,-400)"
-     style="shape-rendering:crispEdges">
-    <path
-       fill="#d40000"
-       d="m 480,440 h 340 60 v 60 h -60 v 60 H 760 V 790 H 680 V 560 H 620 V 790 H 540 V 560 h -60 v 30 h -70 v -70 h 70 z"
-       id="path1"
-       style="fill:#d40000;fill-opacity:1"
-       sodipodi:nodetypes="cccccccccccccccccccc" />
-    <rect
-       x="560"
-       y="480"
-       width="40"
-       height="40"
-       fill="#050403"
-       id="rect2"
-       style="fill:#ffffff;stroke-width:0.999998" />
-    <rect
-       x="700"
-       y="480"
-       width="40.056519"
-       height="40"
-       fill="#050403"
-       id="rect3"
-       style="fill:#ffffff;stroke-width:0.999998" />
-  </g>
+     id="desc1">A low-resolution block-style red mascot shaped like the Greek letter pi, with two white square eyes, a red square border, and a transparent background.</desc>
+  <rect
+     x="30"
+     y="50"
+     width="580"
+     height="450"
+     fill="none"
+     stroke="#d40000"
+     stroke-width="30"
+     id="border1"
+     style="fill:none;stroke:#d40000;stroke-width:30;shape-rendering:crispEdges" />
+  <path
+     fill="#d40000"
+     d="m 150,140 h 410 v 70 h -70 v 90 h -60 v 130 h -80 v -130 h -60 v 130 h -80 v -130 h -60 v 0 H 80 v -70 h 70 z"
+     id="path1"
+     style="fill:#d40000;fill-opacity:1;shape-rendering:crispEdges"
+     sodipodi:nodetypes="ccccccccccccccccccc" />
+  <rect
+     x="230"
+     y="180"
+     width="40"
+     height="40"
+     fill="#ffffff"
+     id="rect2"
+     style="fill:#ffffff;shape-rendering:crispEdges" />
+  <rect
+     x="370"
+     y="180"
+     width="40"
+     height="40"
+     fill="#ffffff"
+     id="rect3"
+     style="fill:#ffffff;shape-rendering:crispEdges" />
   <metadata
-     id="metadata3">
+     id="metadata1">
     <rdf:RDF>
       <cc:Work
          rdf:about="">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "pi-claude-marketplace",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-claude-marketplace",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "isomorphic-git": "^1.37.6",
         "proper-lockfile": "^4.1.2",
-        "write-file-atomic": "^8.0.0"
+        "write-file-atomic": "^7.0.1"
       },
       "devDependencies": {
         "@earendil-works/pi-coding-agent": "^0.74.0",
@@ -31,7 +31,7 @@
         "typescript-eslint": "^8.59.1"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
         "@earendil-works/pi-coding-agent": ">=0.74.0",
@@ -6717,15 +6717,15 @@
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-8.0.0.tgz",
-      "integrity": "sha512-dYwyZredl67GyLLIHJnRM3h2PcOmN5SkcgC7eM5DPDEOEl6dLFqVrMg3F1Ea32usj4VSVZtd2H4MtKTNOf6nPg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-7.0.1.tgz",
+      "integrity": "sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg==",
       "license": "ISC",
       "dependencies": {
         "signal-exit": "^4.0.1"
       },
       "engines": {
-        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/write-file-atomic/node_modules/signal-exit": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "isomorphic-git": "^1.37.6",
     "proper-lockfile": "^4.1.2",
-    "write-file-atomic": "^8.0.0"
+    "write-file-atomic": "^7.0.1"
   },
   "description": "Access Claude plugin marketplaces from Pi.",
   "devDependencies": {
@@ -29,7 +29,7 @@
     "typescript-eslint": "^8.59.1"
   },
   "engines": {
-    "node": ">=22"
+    "node": ">=20.19.0"
   },
   "files": [
     "CHANGELOG.md",
@@ -82,5 +82,5 @@
     "typecheck": "tsc --noEmit"
   },
   "type": "module",
-  "version": "0.1.1"
+  "version": "0.1.2"
 }

--- a/tests/shared/atomic-json.test.ts
+++ b/tests/shared/atomic-json.test.ts
@@ -7,7 +7,7 @@ import test from "node:test";
 import { atomicWriteJson } from "../../extensions/pi-claude-marketplace/shared/atomic-json.ts";
 
 /**
- * NFR-1, AS-1, D-03 -- atomicWriteJson via write-file-atomic@^8.
+ * NFR-1, AS-1, D-03 -- atomicWriteJson via write-file-atomic@^7.
  *
  * The library handles tmp + fsync + rename internally; these tests verify
  * the wrapper produces the expected shape (2-space indent + trailing newline)


### PR DESCRIPTION
## Summary
- Lower Node.js engine requirement to >=20.19.0 via write-file-atomic v7
- Refresh SVG/PNG branding assets
- Bump package version to 0.1.2 and update changelog

## Verification
- pre-commit hooks passed
- npm lint
- npm format check
- npm typecheck