### PR TITLE
refactor: extract shared helpers to cut SonarCloud code duplication (0.4.3)

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -182,6 +182,7 @@ None yet.
 | 260530-fast | Resolve 4 SonarCloud code smells on PR #22 (S3735 void operator, S1871 duplicate case, S3626 redundant jump, S7755 .at indexing); coverage deferred | 2026-05-30 | a36988d |          | (inline /gsd-fast, no task dir) |
 | 260605-tmr | Reconcile v1.8 shipped state (STATE.md frontmatter/body/session-continuity) and prune resolved v1.4-UAT section from BACKLOG.md | 2026-06-05 | 0a11ba3 | Verified | [260605-tmr-reconcile-v1-8-shipped-state-and-prune-s](./quick/260605-tmr-reconcile-v1-8-shipped-state-and-prune-s/) |
 | 260608-npa | Remove brittle README-prose reinstall-docs test; PRL coverage already on behavior/spec tests (output-catalog catalog-uat); re-tag PRL-01; npm run check green | 2026-06-08 | 0d7c797 | Verified | [260608-npa-remove-readme-prose-reinstall-docs-test-](./quick/260608-npa-remove-readme-prose-reinstall-docs-test-/) |
+| 260609-bfq | Reduce SonarCloud CPD duplication via shared-helper extraction (plugin/marketplace edge handlers, marketplace orchestrators, notify plugin-row) + patch bump 0.4.2->0.4.3; byte-neutral (catalog-uat + notify 110/110) | 2026-06-09 | 7242a1e | Verified | [260609-bfq-reduce-sonarcloud-cpd-duplication-via-sh](./quick/260609-bfq-reduce-sonarcloud-cpd-duplication-via-sh/) |
 
 ## Deferred Items
 
