### PR TITLE
chore(tooling): switch from gsd to gsd-redux

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -44,6 +44,16 @@
         ]
       },
       {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/gsd-graphify-update.sh",
+            "timeout": 5
+          }
+        ]
+      },
+      {
         "matcher": "Write|Edit",
         "hooks": [
           {

--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ npm run check
 
 ## AI disclaimer
 
-This project is developed with AI agent engineering practices using the [GSD](https://github.com/gsd-build/get-shit-done) spec-driven development system.
+This project is developed with AI agent engineering practices using the [GSD redux](https://github.com/open-gsd/get-shit-done-redux) spec-driven development system.
 
 The author vibe-coded a prototype until it was feature-complete for a first release, then extracted and reviewed a PRD from the implementation.
 


### PR DESCRIPTION
## Summary

The original GSD maintainer went quiet in April 2026 after a crypto rug pull. The community picked up the codebase and published it as [open-gsd/get-shit-done-redux](https://github.com/open-gsd/get-shit-done-redux) (discussion: https://github.com/open-gsd/get-shit-done-redux/discussions/1).

- Updates the README AI disclaimer to link to the community fork
- Applies `settings.json` hook additions that came in with the redux version

## Test plan

- [x] README link points to `open-gsd/get-shit-done-redux`
- [x] `npm run check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)