### PR TITLE
fix(paths): honor pi agent dir override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@
 /.ralph/
 /.serena
 
+# gsd
+/.agent/
+
 # build output
 /dist/
 /build/
@@ -28,6 +31,9 @@ pnpm-debug.log*
 
 # package artifacts
 *.tgz
+
+# tmp
+/tmp/
 
 # worktrees
 /.worktrees/

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -92,6 +92,12 @@ None yet.
 - Behavioral Gaps 1, 2, 4-10 (FEATURES Gap series) need explicit resolutions logged in PROJECT.md Key Decisions before Phase 4/5 planning. SUMMARY.md provides recommended resolutions.
 - `write-file-atomic@^8` Node engine constraint bumps effective floor from 22.0 to 22.22.2; confirm CI Node range before adopting in Phase 1.
 
+### Quick Tasks Completed
+
+| # | Description | Date | Commit | Status | Directory |
+| --- | --- | --- | --- | --- | --- |
+| 260515-bkt | lets update the specs and the implementation to listen to PI_CODING_AGENT_DIR if set instead of hardcoding ~/.pi | 2026-05-14 | 0257577 | Verified | [260515-bkt-pi-coding-agent-dir](./quick/260515-bkt-pi-coding-agent-dir/) |
+
 ## Deferred Items
 
 Items acknowledged and carried forward from previous milestone close:
@@ -101,5 +107,7 @@ Items acknowledged and carried forward from previous milestone close:
 | *(none -- first milestone)* |      |        |             |
 
 ## Session Continuity
+
+Last activity: 2026-05-14 - Completed quick task 260515-bkt: lets update the specs and the implementation to listen to PI_CODING_AGENT_DIR if set instead of hardcoding ~/.pi
 
 Last session: 2026-05-11T20:42:58.893Z

--- a/.planning/quick/260515-bkt-pi-coding-agent-dir/260515-bkt-PLAN.md
+++ b/.planning/quick/260515-bkt-pi-coding-agent-dir/260515-bkt-PLAN.md
@@ -1,0 +1,64 @@
+---
+mode: quick-full
+must_haves:
+  truths:
+    - User-scope storage must resolve through Pi's agent directory resolver, honoring PI_CODING_AGENT_DIR when set.
+    - Project scope must remain <cwd>/.pi and not be affected by PI_CODING_AGENT_DIR.
+    - Specs must describe user scope as the resolved Pi agent directory, with ~/.pi/agent only as the default.
+  artifacts:
+    - extensions/pi-claude-marketplace/platform/pi-api.ts
+    - extensions/pi-claude-marketplace/persistence/locations.ts
+    - extensions/pi-claude-marketplace/bridges/mcp/collision-slots.ts
+    - docs/prd/pi-claude-marketplace-prd.md
+    - CLAUDE.md
+    - tests/persistence/locations.test.ts
+    - tests/bridges/mcp/collision-slots.test.ts
+  key_links:
+    - Pi exports getAgentDir from @earendil-works/pi-coding-agent.
+---
+
+# Quick Task PLAN: Honor PI_CODING_AGENT_DIR for User Scope
+
+## Task 1: Route user-scope path resolution through Pi
+
+- files:
+  - `extensions/pi-claude-marketplace/platform/pi-api.ts`
+  - `extensions/pi-claude-marketplace/persistence/locations.ts`
+  - `extensions/pi-claude-marketplace/bridges/mcp/collision-slots.ts`
+- action:
+  - Re-export Pi's `getAgentDir` from the local Pi API boundary.
+  - Replace hardcoded `os.homedir()/.pi/agent` user-scope paths with `getAgentDir()`.
+  - Keep project-scope paths based on `<cwd>/.pi`.
+- verify:
+  - Typecheck passes.
+  - Targeted persistence and MCP tests pass.
+- done:
+  - No production user-scope storage path composes `os.homedir(), ".pi", "agent"` directly.
+
+## Task 2: Add regression coverage for PI_CODING_AGENT_DIR
+
+- files:
+  - `tests/persistence/locations.test.ts`
+  - `tests/bridges/mcp/collision-slots.test.ts`
+- action:
+  - Add tests proving `locationsFor("user")` and MCP collision slot 1 honor `PI_CODING_AGENT_DIR`.
+  - Keep default-path tests deterministic by clearing the env var around those assertions.
+- verify:
+  - `node --test tests/persistence/locations.test.ts tests/bridges/mcp/collision-slots.test.ts`
+- done:
+  - Regression tests fail against the old hardcoded implementation and pass after the fix.
+
+## Task 3: Update specs and project context
+
+- files:
+  - `CLAUDE.md`
+  - `docs/prd/pi-claude-marketplace-prd.md`
+  - relevant code comments/user-facing descriptions
+- action:
+  - Define user scope as the resolved Pi agent directory: default `~/.pi/agent`, overridden by `PI_CODING_AGENT_DIR`.
+  - Update MC-4 and storage-layout wording to avoid normative hardcoding of `~/.pi/agent`.
+- verify:
+  - `rg "~/.pi/agent"` only shows default/example wording, not unconditional requirements.
+  - `npm run check` passes.
+- done:
+  - Specs and implementation describe the same behavior.