@@ -204,8 +205,8 @@ _The two former `upstream_finding` rows (pi-tui `@`-precedence tab-completion / 
 
 ## Session Continuity
 
-Last session: 2026-06-08T17:30:38.555Z
-Stopped At: Completed 50-01-PLAN.md
+Last session: 2026-06-09
+Stopped At: Completed quick task 260609-bfq (CPD-duplication shared-helper extraction + v0.4.3 bump) on branch features/reduce-cpd-duplication
 Resume File: None
 
 ## Operator Next Steps

--- a/.planning/quick/260609-bfq-reduce-sonarcloud-cpd-duplication-via-sh/260609-bfq-PLAN.md
+++ b/.planning/quick/260609-bfq-reduce-sonarcloud-cpd-duplication-via-sh/260609-bfq-PLAN.md
@@ -1,0 +1,475 @@
+---
+phase: quick-260609-bfq
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - extensions/pi-claude-marketplace/edge/handlers/plugin/shared.ts
+  - extensions/pi-claude-marketplace/edge/handlers/plugin/install.ts
+  - extensions/pi-claude-marketplace/edge/handlers/plugin/update.ts
+  - extensions/pi-claude-marketplace/edge/handlers/marketplace/shared.ts
+  - extensions/pi-claude-marketplace/edge/handlers/marketplace/info.ts
+  - extensions/pi-claude-marketplace/edge/handlers/marketplace/remove.ts
+  - extensions/pi-claude-marketplace/orchestrators/marketplace/shared.ts
+  - extensions/pi-claude-marketplace/orchestrators/marketplace/update.ts
+  - extensions/pi-claude-marketplace/orchestrators/marketplace/remove.ts
+  - extensions/pi-claude-marketplace/shared/notify.ts
+  - package.json
+  - sonar-project.properties
+  - package-lock.json
+  - CHANGELOG.md
+autonomous: true
+requirements: [NFR-6]
+
+must_haves:
+  truths:
+    - "npm run check stays green after every one of the 5 commits"
+    - "catalog-uat + notify-v2 byte-form tests pass unchanged (output byte-identical)"
+    - "no public API, output, or behavior change — strictly internal helper extraction"
+    - "each refactor + the version bump is its own atomic Conventional-Commits commit, in order"
+    - "version reads 0.4.3 across package.json, sonar-project.properties, package-lock.json"
+  artifacts:
+    - path: "extensions/pi-claude-marketplace/edge/handlers/plugin/shared.ts"
+      provides: "parseMapModelArgs shared arg-parse helper"
+      contains: "parseMapModelArgs"
+    - path: "extensions/pi-claude-marketplace/edge/handlers/marketplace/shared.ts"
+      provides: "makeSingleNameMarketplaceHandler factory"
+      contains: "makeSingleNameMarketplaceHandler"
+    - path: "extensions/pi-claude-marketplace/orchestrators/marketplace/shared.ts"
+      provides: "resolveScopeOrNotifyNotAdded lifted shared helper"
+      contains: "resolveScopeOrNotifyNotAdded"
+    - path: "extensions/pi-claude-marketplace/shared/notify.ts"
+      provides: "pluginRow local helper folding 4 identical switch arms"
+      contains: "pluginRow"
+    - path: "CHANGELOG.md"
+      provides: "0.4.3 changelog entry"
+      contains: "0.4.3"
+  key_links:
+    - from: "edge/handlers/plugin/install.ts"
+      to: "parseMapModelArgs"
+      via: "import from ./shared.ts"
+      pattern: "parseMapModelArgs"
+    - from: "orchestrators/marketplace/update.ts"
+      to: "resolveScopeOrNotifyNotAdded"
+      via: "import from ./shared.ts"
+      pattern: "resolveScopeOrNotifyNotAdded"
+---
+
+<objective>
+Reduce SonarCloud CPD (copy-paste) duplication by extracting four shared helpers
+(plugin edge-handler arg-parse boilerplate, single-name marketplace edge
+handlers, the marketplace orchestrator `resolveScopeOrNotifyNotAdded` function,
+and the notify.ts plugin-row switch arms), then bump the patch version
+0.4.2 → 0.4.3.
+
+This is a STRICTLY BYTE-NEUTRAL refactor: no output, behavior, or public-API
+change. The existing byte-form regression tests are the gate
+(`tests/architecture/catalog-uat.test.ts`, `tests/shared/notify-v2.test.ts`).
+`npm run check` (typecheck + ESLint + Prettier + unit + integration) MUST pass
+after every commit. Each of the 5 items is its OWN atomic commit using
+Conventional Commits, body lines ≤ 80 chars.
+
+Purpose: Lower the CPD percentage SonarCloud reports without touching
+`sonar.cpd.exclusions` and without altering any user-visible surface (NFR-6).
+Output: Four extracted helpers + thin call-site rewrites, plus a patch version
+bump and CHANGELOG entry. Five commits.
+
+OUT OF SCOPE (do NOT touch): refactor #4 (the predicate-divergent block between
+`resolveCrossScopePluginTarget` and `resolveInstalledMarketplaceTarget` in
+`orchestrators/plugin/shared.ts`). Do NOT modify `sonar.cpd.exclusions`.
+</objective>
+
+<execution_context>
+@/home/acolomba/pi-claude-marketplace/.claude/get-shit-done/workflows/execute-plan.md
+@/home/acolomba/pi-claude-marketplace/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@./CLAUDE.md
+
+# Edge handlers (commits 1 + 2)
+@extensions/pi-claude-marketplace/edge/handlers/plugin/install.ts
+@extensions/pi-claude-marketplace/edge/handlers/plugin/update.ts
+@extensions/pi-claude-marketplace/edge/handlers/plugin/shared.ts
+@extensions/pi-claude-marketplace/edge/handlers/marketplace/info.ts
+@extensions/pi-claude-marketplace/edge/handlers/marketplace/remove.ts
+
+# Orchestrators (commit 3)
+@extensions/pi-claude-marketplace/orchestrators/marketplace/update.ts
+@extensions/pi-claude-marketplace/orchestrators/marketplace/remove.ts
+@extensions/pi-claude-marketplace/orchestrators/marketplace/shared.ts
+
+# Renderer (commit 5)
+@extensions/pi-claude-marketplace/shared/notify.ts
+
+# Byte-form gate tests (read to understand what must stay green; do NOT modify)
+@tests/architecture/catalog-uat.test.ts
+@tests/shared/notify-v2.test.ts
+</context>
+
+<commit_policy>
+Per ./CLAUDE.md (follow exactly):
+- We are already on branch `features/reduce-cpd-duplication`. NEVER commit to `main`.
+- Before EACH `git commit`, run `pre-commit run --files <changed files>` (or
+  `pre-commit run --all-files`). Fix failures, restage, re-run until clean. A
+  failed hook means the commit did NOT happen — do NOT `--amend` to recover.
+- NEVER use `--no-verify`.
+- Conventional Commits. Title 5–72 chars. Body lines ≤ 80 chars.
+- Five separate atomic commits, IN ORDER (refactor 1 → 2 → 3 → 5 → version bump).
+  Do not squash; each commit must independently leave `npm run check` green.
+- The byte-form gate for every refactor commit is that
+  `tests/architecture/catalog-uat.test.ts` and `tests/shared/notify-v2.test.ts`
+  pass UNCHANGED (output byte-identical) — not merely that the code compiles.
+</commit_policy>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1 — refactor: plugin edge-handler arg-parse boilerplate</name>
+  <files>
+    extensions/pi-claude-marketplace/edge/handlers/plugin/shared.ts
+    extensions/pi-claude-marketplace/edge/handlers/plugin/install.ts
+    extensions/pi-claude-marketplace/edge/handlers/plugin/update.ts
+  </files>
+  <action>
+install.ts and update.ts share the identical opening sequence: a `try { parsed =
+parseArgs(args) } catch (err) { notifyUsageError(ctx, { message:
+errorMessage(err), usage: USAGE }); return; }`, then `const flagged =
+parsePositionalsWithFlags(parsed.positional, ctx, USAGE)` with an `=== undefined`
+return-guard, then `const { nonFlagPositionals, mapModel } = flagged`.
+
+Extract this into a new exported helper in edge/handlers/plugin/shared.ts
+(alongside `parsePositionalsWithFlags` / `splitPluginMarketplaceRef`):
+`parseMapModelArgs(args: string, ctx: ExtensionCommandContext, usage: string):
+{ scope?: Scope; nonFlagPositionals: string[]; mapModel: boolean } | undefined`.
+It performs the parseArgs try/catch (notifying via `notifyUsageError` with
+`errorMessage(err)` on failure), then the `parsePositionalsWithFlags` call with
+its undefined-guard, and returns `undefined` whenever an error has ALREADY been
+notified (either parse failure or unknown-flag from parsePositionalsWithFlags).
+On success it returns the destructured `{ nonFlagPositionals, mapModel }` plus
+`parsed.scope` carried out via `...(parsed.scope !== undefined && { scope:
+parsed.scope })` so the optional-property contract matches `parsed.scope`'s
+`Scope | undefined` shape under TS strict.
+
+Import the needed symbols into shared.ts: `parseArgs` from `../../args.ts`,
+`errorMessage` from `../../../shared/errors.ts` (notifyUsageError is already
+imported there). Return type uses the existing `Scope` type import.
+
+Rewrite install.ts: replace its opening parse block with `const flagged =
+parseMapModelArgs(args, ctx, USAGE); if (flagged === undefined) return; const {
+nonFlagPositionals, mapModel } = flagged;` then KEEP its distinct post-parse
+logic verbatim (the `nonFlagPositionals.length !== 1` exactly-one-ref guard, the
+`splitPluginMarketplaceRef` ref guard, and the `installPlugin({...})` call). The
+install call reads `parsed.scope ?? "user"`; after the refactor it reads
+`flagged.scope ?? "user"` — same value, since the helper carries scope through.
+
+Rewrite update.ts identically for the opening block, then KEEP its distinct
+post-parse logic verbatim (the `nonFlagPositionals.length > 1` too-many guard,
+the all / `@<marketplace>` / `<plugin>@<marketplace>` target-form branching, and
+the `updatePlugins({...})` call). The update call's `...(parsed.scope !==
+undefined && { scope: parsed.scope })` becomes `...(flagged.scope !== undefined
+&& { scope: flagged.scope })`.
+
+Both handlers drop their now-unused direct imports of `parseArgs`,
+`errorMessage`, and `notifyUsageError` IF those symbols are no longer referenced
+in the file after the rewrite (install/update still import
+`splitPluginMarketplaceRef`; update still uses it; install still uses
+`notifyUsageError` for its post-parse guards, so KEEP notifyUsageError +
+splitPluginMarketplaceRef in install; check each import against actual remaining
+usage and let ESLint `import-x`/`no-unused-vars` confirm). Behavior, notified
+strings, and the install/update USAGE constants stay byte-identical.
+  </action>
+  <verify>
+    <automated>npm run typecheck && npm run lint && npm run format:check && node --test "tests/edge/**/*.test.ts" "tests/architecture/catalog-uat.test.ts"</automated>
+  </verify>
+  <done>
+parseMapModelArgs exists in plugin/shared.ts and is called by both install.ts
+and update.ts; the duplicated parse-block is gone from both handlers; their
+post-parse logic is unchanged; typecheck/lint/format/edge+catalog-uat tests
+green. Then run `pre-commit run --files <changed>`, restage, and commit as
+`refactor: extract plugin edge-handler arg-parse boilerplate` (body explains the
+parseMapModelArgs extraction, ≤ 80-char lines).
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 2 — refactor: single-name marketplace edge handlers</name>
+  <files>
+    extensions/pi-claude-marketplace/edge/handlers/marketplace/shared.ts
+    extensions/pi-claude-marketplace/edge/handlers/marketplace/info.ts
+    extensions/pi-claude-marketplace/edge/handlers/marketplace/remove.ts
+  </files>
+  <action>
+info.ts and remove.ts are identical except (a) the USAGE string and (b) which
+orchestrator they delegate to (`getMarketplaceInfo` vs `removeMarketplace`),
+both invoked as `{ ctx, pi, name: parsed.name, cwd: ctx.cwd, ...(parsed.scope
+!== undefined && { scope: parsed.scope }) }`. Both perform the same
+`parseCommandArgs(args, { positional: [{ name: "name" }] as const, usage:
+USAGE }, (message) => notifyUsageError(ctx, { message: message === USAGE ?
+"Missing required argument." : message, usage: USAGE }))` parse + the `===
+undefined` guard.
+
+Create a NEW file edge/handlers/marketplace/shared.ts exporting a factory
+`makeSingleNameMarketplaceHandler(pi, usage, run)` where:
+- `pi: ExtensionAPI`,
+- `usage: string`,
+- `run` is the delegate, typed to structurally accept `{ ctx:
+  ExtensionCommandContext; pi: ExtensionAPI; name: string; cwd: string; scope?:
+  Scope } => Promise<void>`. Confirm BOTH `GetMarketplaceInfoOptions`
+  (orchestrators/marketplace/info.ts) and `RemoveMarketplaceOptions`
+  (orchestrators/marketplace/remove.ts) structurally satisfy this param shape —
+  GetMarketplaceInfoOptions is `{ ctx, pi, name, scope?, cwd }` (exact match);
+  RemoveMarketplaceOptions is the same plus an OPTIONAL `cascade?`, which a
+  caller omitting `cascade` satisfies. Type the `run` param so the factory's
+  returned handler builds the options object with `{ ctx, pi, name: parsed.name,
+  cwd: ctx.cwd, ...(parsed.scope !== undefined && { scope: parsed.scope }) }`.
+
+The factory returns `(args, ctx) => Promise<void>` performing the
+parseCommandArgs single-`name`-positional parse + the `message === usage ?
+"Missing required argument." : message` error callback + the `=== undefined`
+guard + `await run({...})`. Import `notifyUsageError` from
+`../../../shared/notify.ts`, `parseCommandArgs` from `../../args-schema.ts`, and
+the `ExtensionAPI`, `ExtensionCommandContext`, `Scope` types.
+
+Rewrite makeMarketplaceInfoHandler / makeRemoveHandler as thin wrappers:
+`export function makeMarketplaceInfoHandler(pi) { return
+makeSingleNameMarketplaceHandler(pi, USAGE, getMarketplaceInfo); }` and
+likewise for remove with `removeMarketplace`. Each handler file KEEPS its own
+USAGE constant and its existing header-comment rationale verbatim (info's `{not
+added}` carve-out note; remove's `rm`-alias note + the `removeMarketplace`
+requires-`pi` RH-5 note). info.ts/remove.ts drop their now-unused
+`parseCommandArgs` and `notifyUsageError` imports (the factory owns them);
+verify via ESLint. Notified strings, USAGE byte values, and delegate behavior
+stay byte-identical.
+  </action>
+  <verify>
+    <automated>npm run typecheck && npm run lint && npm run format:check && node --test "tests/edge/**/*.test.ts" "tests/architecture/catalog-uat.test.ts"</automated>
+  </verify>
+  <done>
+edge/handlers/marketplace/shared.ts exists with
+`makeSingleNameMarketplaceHandler`; makeMarketplaceInfoHandler and
+makeRemoveHandler are thin wrappers over it; each handler's header rationale
+comment is preserved; USAGE strings unchanged; typecheck/lint/format/edge+
+catalog-uat tests green. Then run `pre-commit run --files <changed>`, restage,
+and commit as `refactor: extract single-name marketplace edge handler factory`
+(≤ 80-char body lines).
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 3 — refactor (top priority): lift resolveScopeOrNotifyNotAdded</name>
+  <files>
+    extensions/pi-claude-marketplace/orchestrators/marketplace/shared.ts
+    extensions/pi-claude-marketplace/orchestrators/marketplace/update.ts
+    extensions/pi-claude-marketplace/orchestrators/marketplace/remove.ts
+  </files>
+  <action>
+The ~33-line `resolveScopeOrNotifyNotAdded` function is duplicated near-verbatim
+in orchestrators/marketplace/update.ts (lines ~225-259) and remove.ts (lines
+~180-212); only the `opts` type and a couple of comments differ. Body: the
+bare-form path (`opts.scope === undefined`) calls `resolveScopeFromState`,
+catching `MarketplaceNotFoundError` to emit `notify(opts.ctx, opts.pi, { kind:
+"marketplace-not-added", name: opts.name })` and return undefined (re-throwing
+any other error); the explicit-scope path does a `loadState` pre-guard read and
+emits `notify(... { kind: "marketplace-not-added", name: opts.name, scope:
+opts.scope })` when the record is absent; otherwise returns `{ scope, locations
+}`.
+
+Lift it into orchestrators/marketplace/shared.ts (already the home of
+`resolveScopeFromState`) as an exported async function. Change its signature to
+take the structural subset instead of the per-caller opts type:
+`resolveScopeOrNotifyNotAdded(opts: { ctx: ExtensionContext; pi: ExtensionAPI;
+name: string; scope?: Scope }, userLocations: ScopedLocations, projectLocations:
+ScopedLocations): Promise<{ scope: Scope; locations: ScopedLocations } |
+undefined>`. Verify BOTH `UpdateMarketplaceOptions` and
+`RemoveMarketplaceOptions` satisfy that structural subset (both carry `ctx: …
+ExtensionContext`, `pi: ExtensionAPI`, `name: string`, `scope?: Scope` — they
+do; the extra fields on each are irrelevant to the subset).
+
+shared.ts needs these imports added (check what is already imported there —
+`loadState` and `MarketplaceNotFoundError` are already imported;
+`resolveScopeFromState` is defined in-file): add `notify` from
+`../../shared/notify.ts` and the types `ExtensionContext`, `ExtensionAPI` from
+`../../platform/pi-api.ts`. `ScopedLocations` and `Scope` types are already
+imported. Consolidate the rationale comment (the ATTR-06 / D-48-C Shape 1 /
+NFR-5 / bracket-discipline block) onto the lifted helper — keep the substantive
+comment, drop per-file `mirrors remove.ts` / `mirrors update.ts` cross-refs that
+no longer apply.
+
+In update.ts: DELETE the local `resolveScopeOrNotifyNotAdded` function and its
+doc comment; import the helper from `./shared.ts`; the existing call site in
+`updateMarketplace` (`await resolveScopeOrNotifyNotAdded(opts, userLocations,
+projectLocations)`) is unchanged because `opts` (UpdateMarketplaceOptions)
+structurally satisfies the subset param. Remove now-unused imports from
+update.ts: `MarketplaceNotFoundError` is used ONLY by the deleted function (the
+`reasonsFromCascadeError` / refresh paths do not reference it — confirm via grep
+before removing) and `loadState` is still used elsewhere in update.ts
+(updateAllMarketplaces + snapshot pre-guard? confirm) — only remove imports
+ESLint flags as unused.
+
+In remove.ts: DELETE the local `resolveScopeOrNotifyNotAdded` and its doc
+comment; import the helper from `./shared.ts`; the call site in
+`removeMarketplace` is unchanged (RemoveMarketplaceOptions satisfies the subset).
+Remove imports that become unused (e.g. `MarketplaceNotFoundError` if only the
+deleted function used it; confirm via grep — remove.ts still uses `loadState`?
+the deleted function used it for the pre-guard; if no other use remains, drop
+it). Let ESLint `no-unused-vars` / `import-x` be the authority; do not guess.
+
+CRITICAL: the lifted helper's behavior — the two notify payloads (bare form WITH
+NO scope field; explicit-scope form WITH the scope field), the
+MarketplaceNotFoundError catch-and-convert, the re-throw of other errors, and the
+loadState pre-guard — must be byte-for-byte preserved. The `{not added}` output
+is exercised by catalog-uat; both orchestrators' option types and call sites must
+still typecheck.
+  </action>
+  <verify>
+    <automated>npm run typecheck && npm run lint && npm run format:check && node --test "tests/orchestrators/**/*.test.ts" "tests/architecture/catalog-uat.test.ts"</automated>
+  </verify>
+  <done>
+`resolveScopeOrNotifyNotAdded` exists once in orchestrators/marketplace/shared.ts
+with the structural-subset signature; both update.ts and remove.ts import and
+call it; both local copies are DELETED; both option types satisfy the subset and
+both files typecheck; the consolidated rationale comment lives on the shared
+helper; orchestrator + catalog-uat tests green (the `{not added}` byte form is
+unchanged). Then run `pre-commit run --files <changed>`, restage, and commit as
+`refactor: lift marketplace resolveScopeOrNotifyNotAdded to shared` (≤ 80-char
+body lines).
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 5 — refactor: notify.ts plugin-row switch arms</name>
+  <files>
+    extensions/pi-claude-marketplace/shared/notify.ts
+  </files>
+  <action>
+In `renderPluginRow` (shared/notify.ts, switch on `p.status`), the `upgradable`,
+`skipped`, `failed`, and `manual recovery` arms are identical except (a) the icon
+(`ICON_INSTALLED` for `upgradable`; `ICON_UNINSTALLABLE` for the other three) and
+(b) the parenthesized status label (`"(upgradable)"` / `"(skipped)"` /
+`"(failed)"` / `"(manual recovery)"`). Each arm is currently:
+`return joinTokens([icon, p.name, renderScopeBracket(p.scope, mpScope),
+renderVersion(p.version), "(label)", composeReasons(p.reasons, false, false,
+probe)]);`
+
+Add a LOCAL, NON-EXPORTED helper near `renderPluginRow` (file-private, same as
+`joinTokens` / `renderVersion`):
+`function pluginRow(icon: string, p: { name: string; scope?: Scope; version?:
+string; reasons: readonly ContentReason[] }, mpScope: Scope, label: string,
+probe: SoftDepStatus): string` returning `joinTokens([icon, p.name,
+renderScopeBracket(p.scope, mpScope), renderVersion(p.version), label,
+composeReasons(p.reasons, false, false, probe)])`. Type the `p` param as the
+structural subset the four arms share (name + optional scope + optional version +
+required reasons) so each arm's already-narrowed `p` satisfies it; `reasons`
+is `readonly ContentReason[]` per those four variants' interfaces. `label` is the
+full parenthesized token (caller passes `"(upgradable)"` etc., INCLUDING the
+parens), keeping the `"(manual recovery)"` literal WITH ITS SPACE verbatim.
+
+Rewrite the four arms to call it:
+- `case "upgradable": return pluginRow(ICON_INSTALLED, p, mpScope,
+  "(upgradable)", probe);`
+- `case "skipped": return pluginRow(ICON_UNINSTALLABLE, p, mpScope, "(skipped)",
+  probe);`
+- `case "failed": return pluginRow(ICON_UNINSTALLABLE, p, mpScope, "(failed)",
+  probe);`
+- `case "manual recovery": return pluginRow(ICON_UNINSTALLABLE, p, mpScope,
+  "(manual recovery)", probe);`
+
+LEAVE the `unavailable` arm UNCHANGED — it uses `renderScopeBracket(undefined,
+mpScope)` (the MSG-PL-6 / SNM-11 carve-out: `unavailable` has NO `scope?` field
+and must NOT pass `p.scope`), so it is NOT byte-equivalent to the four folded
+arms and must not be folded in. Do NOT touch the `installed`/`present`/`updated`/
+`reinstalled`/`uninstalled`/`available` arms either (different icons, version
+forms, dependencies-driven composeReasons, or undefined-scope carve-out). The
+`failed.cause` / `manual recovery.cause` trailers and `failed.rollbackPartial`
+child rows are composed OUTSIDE renderPluginRow (by `notify`) and are unaffected.
+
+Output MUST stay byte-identical — `tests/architecture/catalog-uat.test.ts` and
+`tests/shared/notify-v2.test.ts` are the gate.
+  </action>
+  <verify>
+    <automated>npm run typecheck && npm run lint && npm run format:check && node --test "tests/shared/notify-v2.test.ts" "tests/architecture/catalog-uat.test.ts"</automated>
+  </verify>
+  <done>
+A file-private `pluginRow` helper exists in shared/notify.ts; the `upgradable`,
+`skipped`, `failed`, and `manual recovery` arms call it; the `unavailable` arm
+and all other arms are untouched; notify-v2 + catalog-uat byte-form tests pass
+UNCHANGED (output byte-identical). Then run `pre-commit run --files <changed>`,
+restage, and commit as `refactor: fold notify plugin-row switch arms into helper`
+(≤ 80-char body lines).
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 6 (final) — chore: patch version bump 0.4.2 → 0.4.3</name>
+  <files>
+    package.json
+    sonar-project.properties
+    package-lock.json
+    CHANGELOG.md
+  </files>
+  <action>
+Bump the patch version 0.4.2 → 0.4.3:
+- package.json: update the top-level `"version": "0.4.2"` (line ~87) to
+  `"0.4.3"`.
+- sonar-project.properties: update `sonar.projectVersion=0.4.2` (line ~7) to
+  `0.4.3`.
+- package-lock.json: update the root `"version": "0.4.2"` (line ~3) AND the
+  matching self-referential package entry `"version": "0.4.2"` at the `""`
+  package key (line ~9) to `"0.4.3"`. Prefer regenerating via `npm install
+  --package-lock-only` after bumping package.json so the lockfile stays
+  internally consistent; if editing by hand, change ONLY the two `0.4.2` →
+  `0.4.3` version fields and leave everything else untouched. Verify `git diff
+  package-lock.json` shows only version-field changes.
+- CHANGELOG.md: add a new `## [0.4.3] - 2026-06-09` section at the top (directly
+  under the `# Changelog` heading, above the `## [0.4.2]` section), following the
+  existing bullet format. One succinct entry: internal refactor — extracted
+  shared helpers to cut SonarCloud CPD duplication across the plugin and
+  marketplace edge handlers, the marketplace orchestrators, and the notify
+  plugin-row renderer; no behavior or output change.
+
+Do NOT touch sonar.cpd.exclusions. This is the LAST commit; it carries no source
+changes.
+  </action>
+  <verify>
+    <automated>grep -q '"version": "0.4.3"' package.json && grep -q "sonar.projectVersion=0.4.3" sonar-project.properties && grep -q '0.4.3' CHANGELOG.md && head -5 package-lock.json | grep -q '"version": "0.4.3"' && npm run check</automated>
+  </verify>
+  <done>
+`version` reads `0.4.3` in package.json, sonar-project.properties, and the
+package-lock.json root (+ self-entry); CHANGELOG.md has a `## [0.4.3] -
+2026-06-09` section in the established format; `git diff package-lock.json`
+shows only version fields changed; `npm run check` is fully green. Then run
+`pre-commit run --files <changed>`, restage, and commit as `chore: bump version
+to 0.4.3` (≤ 80-char body lines).
+  </done>
+</task>
+
+</tasks>
+
+<verification>
+After each of the 5 commits, the relevant gate must be green; after the final
+commit, the full `npm run check` (typecheck + lint + format:check + test +
+test:integration) must pass. The two byte-form regression suites
+(`tests/architecture/catalog-uat.test.ts`, `tests/shared/notify-v2.test.ts`)
+must pass UNCHANGED throughout — they prove the refactors are byte-neutral. No
+edits to `sonar.cpd.exclusions`. No source changes in the version-bump commit.
+</verification>
+
+<success_criteria>
+- 5 atomic Conventional-Commits commits exist in order: refactor 1, 2, 3, 5,
+  then the chore version bump.
+- `parseMapModelArgs` (plugin/shared.ts), `makeSingleNameMarketplaceHandler`
+  (marketplace edge shared.ts), `resolveScopeOrNotifyNotAdded` (marketplace
+  orchestrator shared.ts), and `pluginRow` (notify.ts) exist and are consumed at
+  their respective call sites; the duplicated blocks are gone.
+- Output is byte-identical pre/post (catalog-uat + notify-v2 green unchanged).
+- Version is 0.4.3 across package.json, sonar-project.properties,
+  package-lock.json; CHANGELOG has a 0.4.3 entry.
+- `npm run check` green after the final commit. refactor #4 and
+  sonar.cpd.exclusions untouched.
+</success_criteria>
+
+<output>
+Create `.planning/quick/260609-bfq-reduce-sonarcloud-cpd-duplication-via-sh/260609-bfq-SUMMARY.md` when done.
+</output>

