### PR TITLE
feat(images): add white background inside redpi border

### DIFF
--- a/images/redpi.png
+++ b/images/redpi.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:46e822c5b4f14ca95bded9d65ab284e3369b1ccdb945630e234ed4d76c4cd543
-size 2733
+oid sha256:5b10aa5578c41a0d2f84a0f0fbb706394c5a6fda1f40ac275985a016b2de5449
+size 2727

--- a/images/redpi.svg
+++ b/images/redpi.svg
@@ -71,6 +71,14 @@
      stroke-width="30"
      id="border1"
      style="fill:none;stroke:#d40000;stroke-width:30;shape-rendering:crispEdges" />
+  <rect
+     x="45"
+     y="65"
+     width="550"
+     height="420"
+     fill="#ffffff"
+     id="background"
+     style="fill:#ffffff;shape-rendering:crispEdges" />
   <path
      fill="#d40000"
      d="m 150,140 h 410 v 70 h -70 v 90 h -60 v 130 h -80 v -130 h -60 v 130 h -80 v -130 h -60 v 0 H 80 v -70 h 70 z"


### PR DESCRIPTION
## Summary

- Adds a white fill behind the pi mascot in `redpi.svg` — transparent background is now white.
- `redpi.png` updated to match.

## Test plan

- [ ] Open `images/redpi.svg` and confirm the area inside the red border is white, not transparent.
- [ ] Open `images/redpi.png` and confirm the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)