--- a/.planning/quick/260515-bkt-pi-coding-agent-dir/260515-bkt-SUMMARY.md
+++ b/.planning/quick/260515-bkt-pi-coding-agent-dir/260515-bkt-SUMMARY.md
@@ -1,0 +1,22 @@
+# Quick Task 260515-bkt Summary
+
+**Task:** lets update the specs and the implementation to listen to PI_CODING_AGENT_DIR if set instead of hardcoding ~/.pi
+**Status:** Complete
+
+## Changes
+
+- Routed user-scope path resolution through Pi's `getAgentDir()` export via `platform/pi-api.ts`.
+- Updated user-scope `ScopedLocations` and pi-mcp-adapter collision slot 1 to honor `PI_CODING_AGENT_DIR`.
+- Added regression tests for `locationsFor("user")` and `MCP_COLLISION_SLOTS()` with `PI_CODING_AGENT_DIR` set.
+- Updated PRD/project docs and code comments to define user scope as the resolved Pi agent dir, with `~/.pi/agent` only as the default.
+- Kept project scope unchanged at `<cwd>/.pi`.
+
+## Verification
+
+- `node --test tests/persistence/locations.test.ts tests/bridges/mcp/collision-slots.test.ts` ✅
+- `npm run check` ✅
+- LSP diagnostics for edited implementation files ✅
+
+## Notes
+
+`scripts/pi.sh --home ...` now aligns with extension behavior because the extension resolves user scope through Pi's agent-dir resolver instead of composing `os.homedir()/.pi/agent` directly.

--- a/.planning/quick/260515-bkt-pi-coding-agent-dir/260515-bkt-VERIFICATION.md
+++ b/.planning/quick/260515-bkt-pi-coding-agent-dir/260515-bkt-VERIFICATION.md
@@ -1,0 +1,17 @@
+status: passed
+
+# Quick Task 260515-bkt Verification
+
+## Must-haves
+
+- User-scope storage resolves through Pi's agent directory resolver and honors `PI_CODING_AGENT_DIR`: **passed**
+- Project scope remains `<cwd>/.pi`: **passed**
+- Specs describe user scope as resolved Pi agent dir with `~/.pi/agent` only as default: **passed**
+- Regression tests cover env override for locations and MCP collision slots: **passed**
+
+## Evidence
+
+- `platform/pi-api.ts` re-exports `getAgentDir` from `@earendil-works/pi-coding-agent`.
+- `persistence/locations.ts` uses `getAgentDir()` for `scope === "user"`.
+- `bridges/mcp/collision-slots.ts` uses `path.join(getAgentDir(), "mcp.json")` for pi-user-scope slot.
+- Targeted tests and full `npm run check` pass.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.1.3] - 2026-05-15
+
+- Fixed user-scope path resolution to honor Pi's agent home override.
+- Updated the demo recording to use an isolated Pi home.
+
 ## [0.1.2] - 2026-05-13
 
 - Lowered Node.js engine requirement to `>=20.19.0` and downgraded `write-file-atomic` to v7 for broader compatibility.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ This GSD project plans a successor architecture for the V1 implementation alread
 - **Output channel:** All user-visible messages MUST go through `ctx.ui.notify(message, severity)`; direct `process.stdout`/`process.stderr` writes forbidden in command/bridge code (IL-2). Single sanctioned `console.warn` is the load-time legacy migration save failure (IL-3)
 - **No telemetry V1:** No metrics, no event sink, no analytics endpoint (IL-4)
 - **English only V1:** No message catalog, no locale negotiation (IL-1)
-- **Scope model:** Exactly two scopes -- `user` (`~/.pi/agent/`) and `project` (`<cwd>/.pi/`). Claude Code's `local` scope is not introduced (SC-1)
+- **Scope model:** Exactly two scopes -- `user` (Pi agent dir; defaults to `~/.pi/agent/` and honors `PI_CODING_AGENT_DIR`) and `project` (`<cwd>/.pi/`). Claude Code's `local` scope is not introduced (SC-1)
 
 <!-- GSD:project-end -->
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,3 +225,19 @@ Do not make direct repo edits outside a GSD workflow unless the user explicitly 
 > Profile not yet configured. Run `/gsd-profile-user` to generate your developer profile. This section is managed by `generate-claude-profile` -- do not edit manually.
 
 <!-- GSD:profile-end -->