--- a/.planning/quick/260609-bfq-reduce-sonarcloud-cpd-duplication-via-sh/260609-bfq-SUMMARY.md
+++ b/.planning/quick/260609-bfq-reduce-sonarcloud-cpd-duplication-via-sh/260609-bfq-SUMMARY.md
@@ -1,0 +1,152 @@
+---
+phase: quick-260609-bfq
+plan: 01
+subsystem: refactoring
+tags: [sonarcloud, cpd, duplication, edge-handlers, orchestrators, notify, byte-neutral]
+
+# Dependency graph
+requires:
+  - phase: v1.11 (Phase 50)
+    provides: shared/notify.ts structured-notification seam + catalog-uat byte-form gate
+provides:
+  - parseMapModelArgs shared arg-parse helper (plugin edge handlers)
+  - makeSingleNameMarketplaceHandler factory (marketplace edge handlers)
+  - resolveScopeOrNotifyNotAdded lifted to orchestrators/marketplace/shared.ts
+  - pluginRow file-private helper folding 4 identical notify switch arms
+  - version bump 0.4.2 -> 0.4.3
+affects: [edge-handlers, marketplace-orchestrators, notify-renderer, sonarcloud-cpd]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - "Shared helper extraction to cut SonarCloud CPD without sonar.cpd.exclusions"
+    - "Structural-subset param typing so divergent option types satisfy one helper"
+    - "Byte-neutral refactor gated by catalog-uat + notify-v2 byte-form regression suites"
+
+key-files:
+  created:
+    - extensions/pi-claude-marketplace/edge/handlers/marketplace/shared.ts
+  modified:
+    - extensions/pi-claude-marketplace/edge/handlers/plugin/shared.ts
+    - extensions/pi-claude-marketplace/edge/handlers/plugin/install.ts
+    - extensions/pi-claude-marketplace/edge/handlers/plugin/update.ts
+    - extensions/pi-claude-marketplace/edge/handlers/marketplace/info.ts
+    - extensions/pi-claude-marketplace/edge/handlers/marketplace/remove.ts
+    - extensions/pi-claude-marketplace/orchestrators/marketplace/shared.ts
+    - extensions/pi-claude-marketplace/orchestrators/marketplace/update.ts
+    - extensions/pi-claude-marketplace/orchestrators/marketplace/remove.ts
+    - extensions/pi-claude-marketplace/shared/notify.ts
+    - package.json
+    - sonar-project.properties
+    - package-lock.json
+    - CHANGELOG.md
+
+key-decisions:
+  - "Reverted an incidental npm package-lock bin-path normalization (./dist/cli.js) to keep the lockfile diff to only the two version fields"
+  - "Folded only the 4 byte-equivalent notify arms (upgradable/skipped/failed/manual recovery); left the unavailable arm untouched (its renderScopeBracket(undefined,...) carve-out is not byte-equivalent)"
+
+patterns-established:
+  - "parseMapModelArgs: shared opening parse for --map-model handlers; carries parsed.scope via spread under TS strict"
+  - "makeSingleNameMarketplaceHandler: factory over divergent orchestrator option types via a structural run param"
+  - "resolveScopeOrNotifyNotAdded: single lifted helper takes { ctx, pi, name, scope? } structural subset so both update + remove option types satisfy it"
+
+requirements-completed: [NFR-6]
+
+# Metrics
+duration: 23min
+completed: 2026-06-09
+---
+
+# Quick Task 260609-bfq: Reduce SonarCloud CPD Duplication Summary
+
+**Four shared helpers extracted (plugin/marketplace edge arg-parse + single-name handler factory, marketplace orchestrator scope-resolution, notify plugin-row arms) plus a 0.4.2 -> 0.4.3 patch bump — strictly byte-neutral, every commit green.**
+
+## Performance
+
+- **Duration:** ~23 min
+- **Started:** 2026-06-09T08:30:01-04:00 (first task commit)
+- **Completed:** 2026-06-09T08:52:42-04:00 (version-bump commit)
+- **Tasks:** 5
+- **Files modified:** 14 (1 created)
+
+## Accomplishments
+
+- Extracted `parseMapModelArgs` into `edge/handlers/plugin/shared.ts`, eliminating the identical parseArgs-try/catch + parsePositionalsWithFlags opening block duplicated in `install.ts` and `update.ts`.
+- Created `edge/handlers/marketplace/shared.ts` with `makeSingleNameMarketplaceHandler`; `info.ts` and `remove.ts` collapsed to one-line wrappers (info/remove were identical except their USAGE string and delegate).
+- Lifted the ~33-line `resolveScopeOrNotifyNotAdded` (duplicated near-verbatim in marketplace `update.ts` + `remove.ts`) into `orchestrators/marketplace/shared.ts` with a structural-subset signature both option types satisfy.
+- Folded the four identical `renderPluginRow` switch arms (`upgradable`/`skipped`/`failed`/`manual recovery`) into a file-private `pluginRow` helper in `shared/notify.ts`.
+- Bumped 0.4.2 -> 0.4.3 across package.json, sonar-project.properties, package-lock.json, and added the CHANGELOG entry.
+- `npm run check` green after every one of the 5 commits (1511 unit/arch + 7 integration); the catalog-uat + notify-v2 byte-form gates (110 tests) prove output is byte-identical.
+
+## Task Commits
+
+Each task was committed atomically (Conventional Commits; `npm run check` green and `pre-commit run --files <changed>` clean before each):
+
+1. **Task 1: plugin edge-handler arg-parse boilerplate** - `6984c8d` (refactor)
+2. **Task 2: single-name marketplace edge handler factory** - `f8eaa36` (refactor)
+3. **Task 3: lift marketplace resolveScopeOrNotifyNotAdded to shared** - `17d3fa2` (refactor)
+4. **Task 5: fold notify plugin-row switch arms into helper** - `285ddf2` (refactor)
+5. **Task 6: bump version to 0.4.3** - `7242a1e` (chore)
+
+_(Task numbering follows the plan: refactor 1, 2, 3, 5, then the version bump. Refactor #4 — the predicate-divergent block in orchestrators/plugin/shared.ts — was explicitly out of scope and untouched.)_
+
+## Files Created/Modified
+
+- `edge/handlers/marketplace/shared.ts` (created) - `makeSingleNameMarketplaceHandler` factory over the info/remove delegates.
+- `edge/handlers/plugin/shared.ts` - added `parseMapModelArgs` + its `ParsedMapModelArgs` type.
+- `edge/handlers/plugin/install.ts` / `update.ts` - opening parse block replaced with the helper; distinct post-parse logic preserved verbatim.
+- `edge/handlers/marketplace/info.ts` / `remove.ts` - reduced to thin factory wrappers; each keeps its USAGE + header rationale.
+- `orchestrators/marketplace/shared.ts` - lifted `resolveScopeOrNotifyNotAdded` (exported, structural-subset signature); added `notify` + `ExtensionContext`/`ExtensionAPI` type imports.
+- `orchestrators/marketplace/update.ts` / `remove.ts` - deleted local copies; import the shared helper; removed now-unused imports.
+- `shared/notify.ts` - added file-private `pluginRow`; rewrote the 4 folded arms.
+- `package.json`, `sonar-project.properties`, `package-lock.json`, `CHANGELOG.md` - 0.4.3 bump.
+
+## Decisions Made
+
+- **Lockfile minimization:** `npm install --package-lock-only` regenerated the lockfile with an incidental `bin` path normalization (`./dist/cli.js` -> `dist/cli.js`) on a transitive peer-dep entry, unrelated to the version bump. Per the plan ("change ONLY the two version fields"), I reverted that one line by hand so the lockfile diff is exactly the two `0.4.2 -> 0.4.3` version fields.
+- **notify fold scope:** Only the four byte-equivalent arms were folded. The `unavailable` arm passes `renderScopeBracket(undefined, mpScope)` (MSG-PL-6 / SNM-11 carve-out — no `scope?` field) and is therefore NOT byte-equivalent, so it was deliberately left inline, as were all other arms.
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+**1. [Rule 3 - Blocking] Import-order ESLint error in plugin/shared.ts**
+- **Found during:** Task 1 (plugin arg-parse extraction)
+- **Issue:** Added `import { parseArgs } from "../../args.ts"` before the existing `parseCommandArgs` from `../../args-schema.ts`; ESLint `import-x/order` requires `args-schema.ts` before `args.ts`.
+- **Fix:** Reordered the two import lines.
+- **Files modified:** extensions/pi-claude-marketplace/edge/handlers/plugin/shared.ts
+- **Verification:** `npm run lint` clean; committed in `6984c8d`.
+
+---
+
+**Total deviations:** 1 auto-fixed (1 blocking import-order). No scope creep — within the file Task 1 already edits.
+**Impact on plan:** Trivial; required for the lint gate.
+
+## Issues Encountered
+
+None beyond the auto-fixed import-order. All typecheck/lint/format/test gates were green on first or second attempt per task; no fix-attempt limits approached.
+
+## Constraints Honored
+
+- `sonar.cpd.exclusions` NOT modified (verified via `git diff`).
+- Refactor #4 (`orchestrators/plugin/shared.ts`) NOT touched (verified — zero diff).
+- No public API, output, or behavior change — strictly internal helper extraction; catalog-uat + notify-v2 byte-form suites green unchanged throughout.
+- Version reads 0.4.3 across package.json, sonar-project.properties, and package-lock.json (root + self-entry).
+- Committed only code/config; docs artifacts (PLAN/SUMMARY/STATE) left to the orchestrator.
+
+## Next Phase Readiness
+
+- All 5 commits land on `features/reduce-cpd-duplication`; final `npm run check` green (1511 + 7).
+- Ready for the orchestrator's docs commit and PR. SonarCloud CPD should drop on the next scan (4 duplicated blocks collapsed).
+
+## Self-Check: PASSED
+
+- All 4 extracted helpers present at their target files (`parseMapModelArgs`, `makeSingleNameMarketplaceHandler`, exported `resolveScopeOrNotifyNotAdded`, `pluginRow`).
+- All 5 commits present in history: `6984c8d`, `f8eaa36`, `17d3fa2`, `285ddf2`, `7242a1e`.
+- Created file `edge/handlers/marketplace/shared.ts` and the SUMMARY exist on disk.
+- Final `npm run check` exit 0 (1511 unit/arch + 7 integration); byte-form gates 110/110.
+
+---
+*Quick task: 260609-bfq-reduce-sonarcloud-cpd-duplication-via-sh*
+*Completed: 2026-06-09*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.4.3] - 2026-06-09
+
+- Internal refactor to cut SonarCloud copy-paste duplication: extracted shared helpers across the plugin and marketplace edge handlers (`--map-model` arg-parse boilerplate; the single-`<name>` marketplace handler factory), the marketplace orchestrators (the `resolveScopeOrNotifyNotAdded` scope-resolution helper, now lifted to `shared.ts`), and the notify plugin-row renderer (the four identical switch arms folded into one helper). No behavior or output change -- output is byte-identical to before.
+
 ## [0.4.2] - 2026-06-08
 
 - Error attribution: every operation now blames the right thing. When a marketplace is not added (or is configured only in the other scope), `install`, `uninstall`, `reinstall`, `update`, `marketplace update`, `marketplace remove`, and `autoupdate`/`noautoupdate` all report `{not added}` on the marketplace, instead of the old misleading `{not in manifest}` on the plugin or a raw error. Cleanup and cascade failures now report the truthful on-disk/permission reason rather than a generic `{not in manifest}`, and a path-source manifest that fails to read reports `{invalid manifest}` instead of a false `{network unreachable}`. A target that exists only in the other scope carries the requested-scope bracket so you can tell which scope was checked.

