### PR TITLE
docs: mention @tintinweb/pi-subagents as alternative (0.4.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.4.4] - 2026-06-09
+
+- README: mention `@tintinweb/pi-subagents` as an alternative to `pi-subagents` for agent support. Detection already works for both (probes by tool name, not package name).
+
 ## [0.4.3] - 2026-06-09
 
 - Internal refactor to cut SonarCloud copy-paste duplication: extracted shared helpers across the plugin and marketplace edge handlers (`--map-model` arg-parse boilerplate; the single-`<name>` marketplace handler factory), the marketplace orchestrators (the `resolveScopeOrNotifyNotAdded` scope-resolution helper, now lifted to `shared.ts`), and the notify plugin-row renderer (the four identical switch arms folded into one helper). No behavior or output change -- output is byte-identical to before.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Installs plugins from the Claude plugin marketplace that contain these component
 
 - Commands.
 - Skills.
-- Agents. Requires [pi-subagents](https://pi.dev/packages/pi-subagents).
+- Agents. Requires [pi-subagents](https://pi.dev/packages/pi-subagents) or `@tintinweb/pi-subagents`.
 - MCP servers. Requires [pi-mcp-adapter](https://pi.dev/packages/pi-mcp-adapter).
 
 Plugins that contain unsupported components are marked as "unavailable".
@@ -32,7 +32,7 @@ Plugins that contain unsupported components are marked as "unavailable".
 ## Prerequisites
 
 - [Pi Coding Agent](https://pi.dev)
-- [pi-subagents](https://pi.dev/packages/pi-subagents) (optional but recommended, `pi install npm:pi-subagents`)
+- [pi-subagents](https://pi.dev/packages/pi-subagents) or `@tintinweb/pi-subagents` (optional but recommended, `pi install npm:pi-subagents` or `pi install npm:@tintinweb/pi-subagents`)
 - [pi-mcp-adapter](https://pi.dev/packages/pi-mcp-adapter) (optional but recommended, `pi install npm:pi-mcp-adapter`)
 
 ## Usage

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-claude-marketplace",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-claude-marketplace",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "license": "MIT",
       "dependencies": {
         "isomorphic-git": "^1.38.1",

--- a/package.json
+++ b/package.json
@@ -84,5 +84,5 @@
     "typecheck": "tsc --noEmit"
   },
   "type": "module",
-  "version": "0.4.3"
+  "version": "0.4.4"
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,7 +4,7 @@ sonar.organization=acolomba
 
 # Project metadata.
 sonar.projectName=Pi Claude Marketplace
-sonar.projectVersion=0.4.3
+sonar.projectVersion=0.4.4
 
 # Source code settings.
 sonar.sources=extensions/pi-claude-marketplace


### PR DESCRIPTION
## Summary

README: note that `@tintinweb/pi-subagents` works as an alternative to `pi-subagents` for agent support. The detection probe looks for a tool named `"subagent"`, not a package name, so both packages are treated identically. Updated the Features and Prerequisites sections to list both.

## Test plan

- [ ] CI passes
- [ ] README Features section mentions both packages
- [ ] README Prerequisites section shows install commands for both

🤖 Generated with [Claude Code](https://claude.com/claude-code)