### PR TITLE
chore: point pi.dev manifest image to bootstrap demo

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "extensions": [
       "./extensions/pi-claude-marketplace/index.ts"
     ],
-    "image": "https://media.githubusercontent.com/media/acolomba/pi-claude-marketplace/refs/heads/main/images/redpi.png"
+    "image": "https://media.githubusercontent.com/media/acolomba/pi-claude-marketplace/refs/heads/main/demos/bootstrap.gif"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Swaps the `pi.dev` manifest `image` URL from the static red Pi logo to the bootstrap demo GIF, so the plugin page shows an animated walkthrough instead of just an icon.

No version bump — the manifest field is metadata only.