--- a/extensions/pi-claude-marketplace/edge/handlers/marketplace/info.ts
+++ b/extensions/pi-claude-marketplace/edge/handlers/marketplace/info.ts
@@ -8,8 +8,8 @@
 // shape and delegates.
 
 import { getMarketplaceInfo } from "../../../orchestrators/marketplace/info.ts";
-import { notifyUsageError } from "../../../shared/notify.ts";
-import { parseCommandArgs } from "../../args-schema.ts";
+
+import { makeSingleNameMarketplaceHandler } from "./shared.ts";
 
 import type { ExtensionAPI, ExtensionCommandContext } from "../../../platform/pi-api.ts";
 
@@ -18,30 +18,5 @@ const USAGE = "Usage: /claude:plugin marketplace info <name> [--scope user|proje
 export function makeMarketplaceInfoHandler(
   pi: ExtensionAPI,
 ): (args: string, ctx: ExtensionCommandContext) => Promise<void> {
-  return async (args, ctx): Promise<void> => {
-    const parsed = parseCommandArgs(
-      args,
-      {
-        positional: [{ name: "name" }] as const,
-        usage: USAGE,
-      },
-      (message) => {
-        notifyUsageError(ctx, {
-          message: message === USAGE ? "Missing required argument." : message,
-          usage: USAGE,
-        });
-      },
-    );
-    if (parsed === undefined) {
-      return;
-    }
-
-    await getMarketplaceInfo({
-      ctx,
-      pi,
-      name: parsed.name,
-      cwd: ctx.cwd,
-      ...(parsed.scope !== undefined && { scope: parsed.scope }),
-    });
-  };
+  return makeSingleNameMarketplaceHandler(pi, USAGE, getMarketplaceInfo);
 }