+
+## Guidelines
+
+### Git
+
+- Branch names: `main`, `features/*`, `releases/*`. New feature branches use `features/<name>`.
+- Worktrees are preferred for new feature work; create them under `.worktrees/`.
+- Git commit messages: Follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#specification). Titles must be at least 5 characters and no more than 72 characters. Body lines must be no more than 80 characters.
+- Run `pre-commit run --all-files` (or `pre-commit run --files <changed files>`) **before** attempting `git commit`. Fix any failures, restage, and re-run until clean. Do not commit and recover from hook failures after the fact -- a failed pre-commit hook means the commit did NOT happen, so iterating with `--amend` is wrong (it would alter the previous commit).
+- NEVER use `--no-verify` to skip the hooks.
+- When committing from inside a worktree, prefix the commit with `SKIP=trufflehog`. The trufflehog hook's auto-updater fails to spawn child processes under the worktree sandbox even though the underlying scan succeeds; running `pre-commit run trufflehog --all-files` separately (outside `git commit`) still passes and should be done before the commit to confirm the scan is clean. Do not extend `SKIP=` to other hooks.
+- When writing PR descriptions, use the `humanizer` skill if available.
+
+### Versioning
+
+- Before creating a PR, offer to bump the project version and record the change in CHANGELOG.md.

--- a/demos/marketplace-add-plugin-install.gif
+++ b/demos/marketplace-add-plugin-install.gif
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1c4bc3e4e3864cb4e59bd256f830ca3e4cd8c25b1c53fe9144a23109869d96cf
-size 2169227
+oid sha256:4a7374d97055c645fd362092b1e9c899fa70838555d977251ad0ab82b0d5be26
+size 2742672

--- a/demos/marketplace-add-plugin-install.tape
+++ b/demos/marketplace-add-plugin-install.tape
@@ -66,4 +66,6 @@ Enter
 Sleep 5s
 
 Hide
+Type "/claude:plugin marketplace rm anthropics/claude-plugins-official"
+Sleep 500ms
 Ctrl+C

--- a/demos/marketplace-add-plugin-install.tape
+++ b/demos/marketplace-add-plugin-install.tape
@@ -1,6 +1,7 @@
 Output demos/marketplace-add-plugin-install.gif
 
 Require pi
+Require npm
 
 Set Shell "bash"
 Set FontFamily "Fira Code Retina"
@@ -10,7 +11,7 @@ Set Height 1080
 Set TypingSpeed 55ms
 
 Hide
-Type "pi --no-extensions --no-skills --no-prompt-templates -e ./extensions/pi-claude-marketplace/index.ts -e /opt/homebrew/lib/node_modules/pi-mcp-adapter/index.ts -e /opt/homebrew/lib/node_modules/pi-subagents/src/extension/index.ts"
+Type "./scripts/pi.sh --home tmp/pihome --cd work --clear-screen"
 Enter
 Sleep 3000ms
 Show
@@ -66,9 +67,3 @@ Sleep 5s
 
 Hide
 Ctrl+C
-Sleep 1s
-Type "/claude:plugin marketplace remove claude-plugins-official"
-Enter
-Sleep 1800ms
-Type "/quit"
-Enter

--- a/demos/marketplace-add-plugin-install.tape
+++ b/demos/marketplace-add-plugin-install.tape
@@ -11,7 +11,7 @@ Set Height 1080
 Set TypingSpeed 55ms
 
 Hide
-Type "./scripts/pi.sh --home tmp/pihome --cd work --clear-screen"
+Type "./scripts/pi.sh --home $(pwd)/tmp/pihome --cd $(pwd)/tmp/work --clear-screen"
 Enter
 Sleep 3000ms
 Show

--- a/docs/prd/pi-claude-marketplace-prd.md
+++ b/docs/prd/pi-claude-marketplace-prd.md
@@ -79,7 +79,7 @@ ______________________________________________________________________
 
 - **Reuse the Claude plugin ecosystem from inside Pi** -- every supported Claude plugin component should be installable through a single namespaced command (`/claude:plugin …`).
 - **Preserve familiar UX** -- subcommand names, syntax for plugin references (`<plugin>@<marketplace>`), and source forms (`owner/repo`, `https://github.com/...#<ref>`, local paths) match Claude Code parity within the V1 scope.
-- **Two scopes only** -- `user` (`~/.pi/agent/`) and `project` (`<cwd>/.pi/`), mirroring Pi's scope model rather than Claude Code's `local` scope.
+- **Two scopes only** -- `user` (Pi agent dir, default `~/.pi/agent/`, honoring `PI_CODING_AGENT_DIR`) and `project` (`<cwd>/.pi/`), mirroring Pi's scope model rather than Claude Code's `local` scope.
 - **Soft-degrade** -- features that require companion extensions (`pi-subagents`, `pi-mcp-adapter`) must not block installs; instead they degrade gracefully with explicit guidance.
 - **Atomic, recoverable operations** -- install, update, uninstall, and marketplace removal must never leave on-disk artefacts and persisted state in irrecoverable disagreement; failures must surface a recovery path.
 