--- a/extensions/pi-claude-marketplace/edge/handlers/marketplace/remove.ts
+++ b/extensions/pi-claude-marketplace/edge/handlers/marketplace/remove.ts
@@ -14,8 +14,8 @@
 // positional/scope shape.
 
 import { removeMarketplace } from "../../../orchestrators/marketplace/remove.ts";
-import { notifyUsageError } from "../../../shared/notify.ts";
-import { parseCommandArgs } from "../../args-schema.ts";
+
+import { makeSingleNameMarketplaceHandler } from "./shared.ts";
 
 import type { ExtensionAPI, ExtensionCommandContext } from "../../../platform/pi-api.ts";
 
@@ -24,30 +24,5 @@ const USAGE = "Usage: /claude:plugin marketplace <remove|rm> <name> [--scope use
 export function makeRemoveHandler(
   pi: ExtensionAPI,
 ): (args: string, ctx: ExtensionCommandContext) => Promise<void> {
-  return async (args, ctx): Promise<void> => {
-    const parsed = parseCommandArgs(
-      args,
-      {
-        positional: [{ name: "name" }] as const,
-        usage: USAGE,
-      },
-      (message) => {
-        notifyUsageError(ctx, {
-          message: message === USAGE ? "Missing required argument." : message,
-          usage: USAGE,
-        });
-      },
-    );
-    if (parsed === undefined) {
-      return;
-    }
-
-    await removeMarketplace({
-      ctx,
-      pi,
-      name: parsed.name,
-      cwd: ctx.cwd,
-      ...(parsed.scope !== undefined && { scope: parsed.scope }),
-    });
-  };
+  return makeSingleNameMarketplaceHandler(pi, USAGE, removeMarketplace);
 }

--- a/extensions/pi-claude-marketplace/edge/handlers/marketplace/shared.ts
+++ b/extensions/pi-claude-marketplace/edge/handlers/marketplace/shared.ts
@@ -1,0 +1,72 @@
+// edge/handlers/marketplace/shared.ts
+//
+// Shared factory for the single-`<name>`-positional marketplace edge handlers
+// (`info` / `remove`). Both shims parse one required `name` positional + the
+// optional `--scope` flag, route an argument-parsing failure through
+// `notifyUsageError` (MSG-NC-2: the missing-required-positional path collapses
+// the duplicated usage block into "Missing required argument."), then delegate
+// to their orchestrator with `{ ctx, pi, name, cwd, scope? }`.
+//
+// Argument-parsing failures route through `notifyUsageError`; the orchestrator
+// owns per-scope projection / fan-out / the conditional `{not added}` forms.
+
+import { notifyUsageError } from "../../../shared/notify.ts";
+import { parseCommandArgs } from "../../args-schema.ts";
+
+import type { ExtensionAPI, ExtensionCommandContext } from "../../../platform/pi-api.ts";
+import type { Scope } from "../../../shared/types.ts";
+
+/**
+ * Delegate shape shared by `getMarketplaceInfo` and `removeMarketplace`.
+ * `GetMarketplaceInfoOptions` matches this exactly; `RemoveMarketplaceOptions`
+ * adds an OPTIONAL `cascade?` field, which a caller omitting `cascade`
+ * structurally satisfies.
+ */
+type SingleNameMarketplaceRun = (opts: {
+  ctx: ExtensionCommandContext;
+  pi: ExtensionAPI;
+  name: string;
+  cwd: string;
+  scope?: Scope;
+}) => Promise<void>;
+
+/**
+ * Build a thin-shim handler for a `<name>`-only marketplace subcommand. The
+ * returned handler performs the single-`name`-positional `parseCommandArgs`
+ * parse + the `message === usage ? "Missing required argument." : message`
+ * error callback + the `=== undefined` guard, then delegates to `run` with
+ * `{ ctx, pi, name, cwd, scope? }`. `pi` is closed over by the caller (the
+ * orchestrators require it for the RH-5 soft-dep probes).
+ */
+export function makeSingleNameMarketplaceHandler(
+  pi: ExtensionAPI,
+  usage: string,
+  run: SingleNameMarketplaceRun,
+): (args: string, ctx: ExtensionCommandContext) => Promise<void> {
+  return async (args, ctx): Promise<void> => {
+    const parsed = parseCommandArgs(
+      args,
+      {
+        positional: [{ name: "name" }] as const,
+        usage,
+      },
+      (message) => {
+        notifyUsageError(ctx, {
+          message: message === usage ? "Missing required argument." : message,
+          usage,
+        });
+      },
+    );
+    if (parsed === undefined) {
+      return;
+    }
+
+    await run({
+      ctx,
+      pi,
+      name: parsed.name,
+      cwd: ctx.cwd,
+      ...(parsed.scope !== undefined && { scope: parsed.scope }),
+    });
+  };
+}

--- a/extensions/pi-claude-marketplace/edge/handlers/plugin/install.ts
+++ b/extensions/pi-claude-marketplace/edge/handlers/plugin/install.ts
@@ -21,11 +21,9 @@
 // platform/. Only orchestrators/, shared/, edge/ (sibling) imports.
 
 import { installPlugin } from "../../../orchestrators/plugin/install.ts";
-import { errorMessage } from "../../../shared/errors.ts";
 import { notifyUsageError } from "../../../shared/notify.ts";
-import { parseArgs } from "../../args.ts";
 
-import { parsePositionalsWithFlags, splitPluginMarketplaceRef } from "./shared.ts";
+import { parseMapModelArgs, splitPluginMarketplaceRef } from "./shared.ts";
 
 import type { ExtensionAPI, ExtensionCommandContext } from "../../../platform/pi-api.ts";
 