@@ -109,7 +109,7 @@ ______________________________________________________________________
 
 - **Pi** -- the host coding agent (`@mariozechner/pi-coding-agent`).
 - **Extension** -- a Pi extension; this product registers the `claude:plugin` LLM tool family, one `resources_discover` listener (the bridge that exposes staged skills/prompts to Pi), and one `session_start` listener (the wrapper that adds `/claude:plugin`-scoped fish-style space normalization to the autocomplete provider; see §6.6 TC-7).
-- **Scope** -- `user` or `project`. User scope writes to `~/.pi/agent/`; project scope writes to `<cwd>/.pi/`.
+- **Scope** -- `user` or `project`. User scope writes to the Pi agent dir (default `~/.pi/agent/`, overridden by `PI_CODING_AGENT_DIR`); project scope writes to `<cwd>/.pi/`.
 - **Marketplace** -- a Claude marketplace, identified by a name from its `marketplace.json`.
 - **Marketplace source** -- how a marketplace is fetched: GitHub `owner/repo[#<ref>]`, GitHub HTTPS URL, or a local path.
 - **Plugin** -- a Claude plugin, identified by `<plugin>@<marketplace>`.
@@ -431,7 +431,7 @@ flowchart LR
 | **MC-1** | The `mcpServers` declaration MUST be resolved with precedence: marketplace entry > plugin manifest > standalone `.mcp.json` at plugin root. First match wins; malformed at the matched source MUST throw (no fallthrough). Under `strict=false`, this precedence chain applies only when the marketplace entry itself declares `mcpServers`; manifest- or standalone-only declarations under `strict=false` are conflicts (per MM-7), not precedence fallbacks. |
 | **MC-2** | A `.mcp.json` may use either the canonical unwrapped form (top-level entries) or the legacy wrapped form (`{ "mcpServers": { ... } }`). Both MUST parse.                                                                                                                                                                                                                                                                                                        |
 | **MC-3** | A plugin whose only declaration is a malformed `mcpServers` MUST surface as **unavailable** with `malformed mcpServers: <reason>` -- silent fallthrough is not allowed.                                                                                                                                                                                                                                                                                         |
-| **MC-4** | Server-name collisions MUST be checked across all four pi-mcp-adapter slots: `~/.config/mcp/mcp.json`, `~/.pi/agent/mcp.json`, `<cwd>/.mcp.json`, `<cwd>/.pi/mcp.json`. Self-replace within the same scope's mcp.json is allowed; foreign collisions MUST refuse stage.                                                                                                                                                                                         |
+| **MC-4** | Server-name collisions MUST be checked across all four pi-mcp-adapter slots: `~/.config/mcp/mcp.json`, `<Pi agent dir>/mcp.json` (default `~/.pi/agent/mcp.json`, honoring `PI_CODING_AGENT_DIR`), `<cwd>/.mcp.json`, `<cwd>/.pi/mcp.json`. Self-replace within the same scope's mcp.json is allowed; foreign collisions MUST refuse stage.                                                                                                                     |
 | **MC-5** | Each staged entry MUST carry a `_piClaudeMarketplace: { plugin, marketplace }` marker so uninstall/update drops only its own entries.                                                                                                                                                                                                                                                                                                                           |
 | **MC-6** | Staging MUST be two-phase (compute next doc in memory; commit via atomic JSON write). The "noop" branch (no new servers AND no previous ours) MUST not materialize the file.                                                                                                                                                                                                                                                                                    |
 | **MC-7** | Unstage MUST tolerate a missing `mcpServers` field (null/missing) without crashing.                                                                                                                                                                                                                                                                                                                                                                             |
@@ -481,7 +481,7 @@ ______________________________________________________________________
 
 | ID       | Requirement                                                                                                                                                                                                                                                                                       |
 | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **SC-1** | The system MUST support exactly two scopes: `user` (`~/.pi/agent/`) and `project` (`<cwd>/.pi/`). Claude Code's `local` scope MUST NOT be introduced unless Pi adds an equivalent.                                                                                                                |