@@ -41,17 +39,7 @@ export function makeInstallHandler(
   pi: ExtensionAPI,
 ): (args: string, ctx: ExtensionCommandContext) => Promise<void> {
   return async (args, ctx): Promise<void> => {
-    let parsed;
-    try {
-      parsed = parseArgs(args);
-    } catch (err) {
-      // MSG-NC-2: argument-parsing failure (invalid --scope value) -- sentence
-      // form with Usage block appended after a blank line.
-      notifyUsageError(ctx, { message: errorMessage(err), usage: USAGE });
-      return;
-    }
-
-    const flagged = parsePositionalsWithFlags(parsed.positional, ctx, USAGE);
+    const flagged = parseMapModelArgs(args, ctx, USAGE);
     if (flagged === undefined) {
       return;
     }
@@ -82,7 +70,7 @@ export function makeInstallHandler(
     await installPlugin({
       ctx,
       pi,
-      scope: parsed.scope ?? "user",
+      scope: flagged.scope ?? "user",
       cwd: ctx.cwd,
       marketplace: ref.marketplace,
       plugin: ref.plugin,

--- a/extensions/pi-claude-marketplace/edge/handlers/plugin/shared.ts
+++ b/extensions/pi-claude-marketplace/edge/handlers/plugin/shared.ts
@@ -6,8 +6,10 @@
 // live in the orchestrator layer and surface as `EntityErrorRow` compact
 // lines per CMC-34 / MSG-NC-1.
 
+import { errorMessage } from "../../../shared/errors.ts";
 import { notifyUsageError } from "../../../shared/notify.ts";
 import { parseCommandArgs } from "../../args-schema.ts";
+import { parseArgs } from "../../args.ts";
 
 import type { ExtensionCommandContext } from "../../../platform/pi-api.ts";
 import type { Scope } from "../../../shared/types.ts";
@@ -63,6 +65,50 @@ export function parsePositionalsWithFlags(
   }
 
   return { nonFlagPositionals, mapModel };
+}
+
+export interface ParsedMapModelArgs {
+  readonly scope?: Scope;
+  readonly nonFlagPositionals: readonly string[];
+  readonly mapModel: boolean;
+}
+
+/**
+ * Shared opening parse sequence for the `--map-model`-bearing plugin handlers
+ * (`install` / `update`). Runs `parseArgs` (notifying via `notifyUsageError`
+ * with `errorMessage(err)` on an MSG-NC-2 argument-parsing failure), then
+ * `parsePositionalsWithFlags` with its undefined-guard. Returns `undefined`
+ * whenever an error has ALREADY been notified (parse failure OR an unknown
+ * long flag); on success returns the destructured `{ nonFlagPositionals,
+ * mapModel }` plus `parsed.scope` (carried via spread so the optional-property
+ * contract matches `parsed.scope`'s `Scope | undefined` shape under TS strict).
+ * Each handler keeps its own distinct post-parse positional logic.
+ */
+export function parseMapModelArgs(
+  args: string,
+  ctx: ExtensionCommandContext,
+  usage: string,
+): ParsedMapModelArgs | undefined {
+  let parsed;
+  try {
+    parsed = parseArgs(args);
+  } catch (err) {
+    // MSG-NC-2: argument-parsing failure (invalid --scope value) -- sentence
+    // form with Usage block appended after a blank line.
+    notifyUsageError(ctx, { message: errorMessage(err), usage });
+    return undefined;
+  }
+
+  const flagged = parsePositionalsWithFlags(parsed.positional, ctx, usage);
+  if (flagged === undefined) {
+    return undefined;
+  }
+
+  return {
+    nonFlagPositionals: flagged.nonFlagPositionals,
+    mapModel: flagged.mapModel,
+    ...(parsed.scope !== undefined && { scope: parsed.scope }),
+  };
 }
 
 export function parseRequiredPluginMarketplaceRef(

--- a/extensions/pi-claude-marketplace/edge/handlers/plugin/update.ts
+++ b/extensions/pi-claude-marketplace/edge/handlers/plugin/update.ts
@@ -12,11 +12,9 @@
 // manual positional scan pattern from `list.ts`.
 
 import { updatePlugins } from "../../../orchestrators/plugin/update.ts";
-import { errorMessage } from "../../../shared/errors.ts";
 import { notifyUsageError } from "../../../shared/notify.ts";
-import { parseArgs } from "../../args.ts";
 
-import { parsePositionalsWithFlags, splitPluginMarketplaceRef } from "./shared.ts";
+import { parseMapModelArgs, splitPluginMarketplaceRef } from "./shared.ts";
 
 import type { UpdatePluginsTarget } from "../../../orchestrators/plugin/update.ts";
 import type { ExtensionAPI, ExtensionCommandContext } from "../../../platform/pi-api.ts";
@@ -28,15 +26,7 @@ export function makeUpdateHandler(
   pi: ExtensionAPI,
 ): (args: string, ctx: ExtensionCommandContext) => Promise<void> {
   return async (args, ctx): Promise<void> => {
-    let parsed;
-    try {
-      parsed = parseArgs(args);
-    } catch (err) {
-      notifyUsageError(ctx, { message: errorMessage(err), usage: USAGE });
-      return;
-    }
-
-    const flagged = parsePositionalsWithFlags(parsed.positional, ctx, USAGE);
+    const flagged = parseMapModelArgs(args, ctx, USAGE);
     if (flagged === undefined) {
       return;
     }
@@ -75,7 +65,7 @@ export function makeUpdateHandler(
       pi,
       cwd: ctx.cwd,
       target,
-      ...(parsed.scope !== undefined && { scope: parsed.scope }),
+      ...(flagged.scope !== undefined && { scope: flagged.scope }),
       ...(mapModel && { mapModel: true }),
     });
   };

--- a/extensions/pi-claude-marketplace/orchestrators/marketplace/remove.ts
+++ b/extensions/pi-claude-marketplace/orchestrators/marketplace/remove.ts
@@ -40,19 +40,16 @@
 import { rm } from "node:fs/promises";
 
 import { locationsFor } from "../../persistence/locations.ts";
-import { loadState } from "../../persistence/state-io.ts";
 import { dropMarketplaceCache, invalidateMarketplaceNames } from "../../shared/completion-cache.ts";
-import { MarketplaceNotFoundError } from "../../shared/errors.ts";
 import { notify } from "../../shared/notify.ts";
 import { withStateGuard } from "../../transaction/with-state-guard.ts";
 
 import {
   AgentsUnstageFailureError,
   cascadeUnstagePlugin,
-  resolveScopeFromState,
+  resolveScopeOrNotifyNotAdded,
 } from "./shared.ts";
 
-import type { ScopedLocations } from "../../persistence/locations.ts";
 import type { ExtensionAPI, ExtensionContext } from "../../platform/pi-api.ts";
 import type {
   ContentReason,
@@ -158,57 +155,6 @@ function isErrnoException(err: unknown): err is NodeJS.ErrnoException {
   return (
     err instanceof Error && "code" in err && typeof (err as { code?: unknown }).code === "string"
   );
-}
-
-/**
- * ATTR-06 / D-48-C Shape 1: resolve the target scope and enforce the
- * missing-marketplace precondition BEFORE the caller enters withStateGuard.
- *
- * Returns the resolved `{ scope, locations }` when the marketplace record
- * exists in the target scope. Returns `undefined` when the marketplace is
- * absent -- in which case it has ALREADY emitted the standalone
- * MarketplaceNotAddedMessage `(failed) {not added}` variant, so the caller must
- * return without entering the guard (no raw MarketplaceNotFoundError escapes,
- * state untouched). NFR-5: every read here is a network-free `loadState`.
- *
- * Bracket discipline: the bare form absent from BOTH scopes emits NO scope
- * bracket (resolveScopeFromState's MarketplaceNotFoundError is caught here, NOT
- * re-thrown; its throw contract -- shared with update.ts -- is unmodified). The
- * explicit-scope miss emits the requested scope bracket (SCOPE-01). A
- * non-MarketplaceNotFoundError from resolveScopeFromState is re-thrown.
- */
-async function resolveScopeOrNotifyNotAdded(
-  opts: RemoveMarketplaceOptions,
-  userLocations: ScopedLocations,
-  projectLocations: ScopedLocations,
-): Promise<{ scope: Scope; locations: ScopedLocations } | undefined> {
-  // S4 (bare form): resolveScopeFromState proves existence across both scopes.
-  if (opts.scope === undefined) {
-    try {
-      return await resolveScopeFromState(opts.name, userLocations, projectLocations);
-    } catch (err) {
-      if (err instanceof MarketplaceNotFoundError) {
-        notify(opts.ctx, opts.pi, { kind: "marketplace-not-added", name: opts.name });
-        return undefined;
-      }
-
-      throw err;
-    }
-  }
-
-  // S3 (explicit scope): a single pre-guard loadState read blocks the miss.
-  const locations = opts.scope === "user" ? userLocations : projectLocations;
-  const preState = await loadState(locations.extensionRoot);
-  if (preState.marketplaces[opts.name] === undefined) {
-    notify(opts.ctx, opts.pi, {
-      kind: "marketplace-not-added",
-      name: opts.name,
-      scope: opts.scope,
-    });
-    return undefined;
-  }
-
-  return { scope: opts.scope, locations };
 }
 
 export async function removeMarketplace(opts: RemoveMarketplaceOptions): Promise<void> {

--- a/extensions/pi-claude-marketplace/orchestrators/marketplace/shared.ts
+++ b/extensions/pi-claude-marketplace/orchestrators/marketplace/shared.ts
@@ -35,12 +35,14 @@ import { locationsFor } from "../../persistence/locations.ts";
 import { loadState } from "../../persistence/state-io.ts";
 import * as defaultGit from "../../platform/git.ts";
 import { MarketplaceNotFoundError } from "../../shared/errors.ts";
+import { notify } from "../../shared/notify.ts";
 
 import type { UnstageAgentFailure } from "../../bridges/agents/types.ts";
 import type { ScopedLocations } from "../../persistence/locations.ts";
 import type { ExtensionState } from "../../persistence/state-io.ts";
 import type { CredentialOps } from "../../platform/git-credential.ts";
 import type { OnAuthRequiredFn } from "../../platform/git.ts";
+import type { ExtensionAPI, ExtensionContext } from "../../platform/pi-api.ts";
 import type { Scope } from "../../shared/types.ts";
 import type { PluginUpdateOutcome } from "../types.ts";
 
@@ -483,6 +485,67 @@ export async function resolveScopeFromState(
   }
 
   throw new MarketplaceNotFoundError(mpName, ["project", "user"]);
+}
+
+/**
+ * ATTR-06 / D-48-C Shape 1: resolve the target scope and enforce the
+ * missing-marketplace precondition BEFORE the caller enters its state guard
+ * (`removeMarketplace`'s withStateGuard / `updateMarketplace`'s
+ * snapshotAfterRefresh). Shared by remove.ts and update.ts.
+ *
+ * Returns the resolved `{ scope, locations }` when the marketplace record
+ * exists in the target scope. Returns `undefined` when the marketplace is
+ * absent -- in which case it has ALREADY emitted the standalone
+ * MarketplaceNotAddedMessage `(failed) {not added}` variant (SC#1 cross-op
+ * convergence), so the caller must return without entering the guard (no raw
+ * MarketplaceNotFoundError escapes past the orchestrator boundary, state
+ * untouched). NFR-5: every read here is a network-free `loadState`.
+ *
+ * Bracket discipline: the bare form absent from BOTH scopes emits NO scope
+ * bracket (resolveScopeFromState's MarketplaceNotFoundError is caught here, NOT
+ * re-thrown; its throw contract is unmodified). The explicit-scope miss emits
+ * the requested scope bracket (SCOPE-01). A non-MarketplaceNotFoundError from
+ * resolveScopeFromState is re-thrown -- genuine clone/manifest/lock failures
+ * arise later inside the caller's refresh path and keep their `(failed)`
+ * cascade.
+ *
+ * Takes the structural subset of the caller opts ({ ctx, pi, name, scope? })
+ * so both UpdateMarketplaceOptions and RemoveMarketplaceOptions satisfy it.
+ */
+export async function resolveScopeOrNotifyNotAdded(
+  opts: { ctx: ExtensionContext; pi: ExtensionAPI; name: string; scope?: Scope },
+  userLocations: ScopedLocations,
+  projectLocations: ScopedLocations,
+): Promise<{ scope: Scope; locations: ScopedLocations } | undefined> {
+  // Bare form: resolveScopeFromState proves existence across both scopes.
+  if (opts.scope === undefined) {
+    try {
+      return await resolveScopeFromState(opts.name, userLocations, projectLocations);
+    } catch (err) {
+      if (err instanceof MarketplaceNotFoundError) {
+        notify(opts.ctx, opts.pi, { kind: "marketplace-not-added", name: opts.name });
+        return undefined;
+      }
+
+      throw err;
+    }
+  }
+
+  // Explicit scope: a single pre-guard loadState read blocks the miss BEFORE it
+  // reaches the caller's state guard (which would otherwise throw
+  // MarketplaceNotFoundError(name, [scope]) raw past the orchestrator).
+  const locations = opts.scope === "user" ? userLocations : projectLocations;
+  const preState = await loadState(locations.extensionRoot);
+  if (preState.marketplaces[opts.name] === undefined) {
+    notify(opts.ctx, opts.pi, {
+      kind: "marketplace-not-added",
+      name: opts.name,
+      scope: opts.scope,
+    });
+    return undefined;
+  }
+
+  return { scope: opts.scope, locations };
 }
 
 /**

--- a/extensions/pi-claude-marketplace/orchestrators/marketplace/update.ts
+++ b/extensions/pi-claude-marketplace/orchestrators/marketplace/update.ts
@@ -102,7 +102,6 @@ import { DEFAULT_CREDENTIAL_OPS } from "../../platform/git-credential.ts";
 import { dropMarketplaceCache } from "../../shared/completion-cache.ts";
 import {
   InvalidMarketplaceManifestError,
-  MarketplaceNotFoundError,
   MarketplaceUpdateError,
   PluginShapeError,
   assertNever,
@@ -115,7 +114,7 @@ import { withStateGuard } from "../../transaction/with-state-guard.ts";
 import {
   DEFAULT_GIT_OPS,
   refreshGitHubClone,
-  resolveScopeFromState,
+  resolveScopeOrNotifyNotAdded,
   type GitAuthBundle,
   type GitOps,
 } from "./shared.ts";
@@ -195,67 +194,6 @@ export interface UpdateAllMarketplacesOptions {
    * inside the orchestrator's onAuthRequired closure.
    */
   readonly deviceFlowHttp?: DeviceFlowHttp;
-}
-
-/**
- * ATTR-06 / D-48-C Shape 1 (mirrors remove.ts::resolveScopeOrNotifyNotAdded):
- * resolve the target scope and enforce the missing-marketplace precondition
- * BEFORE the caller enters refreshOneMarketplace / snapshotAfterRefresh.
- *
- * Returns the resolved `{ scope, locations }` when the marketplace record
- * exists in the target scope. Returns `undefined` when the marketplace is
- * absent -- in which case it has ALREADY emitted the standalone
- * MarketplaceNotAddedMessage `(failed) {not added}` variant (SC#1 cross-op
- * convergence), so the caller must return without entering the guard. This
- * closes the residual Class-C gap: previously a missing marketplace let a raw
- * MarketplaceNotFoundError escape past the orchestrator boundary (bare form via
- * resolveScopeFromState; explicit-scope form via snapshotAfterRefresh's
- * withStateGuard throw). NFR-5: every read here is a network-free `loadState`.
- *
- * Bracket discipline: the bare form absent from BOTH scopes emits NO scope
- * bracket (resolveScopeFromState's MarketplaceNotFoundError is caught here, NOT
- * re-thrown; its throw contract -- shared with other callers -- is unmodified).
- * The explicit-scope miss emits the requested scope bracket (SCOPE-01).
- *
- * Genuine refresh failures are untouched: only a MarketplaceNotFoundError from
- * the resolve seam reroutes here. A non-MarketplaceNotFoundError from
- * resolveScopeFromState is re-thrown; all clone/manifest/lock failures arise
- * later inside refreshOneMarketplace and keep their existing `(failed)` cascade.
- */
-async function resolveScopeOrNotifyNotAdded(
-  opts: UpdateMarketplaceOptions,
-  userLocations: ScopedLocations,
-  projectLocations: ScopedLocations,
-): Promise<{ scope: Scope; locations: ScopedLocations } | undefined> {
-  // Bare form: resolveScopeFromState proves existence across both scopes.
-  if (opts.scope === undefined) {
-    try {
-      return await resolveScopeFromState(opts.name, userLocations, projectLocations);
-    } catch (err) {
-      if (err instanceof MarketplaceNotFoundError) {
-        notify(opts.ctx, opts.pi, { kind: "marketplace-not-added", name: opts.name });
-        return undefined;
-      }
-
-      throw err;
-    }
-  }
-
-  // Explicit scope: a single pre-guard loadState read blocks the miss BEFORE it
-  // reaches snapshotAfterRefresh's withStateGuard (which would otherwise throw
-  // MarketplaceNotFoundError(name, [scope]) raw past the orchestrator).
-  const locations = opts.scope === "user" ? userLocations : projectLocations;
-  const preState = await loadState(locations.extensionRoot);
-  if (preState.marketplaces[opts.name] === undefined) {
-    notify(opts.ctx, opts.pi, {
-      kind: "marketplace-not-added",
-      name: opts.name,
-      scope: opts.scope,
-    });
-    return undefined;
-  }
-
-  return { scope: opts.scope, locations };
 }
 
 /** MU-1 single-name form. */

--- a/extensions/pi-claude-marketplace/shared/notify.ts
+++ b/extensions/pi-claude-marketplace/shared/notify.ts
@@ -1357,6 +1357,40 @@ function composeReasons(
  *  - `failed.cause` / `manual recovery.cause` cause-chain trailers.
  *  - `failed.rollbackPartial[]` child rows.
  */
+/**
+ * Compose a scope-bearing, reasons-bearing plugin row that carries NO
+ * soft-dep marker. Folds the four structurally-identical `renderPluginRow`
+ * arms (`upgradable` / `skipped` / `failed` / `manual recovery`) that differ
+ * only in their icon and their parenthesized status `label`. `label` is the
+ * FULL parenthesized token (the caller passes `"(upgradable)"` etc., INCLUDING
+ * the parens, so the `"(manual recovery)"` literal keeps its space verbatim).
+ * The `p` param is the structural subset those four variants share: a required
+ * `name`, an optional `scope` / `version`, and a required
+ * `readonly ContentReason[]` reasons. Both declares-flags are `false` (these
+ * arms never carry `dependencies`).
+ */
+function pluginRow(
+  icon: string,
+  p: {
+    readonly name: string;
+    readonly scope?: Scope;
+    readonly version?: string;
+    readonly reasons: readonly ContentReason[];
+  },
+  mpScope: Scope,
+  label: string,
+  probe: SoftDepStatus,
+): string {
+  return joinTokens([
+    icon,
+    p.name,
+    renderScopeBracket(p.scope, mpScope),
+    renderVersion(p.version),
+    label,
+    composeReasons(p.reasons, false, false, probe),
+  ]);
+}
+
 function renderPluginRow(
   p: PluginNotificationMessage,
   probe: SoftDepStatus,
@@ -1439,42 +1473,14 @@ function renderPluginRow(
         composeReasons(p.reasons, false, false, probe),
       ]);
     case "upgradable":
-      return joinTokens([
-        ICON_INSTALLED,
-        p.name,
-        renderScopeBracket(p.scope, mpScope),
-        renderVersion(p.version),
-        "(upgradable)",
-        composeReasons(p.reasons, false, false, probe),
-      ]);
+      return pluginRow(ICON_INSTALLED, p, mpScope, "(upgradable)", probe);
     case "skipped":
-      return joinTokens([
-        ICON_UNINSTALLABLE,
-        p.name,
-        renderScopeBracket(p.scope, mpScope),
-        renderVersion(p.version),
-        "(skipped)",
-        composeReasons(p.reasons, false, false, probe),
-      ]);
+      return pluginRow(ICON_UNINSTALLABLE, p, mpScope, "(skipped)", probe);
     case "failed":
-      return joinTokens([
-        ICON_UNINSTALLABLE,
-        p.name,
-        renderScopeBracket(p.scope, mpScope),
-        renderVersion(p.version),
-        "(failed)",
-        composeReasons(p.reasons, false, false, probe),
-      ]);
+      return pluginRow(ICON_UNINSTALLABLE, p, mpScope, "(failed)", probe);
     case "manual recovery":
-      return joinTokens([
-        ICON_UNINSTALLABLE,
-        p.name,
-        renderScopeBracket(p.scope, mpScope),
-        renderVersion(p.version),
-        // `manual recovery` discriminator preserved verbatim WITH A SPACE.
-        "(manual recovery)",
-        composeReasons(p.reasons, false, false, probe),
-      ]);
+      // `(manual recovery)` discriminator preserved verbatim WITH A SPACE.
+      return pluginRow(ICON_UNINSTALLABLE, p, mpScope, "(manual recovery)", probe);
     default: {
       assertNever(p);
       return "";

--- a/package-lock.json
+++ b/package-lock.json
@@ -572,7 +572,7 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "./dist/cli.js"
+        "pi-ai": "dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-claude-marketplace",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-claude-marketplace",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "license": "MIT",
       "dependencies": {
         "isomorphic-git": "^1.38.1",

--- a/package.json
+++ b/package.json
@@ -84,5 +84,5 @@
     "typecheck": "tsc --noEmit"
   },
   "type": "module",
-  "version": "0.4.2"
+  "version": "0.4.3"
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,7 +4,7 @@ sonar.organization=acolomba
 
 # Project metadata.
 sonar.projectName=Pi Claude Marketplace
-sonar.projectVersion=0.4.2
+sonar.projectVersion=0.4.3
 
 # Source code settings.
 sonar.sources=extensions/pi-claude-marketplace


### PR DESCRIPTION
Extracts four shared helpers to remove the copy-paste duplication SonarCloud flagged, plus a patch version bump. Strictly byte-neutral: no output, behavior, or public-API change. The `catalog-uat` and `notify` byte-form tests are the regression gate, and they held at 110/110 across every commit.

## What changed

Each refactor is its own commit:

- `parseMapModelArgs` (`edge/handlers/plugin/shared.ts`): the `parseArgs` + flag-scan boilerplate shared by the install and update handlers.
- `makeSingleNameMarketplaceHandler` (new `edge/handlers/marketplace/shared.ts`): the marketplace `info` and `remove` handlers were identical except the USAGE string and which orchestrator they call, so they are now thin wrappers over this factory.
- `resolveScopeOrNotifyNotAdded` lifted to `orchestrators/marketplace/shared.ts`: a 33-line function duplicated near-verbatim in the `update` and `remove` orchestrators (a deliberate Phase 49 mirror). Both now call the shared copy.
- `pluginRow` helper in `notify.ts`: the `upgradable` / `skipped` / `failed` / `manual recovery` switch arms differed only by icon and status label. The `unavailable` arm keeps its own shape (the MSG-PL-6 carve-out) and is left untouched.

The version bump is a separate commit: 0.4.2 to 0.4.3 across `package.json`, `sonar-project.properties`, `package-lock.json`, and `CHANGELOG.md`.

## Expected duplication impact

SonarCloud's duplications API gave the exact line count per block:

| Block | Dup lines | This PR |
|-------|-----------|---------|
| plugin edge handlers | 36 | removed |
| marketplace edge handlers | 38 | removed |
| marketplace orchestrators | 64 | removed |
| notify plugin-row arms | 34 | removed |
| `plugin/shared.ts` internal | 35 | kept (see below) |

That clears 172 of the 207 duplicated lines, taking density from 0.7% toward ~0.1%. The SonarCloud check on this PR will report the actual figure.

## What was left alone

- The `plugin/shared.ts` internal block (`resolveCrossScopePluginTarget` vs `resolveInstalledMarketplaceTarget`) stays. The two functions look alike but resolve different things (a plugin row cross-scope vs a marketplace container), so a shared helper would obscure that distinction more than it helps.
- `sonar.cpd.exclusions` is unchanged.

## Verification

`npm run check` (typecheck + ESLint + Prettier + 1511 unit/arch + 7 integration) is green after every commit. No behavior change, so no new tests were added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