+| **SC-1** | The system MUST support exactly two scopes: `user` (Pi agent dir, default `~/.pi/agent/`, honoring `PI_CODING_AGENT_DIR`) and `project` (`<cwd>/.pi/`). Claude Code's `local` scope MUST NOT be introduced unless Pi adds an equivalent.                                                          |
 | **SC-2** | All extension data lives at `<scopeRoot>/pi-claude-marketplace/`. Bridge files live at `<scopeRoot>/agents/` and `<scopeRoot>/mcp.json` (deliberately outside the extension's resources/).                                                                                                        |
 | **SC-3** | A `ScopedLocations` object MUST be a typed bundle that's the only way to derive on-disk paths for an operation; hand-crafted shapes that mix scopes MUST not type-check (brand symbol).                                                                                                           |
 | **SC-4** | Scope resolution rules for name-targeted commands. When `--scope` is provided, use that scope and error if the name is not found there. When `--scope` is omitted, search both scopes; error if found in both ("Use --scope user or --scope project to disambiguate"); error if found in neither. |
@@ -931,7 +931,7 @@ flowchart TB
 ### 9.2 Persistence layout per scope
 
 ```text
-<scopeRoot>/                          # ~/.pi/agent (user) or <cwd>/.pi (project)
+<scopeRoot>/                          # Pi agent dir (user; defaults to ~/.pi/agent) or <cwd>/.pi (project)
 ├── pi-claude-marketplace/               # extensionRoot
 │   ├── state.json                    # marketplaces + plugins
 │   ├── agents-index.json             # generated-agent index

--- a/extensions/pi-claude-marketplace/bridges/mcp/collision-slots.ts
+++ b/extensions/pi-claude-marketplace/bridges/mcp/collision-slots.ts
@@ -13,13 +13,15 @@ import { readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import path from "node:path";
 
+import { getAgentDir } from "../../platform/pi-api.ts";
+
 /**
  * MC-4 / RN-5 user-contract slot list. The four pi-mcp-adapter
  * configuration paths checked for cross-slot collisions during stage.
  * Order is FIRST-DECLARER-WINS:
  *
  *   [0] shared-global  -- ~/.config/mcp/mcp.json
- *   [1] pi-user-scope  -- ~/.pi/agent/mcp.json
+ *   [1] pi-user-scope  -- <Pi agent dir>/mcp.json (defaults to ~/.pi/agent/mcp.json)
  *   [2] shared-project -- <cwd>/.mcp.json
  *   [3] pi-project-scope -- <cwd>/.pi/mcp.json
  *
@@ -29,7 +31,7 @@ import path from "node:path";
 export function MCP_COLLISION_SLOTS(cwd: string): readonly string[] {
   return Object.freeze([
     path.join(homedir(), ".config", "mcp", "mcp.json"),
-    path.join(homedir(), ".pi", "agent", "mcp.json"),
+    path.join(getAgentDir(), "mcp.json"),
     path.join(cwd, ".mcp.json"),
     path.join(cwd, ".pi", "mcp.json"),
   ]);

--- a/extensions/pi-claude-marketplace/edge/completions/data.ts
+++ b/extensions/pi-claude-marketplace/edge/completions/data.ts
@@ -145,7 +145,7 @@ export function getScopeCompletions(argumentTextPrefix: string): AutocompleteIte
   return [
     {
       ...buildItem(argumentTextPrefix, "--scope user", true),
-      description: "User scope (~/.pi/agent)",
+      description: "User scope (Pi agent dir; defaults to ~/.pi/agent)",
     },
     {
       ...buildItem(argumentTextPrefix, "--scope project", true),

--- a/extensions/pi-claude-marketplace/persistence/locations.ts
+++ b/extensions/pi-claude-marketplace/persistence/locations.ts
@@ -13,10 +13,10 @@
 // Per CONTEXT.md D-10, ScopedLocations is per-scope independent.
 // Cross-scope reads are explicitly not modeled here.
 
-import os from "node:os";
 import path from "node:path";
 
 import { assertSafeName } from "../domain/name.ts";
+import { getAgentDir } from "../platform/pi-api.ts";
 import { assertPathInside } from "../shared/path-safety.ts";
 
 import type { Scope } from "../shared/types.ts";
@@ -38,7 +38,7 @@ const SCOPED_LOCATIONS_BRAND: unique symbol = Symbol("ScopedLocations");
 export interface ScopedLocations {
   readonly [SCOPED_LOCATIONS_BRAND]: true;
   readonly scope: Scope;
-  /** `~/.pi/agent` for user scope, `<cwd>/.pi` for project scope. */
+  /** Pi agent dir for user scope, `<cwd>/.pi` for project scope. */
   readonly scopeRoot: string;
   /** `<scopeRoot>/pi-claude-marketplace/` -- the extension's writable root. */
   readonly extensionRoot: string;
@@ -104,8 +104,9 @@ export interface ScopedLocations {
 /**
  * SOLE factory for ScopedLocations (SC-3 brand discipline).
  *
- * `scope` selects between user (`~/.pi/agent/`) and project (`<cwd>/.pi/`)
- * roots per SC-1 / SC-2. `cwd` is used only for `scope === 'project'`; for
+ * `scope` selects between user (Pi agent dir; defaults to `~/.pi/agent/`
+ * and honors `PI_CODING_AGENT_DIR`) and project (`<cwd>/.pi/`) roots per
+ * SC-1 / SC-2. `cwd` is used only for `scope === 'project'`; for
  * user scope, `cwd` is ignored.
  *
  * The returned object is frozen so a caller cannot mutate `scope` or any
@@ -113,8 +114,7 @@ export interface ScopedLocations {
  * the brand-symbol type-level guarantee.
  */
 export function locationsFor(scope: Scope, cwd: string): ScopedLocations {
-  const scopeRoot =
-    scope === "user" ? path.join(os.homedir(), ".pi", "agent") : path.join(cwd, ".pi");
+  const scopeRoot = scope === "user" ? getAgentDir() : path.join(cwd, ".pi");
 
   const extensionRoot = path.join(scopeRoot, "pi-claude-marketplace");
   const stateJsonPath = path.join(extensionRoot, "state.json");

--- a/extensions/pi-claude-marketplace/platform/pi-api.ts
+++ b/extensions/pi-claude-marketplace/platform/pi-api.ts
@@ -9,6 +9,8 @@
 
 import { PI_MCP_ADAPTER_NOT_LOADED, PI_SUBAGENTS_NOT_LOADED } from "../shared/markers.ts";
 
+export { getAgentDir } from "@earendil-works/pi-coding-agent";
+
 export type {
   ExtensionAPI,
   ExtensionCommandContext,

--- a/extensions/pi-claude-marketplace/shared/types.ts
+++ b/extensions/pi-claude-marketplace/shared/types.ts
@@ -5,12 +5,13 @@
 // the D-11 import boundary (edge/ MUST NOT import from domain/).
 //
 // Per Phase 1 SUMMARY handoff item #1 + SC-1 (PRD §6.2): exactly two
-// scopes -- `user` (~/.pi/agent/) and `project` (<cwd>/.pi/). The Claude
-// Code `local` scope is intentionally NOT introduced.
+// scopes -- `user` (Pi agent dir; defaults to ~/.pi/agent and honors
+// PI_CODING_AGENT_DIR) and `project` (<cwd>/.pi). The Claude Code `local`
+// scope is intentionally NOT introduced.
 
 /**
  * The two extension scopes (SC-1).
- * - `user`:    `~/.pi/agent/pi-claude-marketplace/`
+ * - `user`:    `<Pi agent dir>/pi-claude-marketplace/`
  * - `project`: `<cwd>/.pi/pi-claude-marketplace/`
  */
 export type Scope = "user" | "project";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-claude-marketplace",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-claude-marketplace",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "isomorphic-git": "^1.37.6",

--- a/package.json
+++ b/package.json
@@ -82,5 +82,5 @@
     "typecheck": "tsc --noEmit"
   },
   "type": "module",
-  "version": "0.1.2"
+  "version": "0.1.3"
 }

--- a/scripts/pi.sh
+++ b/scripts/pi.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/pi.sh [--clear-screen] [--home PATH] [--cd PATH] [--] [pi args...]
+
+Runs Pi with only this project, pi-mcp-adapter, and pi-subagents loaded as
+extensions.
+
+Options:
+  --cd PATH               Run Pi from PATH instead of the current directory.
+  --clear-screen, --clear  Clear the terminal before preparing and launching Pi.
+  -h, --help              Show this help.
+  --home PATH             Use PATH as the Pi home for this run.
+
+All remaining arguments are forwarded to pi.
+USAGE
+}
+
+clear_screen=0
+pi_home=""
+pi_cd=""
+pi_args=()
+
+while (($# > 0)); do
+  case "$1" in
+    --clear-screen|--clear)
+      clear_screen=1
+      shift
+      ;;
+    --home)
+      if (($# < 2)); then
+        echo "scripts/pi.sh: --home requires a path" >&2
+        exit 2
+      fi
+      pi_home=$2
+      shift 2
+      ;;
+    --home=*)
+      pi_home=${1#--home=}
+      if [[ -z "$pi_home" ]]; then
+        echo "scripts/pi.sh: --home requires a path" >&2
+        exit 2
+      fi
+      shift
+      ;;
+    --cd)
+      if (($# < 2)); then
+        echo "scripts/pi.sh: --cd requires a path" >&2
+        exit 2
+      fi
+      pi_cd=$2
+      shift 2
+      ;;
+    --cd=*)
+      pi_cd=${1#--cd=}
+      if [[ -z "$pi_cd" ]]; then
+        echo "scripts/pi.sh: --cd requires a path" >&2
+        exit 2
+      fi
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      pi_args+=("$@")
+      break
+      ;;
+    *)
+      pi_args+=("$1")
+      shift
+      ;;
+  esac
+done
+
+clear_terminal() {
+  if [[ -n "${TERM:-}" && "${TERM:-}" != "dumb" ]] && command -v clear >/dev/null 2>&1; then
+    clear
+  else
+    printf '\033[H\033[2J\033[3J'
+  fi
+}
+
+if ((clear_screen)); then
+  clear_terminal
+fi
+
+repo_root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+
+restore_cwd() {
+  local status=$?
+
+  popd >/dev/null || true
+  exit "$status"
+}
+
+if [[ -n "$pi_cd" ]]; then
+  if [[ "$pi_cd" == "~" || "$pi_cd" == "~/"* ]]; then
+    pi_cd=${pi_cd/#\~/$HOME}
+  fi
+
+  pushd "$pi_cd" >/dev/null
+  trap restore_cwd EXIT
+fi
+
+project_extension="$repo_root/extensions/pi-claude-marketplace/index.ts"
+
+ensure_global_package() {
+  local package_name=$1
+
+  if ! npm ls -g --depth=0 "$package_name" >/dev/null 2>&1; then
+    npm install -g "$package_name"
+  fi
+}
+
+ensure_global_package pi-mcp-adapter
+ensure_global_package pi-subagents
+
+npm_root=$(npm root -g)
+mcp_adapter_extension="$npm_root/pi-mcp-adapter/index.ts"
+subagents_extension="$npm_root/pi-subagents/src/extension/index.ts"
+
+for extension_path in "$project_extension" "$mcp_adapter_extension" "$subagents_extension"; do
+  if [[ ! -f "$extension_path" ]]; then
+    echo "scripts/pi.sh: extension not found: $extension_path" >&2
+    exit 1
+  fi
+done
+
+if [[ -n "$pi_home" ]]; then
+  if [[ "$pi_home" == "~" || "$pi_home" == "~/"* ]]; then
+    pi_home=${pi_home/#\~/$HOME}
+  fi
+
+  export PI_CODING_AGENT_DIR="$pi_home/agent"
+  export PI_CODING_AGENT_SESSION_DIR="$pi_home/sessions"
+  mkdir -p "$PI_CODING_AGENT_DIR" "$PI_CODING_AGENT_SESSION_DIR"
+fi
+
+pi_command=(
+  pi
+  --no-extensions
+  --no-skills
+  --no-prompt-templates
+  -e "$project_extension"
+  -e "$mcp_adapter_extension"
+  -e "$subagents_extension"
+  "${pi_args[@]}"
+)
+
+"${pi_command[@]}"

--- a/tests/bridges/mcp/collision-slots.test.ts
+++ b/tests/bridges/mcp/collision-slots.test.ts
@@ -11,26 +11,52 @@ import {
 
 // MC-4 / RN-5 -- four-slot enumeration + first-declarer-wins.
 
-test("MC-4 MCP_COLLISION_SLOTS returns 4 paths in user-contract order", () => {
-  const cwd = "/tmp/test-cwd-xyz";
-  const slots = MCP_COLLISION_SLOTS(cwd);
-  assert.equal(slots.length, 4, "exactly four slots");
+function withPiAgentDir<T>(value: string | undefined, fn: () => T): T {
+  const previous = process.env.PI_CODING_AGENT_DIR;
 
-  const [slot0, slot1, slot2, slot3] = slots;
-  // Slot 0: shared-global -- ~/.config/mcp/mcp.json
-  assert.ok(
-    slot0!.endsWith(path.join(".config", "mcp", "mcp.json")),
-    `slot[0] should end with .config/mcp/mcp.json, got ${String(slot0)}`,
-  );
-  // Slot 1: pi-user-scope -- ~/.pi/agent/mcp.json
-  assert.ok(
-    slot1!.endsWith(path.join(".pi", "agent", "mcp.json")),
-    `slot[1] should end with .pi/agent/mcp.json, got ${String(slot1)}`,
-  );
-  // Slot 2: shared-project -- <cwd>/.mcp.json
-  assert.equal(slot2, path.join(cwd, ".mcp.json"));
-  // Slot 3: pi-project-scope -- <cwd>/.pi/mcp.json
-  assert.equal(slot3, path.join(cwd, ".pi", "mcp.json"));
+  if (value === undefined) {
+    delete process.env.PI_CODING_AGENT_DIR;
+  } else {
+    process.env.PI_CODING_AGENT_DIR = value;
+  }
+
+  try {
+    return fn();
+  } finally {
+    if (previous === undefined) {
+      delete process.env.PI_CODING_AGENT_DIR;
+    } else {
+      process.env.PI_CODING_AGENT_DIR = previous;
+    }
+  }
+}
+
+test("MC-4 MCP_COLLISION_SLOTS returns 4 paths in user-contract order", () => {
+  withPiAgentDir(undefined, () => {
+    const cwd = "/tmp/test-cwd-xyz";
+    const slots = MCP_COLLISION_SLOTS(cwd);
+    assert.equal(slots.length, 4, "exactly four slots");
+
+    const [slot0, slot1, slot2, slot3] = slots;
+    // Slot 0: shared-global -- ~/.config/mcp/mcp.json
+    assert.ok(
+      slot0!.endsWith(path.join(".config", "mcp", "mcp.json")),
+      `slot[0] should end with .config/mcp/mcp.json, got ${String(slot0)}`,
+    );
+    // Slot 1: pi-user-scope -- Pi agent dir mcp.json (default ~/.pi/agent/mcp.json)
+    assert.equal(slot1, path.join(os.homedir(), ".pi", "agent", "mcp.json"));
+    // Slot 2: shared-project -- <cwd>/.mcp.json
+    assert.equal(slot2, path.join(cwd, ".mcp.json"));
+    // Slot 3: pi-project-scope -- <cwd>/.pi/mcp.json
+    assert.equal(slot3, path.join(cwd, ".pi", "mcp.json"));
+  });
+});
+
+test("MC-4 MCP_COLLISION_SLOTS honors PI_CODING_AGENT_DIR for pi-user-scope slot", () => {
+  withPiAgentDir(path.join("/tmp", "pi-home", "agent"), () => {
+    const slots = MCP_COLLISION_SLOTS("/tmp/test-cwd-xyz");
+    assert.equal(slots[1], path.join("/tmp", "pi-home", "agent", "mcp.json"));
+  });
 });
 
 test("MC-4 MCP_COLLISION_SLOTS returns frozen array", () => {

--- a/tests/persistence/locations.test.ts
+++ b/tests/persistence/locations.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
@@ -15,14 +16,47 @@ import {
  * SC-7: name-derived path methods route through assertPathInside.
  */
 
-test("SC-1 / SC-2 locationsFor('user') returns ~/.pi/agent/ paths", () => {
-  const loc = locationsFor("user", "/anywhere");
-  assert.equal(loc.scope, "user");
-  assert.ok(loc.scopeRoot.endsWith(path.join(".pi", "agent")));
-  assert.ok(loc.extensionRoot.endsWith(path.join(".pi", "agent", "pi-claude-marketplace")));
-  assert.ok(loc.stateJsonPath.endsWith("state.json"));
-  assert.ok(loc.agentsDir.endsWith(path.join(".pi", "agent", "agents")));
-  assert.ok(loc.mcpJsonPath.endsWith(path.join(".pi", "agent", "mcp.json")));
+function withPiAgentDir<T>(value: string | undefined, fn: () => T): T {
+  const previous = process.env.PI_CODING_AGENT_DIR;
+
+  if (value === undefined) {
+    delete process.env.PI_CODING_AGENT_DIR;
+  } else {
+    process.env.PI_CODING_AGENT_DIR = value;
+  }
+
+  try {
+    return fn();
+  } finally {
+    if (previous === undefined) {
+      delete process.env.PI_CODING_AGENT_DIR;
+    } else {
+      process.env.PI_CODING_AGENT_DIR = previous;
+    }
+  }
+}
+
+test("SC-1 / SC-2 locationsFor('user') returns Pi agent dir default paths", () => {
+  withPiAgentDir(undefined, () => {
+    const loc = locationsFor("user", "/anywhere");
+    assert.equal(loc.scope, "user");
+    assert.equal(loc.scopeRoot, path.join(os.homedir(), ".pi", "agent"));
+    assert.ok(loc.extensionRoot.endsWith(path.join(".pi", "agent", "pi-claude-marketplace")));
+    assert.ok(loc.stateJsonPath.endsWith("state.json"));
+    assert.ok(loc.agentsDir.endsWith(path.join(".pi", "agent", "agents")));
+    assert.ok(loc.mcpJsonPath.endsWith(path.join(".pi", "agent", "mcp.json")));
+  });
+});
+
+test("SC-1 / SC-2 locationsFor('user') honors PI_CODING_AGENT_DIR", () => {
+  withPiAgentDir(path.join("/tmp", "pi-home", "agent"), () => {
+    const loc = locationsFor("user", "/anywhere");
+    assert.equal(loc.scope, "user");
+    assert.equal(loc.scopeRoot, path.join("/tmp", "pi-home", "agent"));
+    assert.equal(loc.extensionRoot, path.join("/tmp", "pi-home", "agent", "pi-claude-marketplace"));
+    assert.equal(loc.agentsDir, path.join("/tmp", "pi-home", "agent", "agents"));
+    assert.equal(loc.mcpJsonPath, path.join("/tmp", "pi-home", "agent", "mcp.json"));
+  });
 });
 
 test("SC-1 / SC-2 locationsFor('project', cwd) returns <cwd>/.pi/ paths", () => {


### PR DESCRIPTION
## Summary
- honor the Pi agent home override when resolving user-scope paths
- record the GSD task notes for the Pi home fix
- update the demo recording assets to use an isolated Pi home

## Validation
- pre-commit run --files .gitignore demos/marketplace-add-plugin-install.gif demos/marketplace-add-plugin-install.tape
- trufflehog filesystem --no-update --fail --exclude-detectors SonarCloud,CloudflareApiToken .

Note: the pre-commit trufflehog hook itself fails in this worktree because it expects .git/index, but .git is a worktree gitdir file. Per project guidance, the commit used SKIP=trufflehog after running a separate TruffleHog scan.