### PR TITLE
feat: track plugin disabled state with an explicit enabled flag (0.6.1)

### DIFF
--- a/.planning/config.json
+++ b/.planning/config.json
@@ -38,5 +38,6 @@
   "agent_skills": {},
   "features": {},
   "mode": "yolo",
-  "granularity": "standard"
+  "granularity": "standard",
+  "context_window": 1000000
 }

--- a/.planning/quick/260621-kmm-add-explicit-enabled-boolean-field-to-pl/260621-kmm-PLAN.md
+++ b/.planning/quick/260621-kmm-add-explicit-enabled-boolean-field-to-pl/260621-kmm-PLAN.md
@@ -1,0 +1,255 @@
+---
+phase: quick
+plan: 260621-kmm
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - extensions/pi-claude-marketplace/persistence/state-io.ts
+  - extensions/pi-claude-marketplace/persistence/migrate.ts
+  - extensions/pi-claude-marketplace/orchestrators/reconcile/plan.ts
+  - extensions/pi-claude-marketplace/orchestrators/plugin/enable-disable.ts
+  - extensions/pi-claude-marketplace/orchestrators/plugin/install.ts
+  - tests/orchestrators/reconcile/plan.test.ts
+autonomous: true
+requirements: [ENBL-02]
+
+must_haves:
+  truths:
+    - "plugin records loaded from pre-migration state.json gain enabled: true via migration"
+    - "isRecordedButDisabled reads record.enabled === false instead of empty-resources arrays"
+    - "install.ts statePhase writes enabled: true on new and re-materialized records"
+    - "disable branch sets record.enabled = false; enable branch sets record.enabled = true"
+    - "STATE_VALIDATOR accepts schemaVersion 2 records with enabled field"
+    - "npm run check stays green"
+  artifacts:
+    - path: "extensions/pi-claude-marketplace/persistence/migrate.ts"
+      provides: "ensurePluginEnabled migration helper for schemaVersion 1->2"
+      contains: "ensurePluginEnabled"
+    - path: "extensions/pi-claude-marketplace/persistence/state-io.ts"
+      provides: "enabled: Type.Boolean() in PLUGIN_INSTALL_RECORD_SCHEMA, schemaVersion 2"
+      contains: "enabled"
+    - path: "extensions/pi-claude-marketplace/orchestrators/reconcile/plan.ts"
+      provides: "isRecordedButDisabled reads record.enabled"
+      contains: "record.enabled"
+  key_links:
+    - from: "migrate.ts::ensurePluginEnabled"
+      to: "state-io.ts::PLUGIN_INSTALL_RECORD_SCHEMA"
+      via: "fills enabled: true before STATE_VALIDATOR.Check"
+    - from: "plan.ts::isRecordedButDisabled"
+      to: "state-io.ts::ExtensionState"
+      via: "reads record.enabled === false"
+    - from: "install.ts statePhase"
+      to: "state-io.ts::PLUGIN_INSTALL_RECORD_SCHEMA"
+      via: "writes enabled: true at record creation"
+---
+
+<objective>
+Replace the inferred empty-resources disabled marker with an explicit
+`enabled: boolean` field on the plugin state record.
+
+Purpose: `enabled: boolean` makes intent explicit and removes the fragile
+five-array-emptiness heuristic that treats any installable plugin with
+zero resources as "disabled". The new field is the single source of truth.
+
+Output:
+- `PLUGIN_INSTALL_RECORD_SCHEMA` gains `enabled: Type.Boolean()`
+- STATE_SCHEMA bumps to `schemaVersion: 2` (Literal union 1|2 at load, writes 2)
+- Migration in `migrate.ts` fills `enabled: true` on all existing records
+- `isRecordedButDisabled` reads `!record.enabled` (plan.ts)
+- `isCurrentlyDisabled` in enable-disable.ts reads `!installed.enabled`
+- disable branch sets `installed.enabled = false`; enable branch sets `installed.enabled = true`
+- install.ts statePhase writes `enabled: true`
+- T5 drift gate updated to assert `enabled` axis instead of five array axes
+</objective>
+
+<execution_context>
+@/Users/acolomba/src/pi-claude-marketplace/.claude/get-shit-done/workflows/execute-plan.md
+@/Users/acolomba/src/pi-claude-marketplace/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@/Users/acolomba/src/pi-claude-marketplace/.planning/STATE.md
+@/Users/acolomba/src/pi-claude-marketplace/CLAUDE.md
+@/Users/acolomba/src/pi-claude-marketplace/extensions/pi-claude-marketplace/persistence/state-io.ts
+@/Users/acolomba/src/pi-claude-marketplace/extensions/pi-claude-marketplace/persistence/migrate.ts
+@/Users/acolomba/src/pi-claude-marketplace/extensions/pi-claude-marketplace/orchestrators/reconcile/plan.ts
+@/Users/acolomba/src/pi-claude-marketplace/extensions/pi-claude-marketplace/orchestrators/plugin/enable-disable.ts
+@/Users/acolomba/src/pi-claude-marketplace/extensions/pi-claude-marketplace/orchestrators/plugin/install.ts
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Schema, migration, and statePhase</name>
+  <files>
+    extensions/pi-claude-marketplace/persistence/state-io.ts,
+    extensions/pi-claude-marketplace/persistence/migrate.ts,
+    extensions/pi-claude-marketplace/orchestrators/plugin/install.ts
+  </files>
+  <action>
+**state-io.ts** — three changes:
+
+1. Add `enabled: Type.Boolean()` as a required field to `PLUGIN_INSTALL_RECORD_SCHEMA`. Place it after `resources` and before `installedAt` to match declaration order.
+
+2. Change `STATE_SCHEMA.schemaVersion` from `Type.Literal(1)` to `Type.Union([Type.Literal(1), Type.Literal(2)])` so both old (1) and new (2) files pass `STATE_VALIDATOR.Check` during the load/migration cycle. The normalized shape written back by `persistMigratedState` should be passed with `schemaVersion: 2`. Update `DEFAULT_STATE.schemaVersion` to `2`. Update the ENOENT early-return in `loadState` to return `{ schemaVersion: 2, marketplaces: {} }`. Update the `const normalized: unknown = { schemaVersion: 1, marketplaces }` line to use `2` so migrated state is written at the new version. Update `saveState`'s `STATE_VALIDATOR.Check` — the validator now accepts both 1 and 2, so saves of version-2 objects pass cleanly.
+
+   Export `ExtensionState` continues to derive from the schema; TypeScript will infer `schemaVersion: 1 | 2`, which is fine.
+
+**migrate.ts** — add `ensurePluginEnabled`:
+
+Add a new helper `ensurePluginEnabled(mp: Record<string, unknown>): boolean` that mirrors `ensurePluginResources`. It iterates `mp.plugins` values; for each plugin record `pl`, if `pl.enabled === undefined`, sets `pl.enabled = true` and marks `mutated = true`. Returns `mutated`. The rationale: all existing plugin records with `resources.*` arrays populated (or even unpopulated) were actively installed and therefore enabled by definition — they would not have been kept in state.json otherwise.
+
+Call `ensurePluginEnabled(mp)` inside `migrateLegacyMarketplaceRecords`'s per-marketplace loop, after `ensurePluginResources(mp)`, with the same `mutated = helper() || mutated` pattern.
+
+Update the file-level JSDoc: add a note that `ensurePluginEnabled` fills `enabled: true` on v1 records (additive default-fill, same discipline as the hooks arm in `ensurePluginResources`).
+
+**install.ts statePhase** — add `enabled: true` to the record being written:
+
+In the `statePhase.do` closure, the block `mpInner.plugins[c.plugin] = { version: ..., resolvedSource: ..., compatibility: ..., resources: ..., installedAt: ..., updatedAt: ... }` needs `enabled: true` added. Place it after `resources` and before `installedAt` so it matches the schema field order. The `allowExistingRecord` arm (re-materialization) should also set `enabled: true` — this is the enable-path writing back the explicit flag (the disable path previously zeroed resources; after this change the disable path sets `enabled: false` explicitly, but the enable path re-runs statePhase via `runInstallLedger`, so statePhase must write `enabled: true` here).
+
+Do NOT touch the `existing?.installedAt ?? nowIso` line — the installedAt preservation logic for re-materialization is unchanged.
+
+After all three edits, run `npm run check` to confirm typecheck + lint + tests pass. Expect failures in plan.ts and enable-disable.ts (next task fixes those) — but state-io and install changes alone should not introduce new type errors if the schema union is wide enough.
+
+Actually: because `PLUGIN_INSTALL_RECORD_SCHEMA` now requires `enabled`, TypeScript will immediately surface missing-field errors in every fixture builder and test helper that constructs plugin records inline. Fix those in the same task: search for `plugins[c.plugin] = {` and inline plugin record literals in tests (state-io.test.ts, migrate.test.ts, plan.test.ts, enable-disable.test.ts, install-related tests) and add `enabled: true` wherever a `PLUGIN_INSTALL_RECORD_SCHEMA`-shaped literal appears. Use grep: `grep -rn "installedAt:" tests/ extensions/` to locate all inline record literals.
+
+The disable branch in enable-disable.ts (next task) currently zeros resources arrays — that still compiles fine since `enabled` just starts as `true` there; next task sets it to `false`. So task 1 can be committed independently once typecheck is clean.
+  </action>
+  <verify>
+    <automated>cd /Users/acolomba/src/pi-claude-marketplace && npm run check 2>&1 | tail -20</automated>
+  </verify>
+  <done>
+    - `PLUGIN_INSTALL_RECORD_SCHEMA` has `enabled: Type.Boolean()`
+    - `STATE_SCHEMA.schemaVersion` is `Type.Union([Type.Literal(1), Type.Literal(2)])`
+    - `DEFAULT_STATE.schemaVersion` is `2`
+    - `migrateLegacyMarketplaceRecords` calls `ensurePluginEnabled`
+    - `statePhase` writes `enabled: true`
+    - All inline plugin record literals in tests have `enabled: true`
+    - `npm run check` exits 0
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Replace disabled marker in plan.ts and enable-disable.ts; update T5 drift gate</name>
+  <files>
+    extensions/pi-claude-marketplace/orchestrators/reconcile/plan.ts,
+    extensions/pi-claude-marketplace/orchestrators/plugin/enable-disable.ts,
+    tests/orchestrators/reconcile/plan.test.ts
+  </files>
+  <action>
+**plan.ts — `isRecordedButDisabled`**:
+
+Replace the entire body of `isRecordedButDisabled` with:
+
+```
+return record.compatibility.installable && record.enabled === false;
+```
+
+Update the JSDoc above it: remove the long explanation of the five-array-emptiness heuristic and the `requireInstallable` gate reasoning. Replace with a short note: reads the explicit `enabled` field; `enabled === false` is the sole disabled marker; `installable === true` guard retained so soft-degraded (`installable: false`) records with `enabled: false` (hypothetically) are not classified as disabled-but-re-enableable. Remove the SPLIT-01 preservation note (no longer relevant).
+
+Also update the module-level block comment at the top of plan.ts: remove the paragraph starting "ENBL-02: the recorded-but-disabled hand-off closes here. `isRecordedButDisabled(record)` reads the empty-resources marker (all four `resources.*` arrays empty -- A1; SPLIT-01 preserved)" and replace it with: "ENBL-02: `isRecordedButDisabled(record)` reads `record.enabled === false` (explicit field, schemaVersion 2). The `installable === true` guard retains the soft-degraded exclusion."
+
+**enable-disable.ts — `isCurrentlyDisabled`**:
+
+Replace the entire body of `isCurrentlyDisabled` with:
+
+```
+return installed.compatibility.installable && installed.enabled === false;
+```
+
+The function signature parameter type already references the state record shape via `InstalledPluginRecord = ExtensionState["marketplaces"][string]["plugins"][string]`. After Task 1 adds `enabled: boolean` to the schema, `installed.enabled` is typed `boolean` — no cast needed.
+
+Update the JSDoc on `isCurrentlyDisabled`: replace the five-axis explanation with "Reads `enabled === false`; installable guard retains soft-degraded exclusion. Duplicated from `isRecordedButDisabled` to keep the orchestrator import graph free of the reconcile module."
+
+**enable-disable.ts — disable branch**:
+
+In `runDisableBranch`, after `installed.resources.hooks = []` and before the `dropCachedHooks` call, add:
+
+```
+installed.enabled = false;
+```
+
+The existing five resource-array zeroing MUST remain — clearing resources is still the mechanism that removes artefacts from Pi. `enabled: false` is the explicit intent marker; the arrays being empty remains the physical state. Both must be set.
+
+**enable-disable.ts — enable branch (idempotent config-flip arm)**:
+
+In the `isCurrentlyDisabled(installed) === !enable` branch (the config-flip arm for mismatched config), after `writeBatchedConfigEntries` and before `outcome = { kind: "fresh", ... }`, add `installed.enabled = enable;` and then `await tx.save();`. Wait — read the existing arm carefully. Currently this arm does NOT call `tx.save()` (the state-side is already correct). With the new field, when the enable branch hits the config-flip arm, `installed.enabled` is already `true` (state matches), so no state update needed there. When the disable branch hits it (`enable === false`), `installed.enabled` is already `false`. So this arm needs no change to state — state truth is correct; only config was diverged. No modification needed.
+
+**enable-disable.ts — enable branch (main path)**:
+
+In `runEnableBranch`, the enable path calls `runInstallLedger` which runs `statePhase` which sets `enabled: true` (Task 1). So the enable branch naturally sets `enabled: true` via `statePhase`. No separate assignment needed here.
+
+**tests/orchestrators/reconcile/plan.test.ts — T5 drift gate**:
+
+The T5 test block (lines ~612-811) has two tests:
+
+1. The truth-table test over `isRecordedButDisabled`: update the `recordWith` helper to accept an `enabled?: boolean` parameter (default `true`) and set `enabled: enabled ?? true` on the returned record. Update the test cases: the matrix is now `installable x enabled` (two boolean dimensions, not three). Keep cases:
+   - `(installable: true, enabled: true)` → `false` (enabled)
+   - `(installable: true, enabled: false)` → `true` (the disabled marker)
+   - `(installable: false, enabled: true)` → `false` (soft-degraded, never disabled)
+   - `(installable: false, enabled: false)` → `false` (soft-degraded, never disabled)
+   Remove the `hooksPopulated` dimension entirely — it is no longer relevant since the heuristic is gone. Remove references to `D-63-04`.
+
+2. The `isCurrentlyDisabled` source-shape pin test: update `requiredAxes` to:
+   - `"compatibility.installable"`
+   - `"enabled === false"` (or `"installed.enabled === false"`)
+   Remove the five `resources.*.length === 0` entries. Remove the `||` conjunction check (no longer relevant — the new body uses `&&` but over two axes, not six). Keep the `&&` check.
+
+   Update the regex that extracts the function body from the source file if needed, but the function signature should still be findable by name.
+
+Run `npm run check` after all changes to confirm full green.
+  </action>
+  <verify>
+    <automated>cd /Users/acolomba/src/pi-claude-marketplace && npm run check 2>&1 | tail -20</automated>
+  </verify>
+  <done>
+    - `isRecordedButDisabled` returns `record.compatibility.installable && record.enabled === false`
+    - `isCurrentlyDisabled` returns `installed.compatibility.installable && installed.enabled === false`
+    - `runDisableBranch` sets `installed.enabled = false` alongside zeroing resource arrays
+    - T5 truth table reduced to `installable x enabled` matrix (4 cases, no hooksPopulated dimension)
+    - T5 source-shape pin asserts `enabled === false` axis, not the six resource-array axes
+    - `npm run check` exits 0
+  </done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| state.json → loadState | Untrusted bytes from disk; schema validation gates all fields |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-kmm-01 | Tampering | migration: enabled default | mitigate | Migration sets `enabled: true` unconditionally for absent field; validation rejects absent field after migration runs |
+| T-kmm-02 | Information disclosure | n/a | accept | `enabled` is a boolean, not PII; no new disclosure surface |
+</threat_model>
+
+<verification>
+- `npm run check` exits 0 (typecheck + ESLint + Prettier + tests)
+- `STATE_VALIDATOR.Check({ schemaVersion: 1, marketplaces: {} })` returns false (missing enabled on any plugin would fail; but schemaVersion 1 with no plugins passes)
+- A state.json with schemaVersion 1 and an existing plugin record (no `enabled` field) loads, migration fills `enabled: true`, `STATE_VALIDATOR.Check` passes, and `persistMigratedState` writes back schemaVersion 2
+- After install: `state.marketplaces[mp].plugins[plugin].enabled === true`
+- After disable: `state.marketplaces[mp].plugins[plugin].enabled === false` AND all five resource arrays are empty
+- After enable: `state.marketplaces[mp].plugins[plugin].enabled === true` AND resource arrays are repopulated
+- `isRecordedButDisabled` returns `true` only for `{ installable: true, enabled: false }` records
+- No test references `resources.skills.length === 0` as a disabled-detection heuristic
+</verification>
+
+<success_criteria>
+- `enabled: boolean` is a required field in `PLUGIN_INSTALL_RECORD_SCHEMA`
+- schemaVersion bumps to 2; version 1 files load and migrate cleanly in a single `loadState` call
+- `isRecordedButDisabled` and `isCurrentlyDisabled` are one-liners reading `enabled === false`
+- Disable sets `enabled: false`; enable (via statePhase) sets `enabled: true`
+- T5 drift gate reflects the new predicate shape
+- `npm run check` is green with no pre-existing test regressions
+</success_criteria>
+
+<output>
+Create `.planning/quick/260621-kmm-add-explicit-enabled-boolean-field-to-pl/260621-kmm-SUMMARY.md` when done
+</output>

--- a/.planning/quick/260621-kmm-add-explicit-enabled-boolean-field-to-pl/260621-kmm-SUMMARY.md
+++ b/.planning/quick/260621-kmm-add-explicit-enabled-boolean-field-to-pl/260621-kmm-SUMMARY.md
@@ -1,0 +1,127 @@
+---
+quick-task: 260621-kmm
+subsystem: persistence, reconcile, plugin-orchestrators
+tags: [schema, state-migration, enable-disable, enbl-02]
+dependency-graph:
+  requires: []
+  provides: [explicit-enabled-boolean, enbl-02-disabled-marker]
+  affects: [state-io, migrate, plan, enable-disable, update, install, reinstall]
+tech-stack:
+  added: []
+  patterns: [additive-migration, discriminated-boolean-flag, enbl-02-marker]
+key-files:
+  created: []
+  modified:
+    - extensions/pi-claude-marketplace/persistence/state-io.ts
+    - extensions/pi-claude-marketplace/persistence/migrate.ts
+    - extensions/pi-claude-marketplace/orchestrators/plugin/install.ts
+    - extensions/pi-claude-marketplace/orchestrators/plugin/reinstall.ts
+    - extensions/pi-claude-marketplace/orchestrators/plugin/enable-disable.ts
+    - extensions/pi-claude-marketplace/orchestrators/plugin/update.ts
+    - extensions/pi-claude-marketplace/orchestrators/reconcile/plan.ts
+    - tests/persistence/state-io.test.ts
+    - tests/persistence/migrate.test.ts
+    - tests/orchestrators/reconcile/plan.test.ts
+    - tests/orchestrators/reconcile/apply.test.ts
+    - tests/orchestrators/plugin/enable-disable.test.ts
+    - tests/orchestrators/plugin/list.test.ts
+    - tests/orchestrators/plugin/update.test.ts
+    - tests/orchestrators/marketplace/autoupdate.test.ts
+    - tests/persistence/fixtures/legacy/state-populated-mixed.json
+    - (27 additional test files with enabled field and schemaVersion 2 updates)
+decisions:
+  - Use !record.enabled (ESLint no-unnecessary-boolean-literal-compare rejects === false on boolean)
+  - Drift gate axis string updated from "enabled === false" to "!installed.enabled"
+  - state-populated-mixed.json updated with enabled:true and hooks:[] for convergence proof
+metrics:
+  duration: 90 minutes (two sessions)
+  completed: 2026-06-21
+  tasks-completed: 2
+  files-changed: 37
+---
+
+# Quick Task 260621-kmm: Add Explicit enabled Boolean to Plugin State Records
+
+**One-liner:** Replaces the five-resource-array-emptiness disabled-plugin heuristic with
+an explicit `enabled: boolean` field (ENBL-02), adding additive migration and bumping
+schemaVersion to 2.
+
+## What Was Built
+
+### Task 1 -- Schema and migration (commit 8ceaa9c3)
+
+Added `enabled: Type.Boolean()` to `PLUGIN_INSTALL_RECORD_SCHEMA` in `state-io.ts`. Bumped
+`STATE_SCHEMA.schemaVersion` from `Type.Literal(1)` to
+`Type.Union([Type.Literal(1), Type.Literal(2)])`. `loadState` now always returns
+`schemaVersion: 2`. Added `ensurePluginEnabled` migration helper in `migrate.ts` (mirrors
+`ensurePluginResources` pattern) that fills `enabled: true` for any plugin record missing the
+field. Set `enabled: true` in `install.ts` and `reinstall.ts`. Updated `clonePluginRecord` in
+`reinstall.ts` to preserve `enabled`. Updated 27+ test fixture files to include `enabled`
+field and `schemaVersion: 2`.
+
+### Task 2 -- Predicate replacement (commit 5b3144d7)
+
+Replaced `isRecordedButDisabled` in `plan.ts` from 5-array emptiness check to
+`record.compatibility.installable && !record.enabled`. Did the same for the local copy in
+`update.ts`. Replaced `isCurrentlyDisabled` in `enable-disable.ts` with `!installed.enabled`
+and added `installed.enabled = false` in `runDisableBranch`. Updated T5 drift gate test in
+`plan.test.ts` to pin the `!installed.enabled` axis. Fixed additional test fixtures that
+wrote disabled-marker records without `enabled: false`.
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+**1. [Rule 1 - Bug] ESLint rejected === false comparison on boolean field**
+- **Found during:** Task 2 lint run
+- **Issue:** @typescript-eslint/no-unnecessary-boolean-literal-compare forbids
+  booleanField === false; plan used this form throughout
+- **Fix:** Changed to !field in all three predicates (plan.ts, update.ts, enable-disable.ts)
+- **Cascade:** Drift gate axis string in plan.test.ts updated from "enabled === false" to
+  "!installed.enabled" to match the new source form
+- **Files modified:** plan.ts, update.ts, enable-disable.ts, plan.test.ts
+
+**2. [Rule 2 - Missing fixture update] state-populated-mixed.json missing enabled field**
+- **Found during:** Task 2 -- plan-convergence.test.ts failing
+- **Issue:** Fixture loaded without migration; !record.enabled evaluated !undefined === true,
+  treating installable records as disabled
+- **Fix:** Added enabled:true and hooks:[] to all plugin records in the fixture
+- **Files modified:** tests/persistence/fixtures/legacy/state-populated-mixed.json
+
+**3. [Rule 2 - Missing fixture updates] apply.test.ts Y3/T1 and autoupdate.test.ts**
+- **Found during:** Task 2 full test run
+- **Issue:** Direct writeFile calls used schemaVersion:1 and no enabled field; migration
+  filled enabled:true, breaking disabled-marker detection
+- **Fix:** Updated to schemaVersion:2, enabled:false, hooks:[] in disabled plugin records
+- **Files modified:** tests/orchestrators/reconcile/apply.test.ts,
+  tests/orchestrators/marketplace/autoupdate.test.ts
+
+**4. [Rule 2 - Missing fixture update] list.test.ts seedMarketplace hardcoded enabled:true**
+- **Found during:** Task 2 full test run (ENBL-04 tests failing)
+- **Issue:** seedMarketplace set enabled:true regardless of disabled:true option
+- **Fix:** Changed to enabled: info.disabled !== true
+- **Files modified:** tests/orchestrators/plugin/list.test.ts
+
+## Known Pre-existing Test Failures
+
+The following failures are pre-existing parallel test interference:
+- on-exit, multi-hook fan-in, rewakeSummary IL-2 exemption, HOOK-06 suite -- parallel
+  interference from spawned child processes sharing process-level state
+- Case D (in-tree symlink) -- macOS /private/var vs /var symlink path issue
+- D-UPD: update on a disabled plugin -- HOME env var mutation across parallel test files
+
+## Commits
+
+| Task | Commit | Description |
+|------|--------|-------------|
+| 1 | 8ceaa9c3 | feat(260621-kmm): add explicit enabled boolean to plugin state records |
+| 2 | 5b3144d7 | feat(260621-kmm): replace resource-emptiness heuristic with enabled flag |
+
+## Self-Check: PASSED
+
+- [x] Both commits exist: 8ceaa9c3 and 5b3144d7
+- [x] npm run typecheck exits 0
+- [x] npm run lint exits 0
+- [x] npm run format:check exits 0
+- [x] npm test passes with only pre-existing parallel interference failures
+- [x] All ENBL-02 predicates use !record.enabled consistently

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.6.1] - 2026-06-21
+
+- Disabled plugins are now tracked by an explicit `enabled` flag in `state.json` instead of being inferred from every resource array being empty. The old heuristic could misclassify an installed plugin that had no materialized resources -- a hooks-only plugin in particular -- so `enable`/`disable`, `list`, and the reconcile planner now agree on one unambiguous marker. The state schema version bumps to 2 and existing `state.json` files migrate automatically on the next reload; any plugin you had disabled stays disabled, and no reinstall or manual edit is required.
+
 ## [0.6.0] - 2026-06-18
 
 - Claude Code hooks bridge: plugins shipping `hooks/hooks.json` now run their declared handlers under Pi's lifecycle. The 7 bucket-A Claude events (`SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `PostToolUseFailure`, `PreCompact`, `PostCompact`, `SessionEnd`) dispatch by matcher + `if`-predicate to the handler set declared by every installed plugin. SessionStart `additionalContext` is captured and drained into the next agent turn's system prompt via Pi's `before_agent_start`, preserving multi-plugin concat order and clearing on `/reload` so stale context cannot leak across sessions. Hook subprocesses receive `CLAUDE_PLUGIN_ROOT` (the plugin's resolved source path) and `CLAUDE_PLUGIN_DATA` (a per-session writable dir) on env; install/uninstall/reinstall/update/enable/disable all keep the routing table in lockstep with state.json so dispatch starts working immediately without `/reload` (NFR-2). Async-rewake re-dispatches surviving child processes after a Pi restart with PID-table reaping; cross-scope cache walks ensure user + project plugins both surface even when only one scope reconciles.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 [![CI](https://github.com/acolomba/pi-claude-marketplace/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/acolomba/pi-claude-marketplace/actions/workflows/ci.yml) [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=acolomba_pi-claude-marketplace&metric=alert_status)](https://sonarcloud.io/summary/overall?id=acolomba_pi-claude-marketplace) [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=acolomba_pi-claude-marketplace&metric=coverage)](https://sonarcloud.io/summary/overall?id=acolomba_pi-claude-marketplace) [![Bugs](https://sonarcloud.io/api/project_badges/measure?project=acolomba_pi-claude-marketplace&metric=bugs)](https://sonarcloud.io/summary/overall?id=acolomba_pi-claude-marketplace) [![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=acolomba_pi-claude-marketplace&metric=code_smells)](https://sonarcloud.io/summary/overall?id=acolomba_pi-claude-marketplace) [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=acolomba_pi-claude-marketplace&metric=sqale_rating)](https://sonarcloud.io/summary/overall?id=acolomba_pi-claude-marketplace) [![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=acolomba_pi-claude-marketplace&metric=reliability_rating)](https://sonarcloud.io/summary/overall?id=acolomba_pi-claude-marketplace) [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=acolomba_pi-claude-marketplace&metric=security_rating)](https://sonarcloud.io/summary/overall?id=acolomba_pi-claude-marketplace) [![GitHub](https://img.shields.io/badge/GitHub-acolomba%2Fpi--claude--marketplace-181717?logo=github&logoColor=white)](https://github.com/acolomba/pi-claude-marketplace) [![npm](https://img.shields.io/badge/npm-pi--claude--marketplace-cb3837?logo=npm&logoColor=white)](https://www.npmjs.com/package/pi-claude-marketplace) [![pi.dev](https://img.shields.io/badge/pi.dev-pi--claude--marketplace-09090b?logo=data:image/svg%2Bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA4MDAgODAwIj48cmVjdCB3aWR0aD0iODAwIiBoZWlnaHQ9IjgwMCIgcng9IjEyMCIgZmlsbD0iIzA5MDkwYiIvPjxwYXRoIGZpbGw9IiNmZmYiIGZpbGwtcnVsZT0iZXZlbm9kZCIgZD0iTTE2NS4yOSAxNjUuMjlINTE3LjM2VjQwMEg0MDBWNTE3LjM2SDI4Mi42NVY2MzQuNzJIMTY1LjI5Wk0yODIuNjUgMjgyLjY1VjQwMEg0MDBWMjgyLjY1WiIvPjxwYXRoIGZpbGw9IiNmZmYiIGQ9Ik01MTcuMzYgNDAwSDYzNC43MlY2MzQuNzJINTE3LjM2WiIvPjwvc3ZnPg==)](https://pi.dev/packages/pi-claude-marketplace)
 
-Access Claude plugin marketplaces from Pi Coding Agent.
+Access Claude plugin marketplaces from [Pi Coding Agent](https://pi.dev).
 
 <!-- markdownlint-disable MD033 -->
 
@@ -20,7 +20,7 @@ Access Claude plugin marketplaces from Pi Coding Agent.
 
 ## Features
 
-Installs plugins from the Claude plugin marketplace that contain these components:
+Installs plugins from Claude plugin marketplaces that contain these components:
 
 - Commands.
 - Skills.
@@ -29,6 +29,8 @@ Installs plugins from the Claude plugin marketplace that contain these component
 - MCP servers. Requires [pi-mcp-adapter](https://pi.dev/packages/pi-mcp-adapter).
 
 Plugins that contain unsupported components are marked as "unavailable".
+
+Claude marketplaces and plugins are managed via a `/claude:plugin` command similar to Claude Code's `/plugin`. A desired-state configuration is kept in `[~/].pi/agent/claude-plugins[.local].json` files for automated, repeatable plugin installations that may be shared across machines or team members.
 
 ## Prerequisites
 

--- a/extensions/pi-claude-marketplace/bridges/hooks/async-rewake/registry.ts
+++ b/extensions/pi-claude-marketplace/bridges/hooks/async-rewake/registry.ts
@@ -192,6 +192,16 @@ export function _getRegistryForTest(): ReadonlyMap<string, AsyncRewakeEntry> {
   return asyncRewakeRegistry;
 }
 
+// Tracks the most recent fire-and-forget pid-table persist so tests can
+// drain it in cleanup before removing the temp directory, avoiding ENOTEMPTY
+// races with write-file-atomic's in-flight atomic rename on macOS.
+let _lastPidTablePersist: Promise<void> = Promise.resolve();
+
+/** Await the most recent in-flight pid-table persist (for test teardown). */
+export function _awaitLastPidTablePersistForTest(): Promise<void> {
+  return _lastPidTablePersist;
+}
+
 // ──────────────────────────────────────────────────────────────────────────
 // Public surface: spawnAndRegister
 // ──────────────────────────────────────────────────────────────────────────
@@ -351,7 +361,8 @@ function onChildExit(
 
   entry.ladder.cancel();
   asyncRewakeRegistry.delete(dispatchId);
-  void persistPidTableForLoc(entry.loc);
+  _lastPidTablePersist = persistPidTableForLoc(entry.loc);
+  void _lastPidTablePersist;
 
   // D-62-03 / D-59-03 captured-epoch zombie defense. A slow child from
   // a prior `/reload` cycle must not inject into the freshly-hydrated
@@ -433,7 +444,8 @@ function onChildError(dispatchId: string, err: unknown): void {
 
   entry.ladder.cancel();
   asyncRewakeRegistry.delete(dispatchId);
-  void persistPidTableForLoc(entry.loc);
+  _lastPidTablePersist = persistPidTableForLoc(entry.loc);
+  void _lastPidTablePersist;
 }
 
 /**

--- a/extensions/pi-claude-marketplace/bridges/hooks/event-router.ts
+++ b/extensions/pi-claude-marketplace/bridges/hooks/event-router.ts
@@ -43,7 +43,7 @@ import {
 } from "../../domain/components/hooks.ts";
 import { asAbsolutePluginRoot, type AbsolutePluginRoot } from "../../domain/plugin-root.ts";
 import { locationsFor, type ScopedLocations } from "../../persistence/locations.ts";
-import { loadState, type ExtensionState } from "../../persistence/state-io.ts";
+import { DEFAULT_STATE, loadState, type ExtensionState } from "../../persistence/state-io.ts";
 import { hookDebugLog } from "../../shared/debug-log.ts";
 import { errorMessage } from "../../shared/errors.ts";
 import { compareByNameThenScope } from "../../shared/notify.ts";
@@ -555,7 +555,7 @@ async function hydrateCacheFromDisk(opts: {
       hookDebugLog(
         `hydrate: loadState failed for scope=${scope} extensionRoot=${loc.extensionRoot}: ${errorMessage(err)}`,
       );
-      state = { schemaVersion: 1, marketplaces: {} };
+      state = { ...DEFAULT_STATE };
     }
 
     // MATCH-03 / A1 projectRoot fallback: pass opts.cwd as cwd +

--- a/extensions/pi-claude-marketplace/bridges/hooks/stage.ts
+++ b/extensions/pi-claude-marketplace/bridges/hooks/stage.ts
@@ -138,9 +138,13 @@ async function readEntriesOrSkip(dir: string): Promise<Dirent[] | null> {
  * (D-17).
  */
 async function assertSymlinkEntryContained(pluginRoot: string, linkPath: string): Promise<void> {
-  const resolved = await realpath(linkPath);
+  // Resolve both sides so the string-prefix check in assertPathInside
+  // works on macOS where /var is a symlink to /private/var: realpath of
+  // linkPath yields /private/var/... but pluginRoot is still /var/...
+  // unless we also resolve it, causing a false containment failure.
+  const [resolved, resolvedRoot] = await Promise.all([realpath(linkPath), realpath(pluginRoot)]);
   try {
-    await assertPathInside(pluginRoot, resolved, `hooks subtree symlink ${linkPath}`);
+    await assertPathInside(resolvedRoot, resolved, `hooks subtree symlink ${linkPath}`);
   } catch (err) {
     if (err instanceof SymlinkRefusedError) {
       throw err;

--- a/extensions/pi-claude-marketplace/orchestrators/plugin/enable-disable.ts
+++ b/extensions/pi-claude-marketplace/orchestrators/plugin/enable-disable.ts
@@ -55,6 +55,7 @@ import path from "node:path";
 import { rebuildRoutingTables, removePluginConfigFromCache } from "../../bridges/hooks/index.ts";
 import { loadConfig } from "../../persistence/config-io.ts";
 import { writeBatchedConfigEntries } from "../../persistence/config-write-back.ts";
+import { toDisabledRecord } from "../../persistence/state-io.ts";
 import { hookDebugLog } from "../../shared/debug-log.ts";
 import { errorMessage, MarketplaceNotFoundError, StateLockHeldError } from "../../shared/errors.ts";
 import { notify, redactAbsolutePaths } from "../../shared/notify.ts";
@@ -72,7 +73,7 @@ import {
 import type { InstallFailureCapture } from "./install.ts";
 import type { ScopeConfig } from "../../persistence/config-io.ts";
 import type { ScopedLocations } from "../../persistence/locations.ts";
-import type { ExtensionState } from "../../persistence/state-io.ts";
+import type { DisabledPluginRecord, ExtensionState } from "../../persistence/state-io.ts";
 import type { ExtensionAPI, ExtensionContext } from "../../platform/pi-api.ts";
 import type {
   ContentReason,
@@ -258,7 +259,7 @@ async function runDisableBranch(
   scope: Scope,
   locations: ScopedLocations,
   installed: InstalledPluginRecord,
-): Promise<{ outcome: SetEnabledOutcome; saveShrunken: boolean }> {
+): Promise<{ outcome: SetEnabledOutcome; saveShrunken: boolean; disabled?: DisabledPluginRecord }> {
   const recordedVersion = installed.version;
   const cascade = await cascadeUnstagePlugin(opts.plugin, opts.marketplace, locations, installed);
   if (!cascade.ok) {
@@ -291,19 +292,16 @@ async function runDisableBranch(
   // PRESERVE version / resolvedSource / compatibility / installedAt;
   // RESET resources.*; SET enabled: false; BUMP updatedAt.
   // D-63-04 / COMPONENT_KINDS 5-tuple: cascadeUnstagePlugin physically
-  // unstages hooks via removeHookConfig, so the in-memory record's hooks
+  // unstages hooks via removeHookConfig, so the disabled record's hooks
   // array must be zeroed alongside the other four axes to stay consistent
   // with what landed on disk.
-  // ENBL-02: set enabled: false as the explicit disabled marker. Resources
-  // arrays are still zeroed for backwards compatibility with the convergence
-  // proof and any reader that has not yet migrated to the boolean check.
-  installed.resources.skills = [];
-  installed.resources.prompts = [];
-  installed.resources.agents = [];
-  installed.resources.mcpServers = [];
-  installed.resources.hooks = [];
-  installed.enabled = false;
-  installed.updatedAt = new Date().toISOString();
+  // ENBL-02: `toDisabledRecord` is the sole sanctioned producer of the
+  // disabled shape -- its empty-tuple return type makes a disabled-but-
+  // populated record a compile error. The resources arrays stay zeroed for
+  // the convergence proof and any reader not yet migrated to the boolean
+  // check. The caller replaces the map slot with the returned record (rather
+  // than mutating in place) so the branded type survives to the assignment.
+  const disabled = toDisabledRecord(installed, new Date().toISOString());
 
   // WR-03: the cascade unstaged the on-disk hooks.json via removeHookConfig;
   // drop the parsed-config cache entry and rebuild the routing table in
@@ -311,7 +309,7 @@ async function runDisableBranch(
   // without requiring /reload (NFR-2). Mirrors the uninstall.ts invariant.
   dropCachedHooks(scope, opts.marketplace, opts.plugin, "", true);
 
-  return { outcome: { kind: "fresh", version: recordedVersion }, saveShrunken: false };
+  return { outcome: { kind: "fresh", version: recordedVersion }, saveShrunken: false, disabled };
 }
 
 /**
@@ -522,6 +520,14 @@ export async function setPluginEnabled(
       } else {
         const disableResult = await runDisableBranch(opts, scope, locations, installed);
         outcome = disableResult.outcome;
+        // ENBL-02: on a clean disable, replace the map slot with the branded
+        // `DisabledPluginRecord` the branch built via `toDisabledRecord`
+        // (rather than mutating `installed` in place). The terminal
+        // `tx.save()` below persists tx.state with the replaced slot.
+        if (disableResult.disabled !== undefined) {
+          mp.plugins[plugin] = disableResult.disabled;
+        }
+
         // I3: a partial disable cascade mutated `installed.resources.*` in
         // place to drop the artefacts already removed before the throw.
         // Persist the shrunken record so state.json never claims artefacts

--- a/extensions/pi-claude-marketplace/orchestrators/plugin/enable-disable.ts
+++ b/extensions/pi-claude-marketplace/orchestrators/plugin/enable-disable.ts
@@ -168,30 +168,17 @@ type SetEnabledOutcome =
   | { kind: "disable-failed"; cause: Error; recordedVersion?: string };
 
 /**
- * The "currently disabled" marker -- the empty-resources + installable:true
- * intersection that `orchestrators/reconcile/plan.ts::isRecordedButDisabled`
- * uses. Duplicated locally to avoid pulling the reconcile module into the
- * orchestrator's import graph (the planner is the canonical owner; this
- * predicate is the deliberate same-rule mirror).
+ * ENBL-02: the "currently disabled" marker is an explicit `enabled: false`
+ * on the plugin install record. Duplicated locally from
+ * `orchestrators/reconcile/plan.ts::isRecordedButDisabled` to avoid pulling
+ * the reconcile module into the orchestrator's import graph (the planner is
+ * the canonical owner; this predicate is the deliberate same-rule mirror).
  */
 function isCurrentlyDisabled(installed: {
   compatibility: { installable: boolean };
-  resources: {
-    skills: readonly string[];
-    prompts: readonly string[];
-    agents: readonly string[];
-    mcpServers: readonly string[];
-    hooks: readonly string[];
-  };
+  enabled: boolean;
 }): boolean {
-  return (
-    installed.compatibility.installable &&
-    installed.resources.skills.length === 0 &&
-    installed.resources.prompts.length === 0 &&
-    installed.resources.agents.length === 0 &&
-    installed.resources.mcpServers.length === 0 &&
-    installed.resources.hooks.length === 0
-  );
+  return installed.compatibility.installable && !installed.enabled;
 }
 
 /**
@@ -302,16 +289,20 @@ async function runDisableBranch(
   }
 
   // PRESERVE version / resolvedSource / compatibility / installedAt;
-  // RESET resources.*; BUMP updatedAt.
+  // RESET resources.*; SET enabled: false; BUMP updatedAt.
   // D-63-04 / COMPONENT_KINDS 5-tuple: cascadeUnstagePlugin physically
   // unstages hooks via removeHookConfig, so the in-memory record's hooks
   // array must be zeroed alongside the other four axes to stay consistent
   // with what landed on disk.
+  // ENBL-02: set enabled: false as the explicit disabled marker. Resources
+  // arrays are still zeroed for backwards compatibility with the convergence
+  // proof and any reader that has not yet migrated to the boolean check.
   installed.resources.skills = [];
   installed.resources.prompts = [];
   installed.resources.agents = [];
   installed.resources.mcpServers = [];
   installed.resources.hooks = [];
+  installed.enabled = false;
   installed.updatedAt = new Date().toISOString();
 
   // WR-03: the cascade unstaged the on-disk hooks.json via removeHookConfig;

--- a/extensions/pi-claude-marketplace/orchestrators/plugin/enable-disable.ts
+++ b/extensions/pi-claude-marketplace/orchestrators/plugin/enable-disable.ts
@@ -275,7 +275,7 @@ async function runDisableBranch(
     // so dispatch does not try to spawn a now-deleted handler. Mirrors
     // the uninstall.ts cache-mutation invariant.
     if (cascade.dropped.hooks.length > 0) {
-      dropCachedHooks(scope, opts.marketplace, opts.plugin, "partial-cascade ");
+      dropCachedHooks(scope, opts.marketplace, opts.plugin, "partial-cascade ", false);
     }
 
     return {
@@ -309,7 +309,7 @@ async function runDisableBranch(
   // drop the parsed-config cache entry and rebuild the routing table in
   // lockstep so subsequent dispatch events bypass the now-disabled plugin
   // without requiring /reload (NFR-2). Mirrors the uninstall.ts invariant.
-  dropCachedHooks(scope, opts.marketplace, opts.plugin, "");
+  dropCachedHooks(scope, opts.marketplace, opts.plugin, "", true);
 
   return { outcome: { kind: "fresh", version: recordedVersion }, saveShrunken: false };
 }
@@ -321,19 +321,31 @@ async function runDisableBranch(
  * the cache is rebuilt from state.json on the next /reload's factory-time
  * hydrate (D-59-02). The `logPrefix` distinguishes the partial-cascade
  * branch from the clean-disable branch in debug logs.
+ *
+ * `unexpected` marks the clean-disable path, where the cascade fully
+ * succeeded and a routing-rebuild failure is NOT anticipated: the failure
+ * message names the consequence (the disabled plugin's hooks stay live in
+ * the running process) and the remedy (the disable's own `/reload` trailer
+ * already instructs the user, and that reload rebuilds the routing table
+ * from state.json). On the partial-cascade path a rebuild failure is an
+ * expected secondary symptom of the cascade throw, so it stays terse.
  */
 function dropCachedHooks(
   scope: Scope,
   marketplace: string,
   plugin: string,
   logPrefix: string,
+  unexpected: boolean,
 ): void {
   try {
     removePluginConfigFromCache(scope, marketplace, plugin);
     rebuildRoutingTables();
   } catch (cacheErr) {
+    const consequence = unexpected
+      ? " -- hooks for this plugin remain active in the running process until the disable's /reload rebuilds the routing table from state.json"
+      : "";
     hookDebugLog(
-      `disable: ${logPrefix}cache/routing mutation failed for ${plugin}@${marketplace}: ${errorMessage(cacheErr)}`,
+      `disable: ${logPrefix}cache/routing mutation failed for ${plugin}@${marketplace}: ${errorMessage(cacheErr)}${consequence}`,
     );
   }
 }

--- a/extensions/pi-claude-marketplace/orchestrators/plugin/install.ts
+++ b/extensions/pi-claude-marketplace/orchestrators/plugin/install.ts
@@ -789,6 +789,10 @@ export async function runInstallLedger(
           // inventory stays empty.
           hooks: c.resolved.hooksConfigPath === undefined ? [] : [c.plugin],
         },
+        // ENBL-02: always set enabled: true on install and re-materialization.
+        // The disable branch sets it to false; the enable branch re-runs
+        // statePhase (via runInstallLedger), which resets it to true here.
+        enabled: true,
         // D-54-01 / ENBL-02: on re-materialization (allowExistingRecord),
         // PRESERVE the original installedAt -- the record was never
         // uninstalled, only disabled. Fresh installs stamp now.

--- a/extensions/pi-claude-marketplace/orchestrators/plugin/reinstall.ts
+++ b/extensions/pi-claude-marketplace/orchestrators/plugin/reinstall.ts
@@ -1363,6 +1363,7 @@ function updateStateRecord(
       unsupported: [...installable.unsupported],
     },
     resources: resourcesFromHandles(handles, plugin, installable),
+    enabled: true,
     installedAt: oldRecord.installedAt,
     updatedAt: new Date().toISOString(),
   };
@@ -1679,6 +1680,7 @@ function clonePluginRecord(record: PluginRecord): PluginRecord {
       // HOOK-02 / D-57-01: clone the additive required hooks inventory verbatim.
       hooks: [...record.resources.hooks],
     },
+    enabled: record.enabled,
     installedAt: record.installedAt,
     updatedAt: record.updatedAt,
   };

--- a/extensions/pi-claude-marketplace/orchestrators/plugin/update.ts
+++ b/extensions/pi-claude-marketplace/orchestrators/plugin/update.ts
@@ -949,7 +949,7 @@ async function markUpdateInProgress(
  * is a truthful "we touched this record" stamp.
  */
 /**
- * D-UPD: same intersection as `reconcile/plan.ts::isRecordedButDisabled`.
+ * ENBL-02: same rule as `reconcile/plan.ts::isRecordedButDisabled`.
  * Duplicated here to avoid pulling the reconcile module into the orchestrator's
  * import graph; the planner is the canonical owner and this predicate is the
  * deliberate same-rule mirror (`enable-disable.ts::isCurrentlyDisabled` does
@@ -958,14 +958,7 @@ async function markUpdateInProgress(
 function isRecordedButDisabled(
   record: ExtensionState["marketplaces"][string]["plugins"][string],
 ): boolean {
-  return (
-    record.compatibility.installable &&
-    record.resources.skills.length === 0 &&
-    record.resources.prompts.length === 0 &&
-    record.resources.agents.length === 0 &&
-    record.resources.mcpServers.length === 0 &&
-    record.resources.hooks.length === 0
-  );
+  return record.compatibility.installable && !record.enabled;
 }
 
 /**

--- a/extensions/pi-claude-marketplace/orchestrators/reconcile/plan.ts
+++ b/extensions/pi-claude-marketplace/orchestrators/reconcile/plan.ts
@@ -252,42 +252,22 @@ interface DeclaredPluginAccumulator {
  * arrays are ALL empty AND whose `compatibility.installable === true` is
  * treated as currently disabled. The
  * `orchestrators/plugin/install.ts::statePhase` is the only path that
- * POPULATES `resources.*` (it copies from `c.stagedXxxNames`, which the
- * resolver fills from the plugin's components); the disable orchestrator
- * is the only path that empties them while keeping the record. The
- * `requireInstallable` gate rules out the zero-component installable
- * degenerate, so an INSTALLABLE plugin always has at least one populated
- * array after install.
+ * ENBL-02: the "currently disabled" marker is now an explicit
+ * `enabled: false` on the plugin install record. The old empty-resources
+ * heuristic (five-array emptiness + installable: true) is replaced by a
+ * single boolean read, which is unambiguous for both classic-resource and
+ * hooks-only plugins.
  *
- * The `installable === true` guard is load-bearing: a soft-degraded
- * (`installable: false`) plugin -- e.g. one whose companion extension is
- * missing -- legally records all four resource arrays empty. Without the
- * guard, the convergence proof
- * (`tests/orchestrators/reconcile/plan-convergence.test.ts`) would
- * misclassify the `soft-degraded` fixture entry in
- * `state-populated-mixed.json` as `pluginsToEnable`, breaking the
- * deferred-convergence no-op proof. The disable orchestrator empties all
- * five arrays (while keeping the version pin -- D-04 / ENBL-02 -- AND
- * preserving the previously-known `installable: true` flag), so the
- * empty-resources + installable-true intersection is the unambiguous
- * "currently disabled" marker. SPLIT-01 preserved -- no new schema field.
- *
- * D-63-04 / COMPONENT_KINDS 5-tuple: the `resources.hooks` axis joined
- * the conjunction once the hook bridge added hooks to the state schema.
- * Omitting it would over-classify a hooks-only installed plugin as
- * "recorded but disabled".
+ * The `installable === true` guard is preserved: a soft-degraded
+ * (`installable: false`) plugin has `enabled: true` in state (it was
+ * never explicitly disabled; the disable orchestrator is the only writer
+ * of `enabled: false`), so `record.compatibility.installable && !record.enabled`
+ * naturally excludes soft-degraded entries.
  */
 export function isRecordedButDisabled(
   record: ExtensionState["marketplaces"][string]["plugins"][string],
 ): boolean {
-  return (
-    record.compatibility.installable &&
-    record.resources.skills.length === 0 &&
-    record.resources.prompts.length === 0 &&
-    record.resources.agents.length === 0 &&
-    record.resources.mcpServers.length === 0 &&
-    record.resources.hooks.length === 0
-  );
+  return record.compatibility.installable && !record.enabled;
 }
 
 /**

--- a/extensions/pi-claude-marketplace/orchestrators/reconcile/plan.ts
+++ b/extensions/pi-claude-marketplace/orchestrators/reconcile/plan.ts
@@ -16,11 +16,11 @@
 // `false` excludes).
 //
 // ENBL-02: the recorded-but-disabled hand-off closes here.
-// `isRecordedButDisabled(record)` reads the empty-resources marker (all
-// four `resources.*` arrays empty -- A1; SPLIT-01 preserved) so a
-// recorded-but-disabled plugin paired with config `enabled !== false`
-// lands in `pluginsToEnable` while the install branch stays mutually
-// exclusive (the recorded-and-not-recorded branches are disjoint).
+// `isRecordedButDisabled(record)` reads the explicit `enabled` field:
+// `record.compatibility.installable && !record.enabled`. An explicit
+// `enabled: false` (set by the disable orchestrator) is the sole
+// "currently disabled" marker; absence of the field after migration
+// is treated as enabled.
 //
 // Plugin-key parser (D-01): flat-keyed plugin entries are parsed by
 // `lastIndexOf("@")` so a plugin name containing `@` (e.g.

--- a/extensions/pi-claude-marketplace/persistence/migrate.ts
+++ b/extensions/pi-claude-marketplace/persistence/migrate.ts
@@ -15,8 +15,14 @@
 // (the hooks arm lands per HOOK-02 / D-57-01; the schema requires
 // `resources.hooks: string[]` and the additive default-fill is what
 // lets v1.0..v1.12 state.json files load cleanly). Per ENBL-02:
-// missing `enabled` is filled with `true` (all existing records were
-// actively installed and therefore enabled by definition).
+// missing `enabled` is filled with `true`. This is a deliberate over-fill:
+// a plugin disabled via `/claude:plugin disable` on a pre-ENBL-02 build
+// persists as `installable: true` + all-empty resources + NO `enabled`
+// field, indistinguishable here from an enabled record, so the fill
+// mislabels it `enabled: true` at the state layer. It self-heals on the
+// next reconcile -- the config still carries `enabled: false`, so the diff
+// emits one redundant disable that re-empties resources and writes
+// `enabled: false`.
 //
 // Per ST-4 "persisted asynchronously (best-effort)": the persist call
 // does NOT re-throw on failure; the IL-3 warn surfaces the cause and
@@ -141,10 +147,14 @@ function ensurePluginResources(mp: Record<string, unknown>): boolean {
  * Mirrors `ensurePluginResources` -- same iteration pattern, same
  * mutated-flag discipline.
  *
- * All existing plugin records (v1.0..v1.13) were actively installed and
- * therefore enabled by definition; `enabled: true` is the correct
- * additive default. The fill MUST run before STATE_VALIDATOR.Check so the
- * newly-required ENBL-02 field is present.
+ * `enabled: true` is the additive default for any record predating the
+ * field. This intentionally over-fills the one legacy shape it cannot
+ * distinguish: a plugin disabled on a pre-ENBL-02 build (`installable: true`
+ * + empty resources + no `enabled` field) is indistinguishable here from an
+ * enabled one, so it too gets `enabled: true`. That mislabel self-heals on
+ * the next reconcile, which reads the still-`enabled: false` config entry
+ * and emits one redundant disable. The fill MUST run before
+ * STATE_VALIDATOR.Check so the newly-required ENBL-02 field is present.
  */
 function ensurePluginEnabled(mp: Record<string, unknown>): boolean {
   const plugins = mp.plugins;
@@ -159,6 +169,9 @@ function ensurePluginEnabled(mp: Record<string, unknown>): boolean {
     }
 
     const pl = plRaw as Record<string, unknown>;
+    // Only an ABSENT field is filled. A present-but-non-boolean value
+    // (e.g. null) is intentionally left untouched for STATE_VALIDATOR.Check
+    // to reject with an actionable error rather than being silently coerced.
     if (pl.enabled === undefined) {
       pl.enabled = true;
       mutated = true;

--- a/extensions/pi-claude-marketplace/persistence/migrate.ts
+++ b/extensions/pi-claude-marketplace/persistence/migrate.ts
@@ -14,8 +14,9 @@
 // resources.mcpServers / resources.hooks are normalized to []
 // (the hooks arm lands per HOOK-02 / D-57-01; the schema requires
 // `resources.hooks: string[]` and the additive default-fill is what
-// lets v1.0..v1.12 state.json files load cleanly without a
-// schemaVersion bump).
+// lets v1.0..v1.12 state.json files load cleanly). Per ENBL-02:
+// missing `enabled` is filled with `true` (all existing records were
+// actively installed and therefore enabled by definition).
 //
 // Per ST-4 "persisted asynchronously (best-effort)": the persist call
 // does NOT re-throw on failure; the IL-3 warn surfaces the cause and
@@ -136,6 +137,38 @@ function ensurePluginResources(mp: Record<string, unknown>): boolean {
 }
 
 /**
+ * ENBL-02: fill `enabled: true` on every plugin record that lacks the field.
+ * Mirrors `ensurePluginResources` -- same iteration pattern, same
+ * mutated-flag discipline.
+ *
+ * All existing plugin records (v1.0..v1.13) were actively installed and
+ * therefore enabled by definition; `enabled: true` is the correct
+ * additive default. The fill MUST run before STATE_VALIDATOR.Check so the
+ * newly-required ENBL-02 field is present.
+ */
+function ensurePluginEnabled(mp: Record<string, unknown>): boolean {
+  const plugins = mp.plugins;
+  if (typeof plugins !== "object" || plugins === null || Array.isArray(plugins)) {
+    return false;
+  }
+
+  let mutated = false;
+  for (const plRaw of Object.values(plugins as Record<string, unknown>)) {
+    if (typeof plRaw !== "object" || plRaw === null || Array.isArray(plRaw)) {
+      continue;
+    }
+
+    const pl = plRaw as Record<string, unknown>;
+    if (pl.enabled === undefined) {
+      pl.enabled = true;
+      mutated = true;
+    }
+  }
+
+  return mutated;
+}
+
+/**
  * Normalize a parsed state.json's `marketplaces` map to the current shape.
  *
  * Pure function -- does NOT touch disk. Caller decides whether to persist
@@ -151,6 +184,8 @@ function ensurePluginResources(mp: Record<string, unknown>): boolean {
  *     D-57-01 -- the schema requires `resources.hooks: string[]` as an
  *     additive REQUIRED field, so the default-fill MUST run before
  *     STATE_VALIDATOR.Check)
+ *   - per-plugin: fill `enabled: true` when the field is absent (ENBL-02
+ *     additive default; same discipline as the hooks arm above)
  *   - `scrubAutoupdate === true` (D-13 gate OPEN): remove the legacy
  *     `autoupdate` field from every marketplace record. The CALLER owns
  *     the gate predicate (loadState probes the scope's
@@ -195,6 +230,7 @@ export function migrateLegacyMarketplaceRecords(
 
     mutated = ensureMarketplacePaths(mpName, mp, extensionRoot) || mutated;
     mutated = ensurePluginResources(mp) || mutated;
+    mutated = ensurePluginEnabled(mp) || mutated;
     if (scrubAutoupdate) {
       mutated = ensureNoLegacyAutoupdate(mp) || mutated;
     }

--- a/extensions/pi-claude-marketplace/persistence/state-io.ts
+++ b/extensions/pi-claude-marketplace/persistence/state-io.ts
@@ -72,6 +72,53 @@ const PLUGIN_INSTALL_RECORD_SCHEMA = Type.Object({
   updatedAt: Type.String(),
 });
 
+/** The permissive stored shape -- any `enabled` + `resources` combination. */
+export type PluginInstallRecord = Type.Static<typeof PLUGIN_INSTALL_RECORD_SCHEMA>;
+
+/**
+ * ENBL-02 two-signal invariant, expressed in the type system.
+ *
+ * The stored record permits any `enabled` + `resources` combination, but
+ * only three are legal: enabled + populated (active), disabled + empty (the
+ * disable terminal state), and enabled + empty (the transient
+ * post-migration / pre-self-heal shape). The fourth -- disabled + populated
+ * -- is the contradiction these branded types forbid: `DisabledPluginRecord`
+ * pins every resources array to the empty tuple `[]`, so a literal carrying a
+ * non-empty array is a compile error. `toDisabledRecord` is the sole
+ * sanctioned producer; the disable orchestrator routes through it (replacing
+ * the record in the map) instead of mutating fields in place, so the branded
+ * type survives to the assignment.
+ */
+export type EnabledPluginRecord = PluginInstallRecord & { enabled: true };
+export type DisabledPluginRecord = PluginInstallRecord & {
+  enabled: false;
+  resources: {
+    skills: [];
+    prompts: [];
+    agents: [];
+    mcpServers: [];
+    hooks: [];
+  };
+};
+
+/**
+ * Build the disabled form of a plugin record: preserve version /
+ * resolvedSource / compatibility / installedAt, reset every resources array
+ * to empty, set `enabled: false`, and stamp `updatedAt`. The empty-tuple
+ * return type makes "disabled but populated" unrepresentable at the call site.
+ */
+export function toDisabledRecord(
+  record: PluginInstallRecord,
+  updatedAt: string,
+): DisabledPluginRecord {
+  return {
+    ...record,
+    resources: { skills: [], prompts: [], agents: [], mcpServers: [], hooks: [] },
+    enabled: false,
+    updatedAt,
+  };
+}
+
 /**
  * ST-2: per-marketplace record. `source` is `Type.Unknown()` so the schema
  * accepts whatever shape ST-6 funnel produced (PathSource | GitHubSource);

--- a/extensions/pi-claude-marketplace/persistence/state-io.ts
+++ b/extensions/pi-claude-marketplace/persistence/state-io.ts
@@ -44,7 +44,12 @@ import { migrateLegacyMarketplaceRecords, persistMigratedState } from "./migrate
  * discipline -- state.json never holds absolute paths). The migration is
  * additive: `ensurePluginResources` in persistence/migrate.ts fills
  * `hooks: []` before validation runs, so v1.0..v1.12 state.json files
- * load cleanly without a STATE_SCHEMA.schemaVersion bump (D-57-01).
+ * load cleanly.
+ *
+ * ENBL-02: `enabled: boolean` is REQUIRED (schemaVersion 2+). The migration
+ * fills `enabled: true` for all existing records via `ensurePluginEnabled`
+ * before validation runs, so v1.0..v1.13 state.json files load cleanly.
+ * `enabled: false` is the sole disable marker; `true` means active.
  */
 const PLUGIN_INSTALL_RECORD_SCHEMA = Type.Object({
   version: Type.String(),
@@ -62,6 +67,7 @@ const PLUGIN_INSTALL_RECORD_SCHEMA = Type.Object({
     mcpServers: Type.Array(Type.String()),
     hooks: Type.Array(Type.String()),
   }),
+  enabled: Type.Boolean(),
   installedAt: Type.String(),
   updatedAt: Type.String(),
 });
@@ -91,9 +97,14 @@ const MARKETPLACE_RECORD_SCHEMA = Type.Object({
   plugins: Type.Record(Type.String(), PLUGIN_INSTALL_RECORD_SCHEMA),
 });
 
-/** ST-1: state.json shape (schemaVersion locked at 1). */
+/**
+ * ST-1: state.json shape. schemaVersion 1 is the pre-ENBL-02 shape (no
+ * `enabled` field on plugin records); schemaVersion 2 is the ENBL-02 shape
+ * (`enabled: boolean` required). The union lets loadState accept both during
+ * the migration cycle; `persistMigratedState` always writes schemaVersion 2.
+ */
 export const STATE_SCHEMA = Type.Object({
-  schemaVersion: Type.Literal(1),
+  schemaVersion: Type.Union([Type.Literal(1), Type.Literal(2)]),
   marketplaces: Type.Record(Type.String(), MARKETPLACE_RECORD_SCHEMA),
 });
 
@@ -104,7 +115,7 @@ export const STATE_VALIDATOR = Compile(STATE_SCHEMA);
 
 /** First-load default (ENOENT and empty treated identically). */
 export const DEFAULT_STATE: ExtensionState = Object.freeze({
-  schemaVersion: 1,
+  schemaVersion: 2,
   marketplaces: {},
 });
 
@@ -175,7 +186,7 @@ export async function loadState(extensionRoot: string): Promise<ExtensionState> 
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") {
       // Missing file -> default state (NOT throw).
-      return { schemaVersion: 1, marketplaces: {} };
+      return { schemaVersion: 2, marketplaces: {} };
     }
 
     throw new Error(`Failed to read ${stateJsonPath}: ${errorMessage(err)}`, { cause: err });
@@ -229,7 +240,7 @@ export async function loadState(extensionRoot: string): Promise<ExtensionState> 
     normalizeStoredSource(mpName, mp);
   }
 
-  const normalized: unknown = { schemaVersion: 1, marketplaces };
+  const normalized: unknown = { schemaVersion: 2, marketplaces };
 
   if (!STATE_VALIDATOR.Check(normalized)) {
     throw new Error(

--- a/package-lock.json
+++ b/package-lock.json
@@ -695,6 +695,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -712,6 +715,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -729,6 +735,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -746,6 +755,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -763,6 +775,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-claude-marketplace",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-claude-marketplace",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "isomorphic-git": "^1.38.1",

--- a/package.json
+++ b/package.json
@@ -84,5 +84,5 @@
     "typecheck": "tsc --noEmit"
   },
   "type": "module",
-  "version": "0.6.0"
+  "version": "0.6.1"
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,7 +4,7 @@ sonar.organization=acolomba
 
 # Project metadata.
 sonar.projectName=Pi Claude Marketplace
-sonar.projectVersion=0.6.0
+sonar.projectVersion=0.6.1
 
 # Source code settings.
 sonar.sources=extensions/pi-claude-marketplace

--- a/tests/architecture/hooks-async-rewake.test.ts
+++ b/tests/architecture/hooks-async-rewake.test.ts
@@ -503,6 +503,34 @@ describe("spawn-and-register", () => {
       await tmp.cleanup();
     }
   });
+
+  test("onChildError removes the registered entry and persists the pid table", async () => {
+    const tmp = await makeTempLocations();
+    try {
+      const spy = installSpawnSpy();
+      _setDispatchIdGeneratorForTest(() => "fixed-uuid-onerror");
+      const ctx = makeMockCtx("/tmp/proj");
+      const pi = makeMockPi();
+      await spawnAndRegister(
+        makeEntry({}),
+        { toolName: "bash", input: {} },
+        ctx.ctx,
+        pi.pi,
+        tmp.loc,
+      );
+      const reg = _getRegistryForTest();
+      assert.equal(reg.has("fixed-uuid-onerror"), true);
+      // A spawn-level failure (e.g. ENOENT) surfaces as a child "error" event,
+      // routed to onChildError out-of-band: it cancels the ladder, drops the
+      // entry, and persists the shrunken pid table.
+      spy.children[0]?.emitError(new Error("spawn failed"));
+      await new Promise((r) => setImmediate(r));
+      assert.equal(reg.has("fixed-uuid-onerror"), false);
+      await _awaitLastPidTablePersistForTest();
+    } finally {
+      await tmp.cleanup();
+    }
+  });
 });
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/tests/architecture/hooks-async-rewake.test.ts
+++ b/tests/architecture/hooks-async-rewake.test.ts
@@ -42,6 +42,7 @@ import {
   type PidTableEntry,
 } from "../../extensions/pi-claude-marketplace/bridges/hooks/async-rewake/pid-table.ts";
 import {
+  _awaitLastPidTablePersistForTest,
   _getRegistryForTest,
   _resetDispatchIdGeneratorForTest,
   _resetOrphanProbesForTest,
@@ -344,6 +345,11 @@ async function makeTempLocations(): Promise<{
   return {
     loc,
     cleanup: async () => {
+      // Drain any in-flight pid-table atomic write before removing the
+      // temp directory.  write-file-atomic holds a temp file open in
+      // _shared/ until the rename+fsync completes; removing the directory
+      // concurrently produces ENOTEMPTY on macOS.
+      await _awaitLastPidTablePersistForTest();
       if (prev === undefined) {
         delete process.env.PI_CODING_AGENT_DIR;
       } else {

--- a/tests/architecture/hooks-exec.test.ts
+++ b/tests/architecture/hooks-exec.test.ts
@@ -610,6 +610,22 @@ test("Block F / D-60-06: registerHooksBridge twice does not throw (idempotent)",
   await assert.doesNotReject(() => registerHooksBridge(pi, { ctx: makeCtx(cwd), cwd }));
 });
 
+test("registerHooksBridge tolerates a corrupt project-scope state.json (hydrate falls back to default state)", async (t) => {
+  _resetForTest();
+  const { cwd } = await relocateAgent(t);
+
+  // Invalid JSON makes loadState throw (non-ENOENT) during factory-time
+  // hydrate. The per-scope catch must swallow it and fall back to
+  // DEFAULT_STATE so a corrupt state file in one scope does not block the
+  // bridge from booting.
+  const extRoot = path.join(cwd, ".pi", "pi-claude-marketplace");
+  await mkdir(extRoot, { recursive: true });
+  await writeFile(path.join(extRoot, "state.json"), "{ not valid json");
+
+  const { pi } = makePiMock();
+  await assert.doesNotReject(() => registerHooksBridge(pi, { ctx: makeCtx(cwd), cwd }));
+});
+
 test("Block F / D-60-06: SessionStart CLAUDE_ENV_FILE matches /data/_shared/claude-env-<sid>.env scheme", async (t) => {
   await relocateAgent(t);
   const spy = installSpawnSpy(t, (h) => {

--- a/tests/architecture/hooks-foundation.test.ts
+++ b/tests/architecture/hooks-foundation.test.ts
@@ -32,27 +32,27 @@ import { STATE_SCHEMA } from "../../extensions/pi-claude-marketplace/persistence
 import type { PluginEntry } from "../../extensions/pi-claude-marketplace/domain/components/plugin.ts";
 
 // ──────────────────────────────────────────────────────────────────────────
-// Block 1: D-57-01 -- STATE_SCHEMA.schemaVersion stays Literal(1) (no bump)
+// Block 1: ENBL-02 -- STATE_SCHEMA.schemaVersion is Union(Literal(1), Literal(2))
 // ──────────────────────────────────────────────────────────────────────────
 
-test("D-57-01: STATE_SCHEMA.schemaVersion is Type.Literal(1) (NOT a union of literals)", () => {
+test("ENBL-02: STATE_SCHEMA.schemaVersion is Type.Union([Literal(1), Literal(2)])", () => {
   const versionSchema = STATE_SCHEMA.properties.schemaVersion as unknown as Record<string, unknown>;
 
-  // Type.Literal(1) compiles to { type: "number", const: 1 }. A future
-  // `Type.Union([Type.Literal(1), Type.Literal(2)])` would compile to
-  // { anyOf: [...] } -- both `const` and `enum` absent, `anyOf` present.
-  // Asserting `const === 1` AND `anyOf === undefined` AND `enum === undefined`
-  // pins the no-bump amendment.
-  assert.equal(versionSchema.const, 1, "schemaVersion must be Type.Literal(1)");
-  assert.equal(
-    versionSchema.anyOf,
-    undefined,
-    "schemaVersion must NOT be a union -- D-57-01 forbids widening",
+  // Type.Union([Type.Literal(1), Type.Literal(2)]) compiles to
+  // { anyOf: [{ const: 1 }, { const: 2 }] }.
+  // Asserting the anyOf structure pins the ENBL-02 migration contract:
+  // both v1 (pre-enabled) and v2 (enabled) on-disk formats are accepted,
+  // and any future widening to v3 requires this test to be updated.
+  assert.ok(Array.isArray(versionSchema.anyOf), "schemaVersion must be a union (anyOf present)");
+  const anyOf = versionSchema.anyOf as Array<Record<string, unknown>>;
+  assert.equal(anyOf.length, 2, "schemaVersion union must have exactly two members (1 and 2)");
+  assert.ok(
+    anyOf.some((m) => m.const === 1),
+    "schemaVersion union must include Literal(1)",
   );
-  assert.equal(
-    versionSchema.enum,
-    undefined,
-    "schemaVersion must NOT be an enum -- D-57-01 forbids widening",
+  assert.ok(
+    anyOf.some((m) => m.const === 2),
+    "schemaVersion union must include Literal(2)",
   );
 });
 

--- a/tests/edge/handlers/tools.test.ts
+++ b/tests/edge/handlers/tools.test.ts
@@ -137,6 +137,7 @@ async function seedMarketplace(opts: {
         mcpServers: string[];
         hooks: string[];
       };
+      enabled: boolean;
       installedAt: string;
       updatedAt: string;
     }
@@ -146,9 +147,6 @@ async function seedMarketplace(opts: {
       version: p.version,
       resolvedSource: path.join(mpRoot, "plugins", p.name),
       compatibility: { installable: true, notes: [], supported: [], unsupported: [] },
-      // ENBL-04: empty resources + installable:true IS the disabled marker;
-      // seed a populated skills array so the record reads as ENABLED (a
-      // production installed record always has >= 1 populated array).
       resources: {
         skills: [`${p.name}-skill`],
         prompts: [],
@@ -156,13 +154,14 @@ async function seedMarketplace(opts: {
         mcpServers: [],
         hooks: [],
       },
+      enabled: true,
       installedAt: nowIso,
       updatedAt: nowIso,
     };
   }
 
   await saveState(locations.extensionRoot, {
-    schemaVersion: 1,
+    schemaVersion: 2,
     marketplaces: {
       [opts.name]: {
         name: opts.name,
@@ -627,7 +626,7 @@ test("pi_claude_marketplace_plugin_list :: installed:true filter skips unavailab
     const locations = locationsFor("project", cwd);
     await mkdir(locations.extensionRoot, { recursive: true });
     await saveState(locations.extensionRoot, {
-      schemaVersion: 1,
+      schemaVersion: 2,
       marketplaces: {
         "filter-mkt": {
           name: "filter-mkt",
@@ -641,8 +640,6 @@ test("pi_claude_marketplace_plugin_list :: installed:true filter skips unavailab
               version: "1.0.0",
               resolvedSource: path.join(mpRoot, "plugins", "pinstalled"),
               compatibility: { installable: true, notes: [], supported: [], unsupported: [] },
-              // Populated resources: an ENABLED installed record (empty
-              // resources + installable:true reads as disabled per ENBL-04).
               resources: {
                 skills: ["pinstalled-skill"],
                 prompts: [],
@@ -650,6 +647,7 @@ test("pi_claude_marketplace_plugin_list :: installed:true filter skips unavailab
                 mcpServers: [],
                 hooks: [],
               },
+              enabled: true,
               installedAt: nowIso,
               updatedAt: nowIso,
             },

--- a/tests/integration/hooks-additionalcontext-end-to-end.test.ts
+++ b/tests/integration/hooks-additionalcontext-end-to-end.test.ts
@@ -89,7 +89,7 @@ async function withHermeticPiHome<T>(
 
 function buildStateWithHooksPlugin(sourcesPluginRoot: string): ExtensionState {
   return {
-    schemaVersion: 1,
+    schemaVersion: 2,
     marketplaces: {
       "test-mp": {
         name: "test-mp",
@@ -115,6 +115,7 @@ function buildStateWithHooksPlugin(sourcesPluginRoot: string): ExtensionState {
               mcpServers: [],
               hooks: ["test-plugin"],
             },
+            enabled: true,
             installedAt: "2026-06-17T00:00:00Z",
             updatedAt: "2026-06-17T00:00:00Z",
           },

--- a/tests/integration/hooks-cross-scope-reconcile.test.ts
+++ b/tests/integration/hooks-cross-scope-reconcile.test.ts
@@ -47,7 +47,7 @@ function buildStateWithSingleHooksPlugin(opts: {
   marketplaceRoot: string;
 }): ExtensionState {
   return {
-    schemaVersion: 1,
+    schemaVersion: 2,
     marketplaces: {
       [opts.marketplace]: {
         name: opts.marketplace,
@@ -73,6 +73,7 @@ function buildStateWithSingleHooksPlugin(opts: {
               mcpServers: [],
               hooks: [opts.plugin],
             },
+            enabled: true,
             installedAt: "2026-06-17T00:00:00Z",
             updatedAt: "2026-06-17T00:00:00Z",
           },

--- a/tests/integration/hooks-dispatch-end-to-end.test.ts
+++ b/tests/integration/hooks-dispatch-end-to-end.test.ts
@@ -61,7 +61,7 @@ function makeMockPi(): { pi: ExtensionAPI; registrations: CapturedRegistration[]
 
 function buildUserScopeStateWithHooksPlugin(): ExtensionState {
   return {
-    schemaVersion: 1,
+    schemaVersion: 2,
     marketplaces: {
       "claude-plugins-official": {
         name: "claude-plugins-official",
@@ -87,6 +87,7 @@ function buildUserScopeStateWithHooksPlugin(): ExtensionState {
               mcpServers: [],
               hooks: ["learning-output-style"],
             },
+            enabled: true,
             installedAt: "2026-06-17T00:00:00Z",
             updatedAt: "2026-06-17T00:00:00Z",
           },

--- a/tests/integration/hooks-spawn-end-to-end.test.ts
+++ b/tests/integration/hooks-spawn-end-to-end.test.ts
@@ -85,7 +85,7 @@ async function withHermeticPiHome<T>(
 
 function buildStateWithHooksPlugin(sourcesPluginRoot: string): ExtensionState {
   return {
-    schemaVersion: 1,
+    schemaVersion: 2,
     marketplaces: {
       "test-mp": {
         name: "test-mp",
@@ -111,6 +111,7 @@ function buildStateWithHooksPlugin(sourcesPluginRoot: string): ExtensionState {
               mcpServers: [],
               hooks: ["test-plugin"],
             },
+            enabled: true,
             installedAt: "2026-06-17T00:00:00Z",
             updatedAt: "2026-06-17T00:00:00Z",
           },
@@ -259,7 +260,7 @@ echo '{}'
 
     // Seed state.json: resolvedSource points OUTSIDE extensionRoot.
     const externalState: ExtensionState = {
-      schemaVersion: 1,
+      schemaVersion: 2,
       marketplaces: {
         "external-mp": {
           name: "external-mp",
@@ -285,6 +286,7 @@ echo '{}'
                 mcpServers: [],
                 hooks: ["ext-plugin"],
               },
+              enabled: true,
               installedAt: "2026-06-17T00:00:00Z",
               updatedAt: "2026-06-17T00:00:00Z",
             },

--- a/tests/orchestrators/edge-deps.test.ts
+++ b/tests/orchestrators/edge-deps.test.ts
@@ -84,7 +84,7 @@ test("makeLocationsResolver: loadStateForScope projects state.json into marketpl
     await mkdir(projectLoc.extensionRoot, { recursive: true });
 
     const state: ExtensionState = {
-      schemaVersion: 1,
+      schemaVersion: 2,
       marketplaces: {
         "test-mp": {
           name: "test-mp",
@@ -99,6 +99,7 @@ test("makeLocationsResolver: loadStateForScope projects state.json into marketpl
               resolvedSource: "/tmp/test-src/plugins/p1",
               compatibility: { installable: true, notes: [], supported: [], unsupported: [] },
               resources: { skills: [], prompts: [], agents: [], mcpServers: [], hooks: [] },
+              enabled: true,
               installedAt: "2026-06-17T00:00:00Z",
               updatedAt: "2026-06-17T00:00:00Z",
             },
@@ -176,7 +177,7 @@ test("makeLocationsResolver: loadManifestForMarketplace returns installed + avai
     const projectLoc = locationsFor("project", cwd);
     await mkdir(projectLoc.extensionRoot, { recursive: true });
     const state: ExtensionState = {
-      schemaVersion: 1,
+      schemaVersion: 2,
       marketplaces: {
         "fixture-mp": {
           name: "fixture-mp",
@@ -191,6 +192,7 @@ test("makeLocationsResolver: loadManifestForMarketplace returns installed + avai
               resolvedSource: path.join(srcRoot, "plugins", "installed-plug"),
               compatibility: { installable: true, notes: [], supported: [], unsupported: [] },
               resources: { skills: [], prompts: [], agents: [], mcpServers: [], hooks: [] },
+              enabled: true,
               installedAt: "2026-06-17T00:00:00Z",
               updatedAt: "2026-06-17T00:00:00Z",
             },

--- a/tests/orchestrators/import/execute.test.ts
+++ b/tests/orchestrators/import/execute.test.ts
@@ -80,7 +80,7 @@ test("importClaudeSettings skips matching existing marketplaces and already-inst
         diagnostics: [],
       }),
       loadState: async () => ({
-        schemaVersion: 1,
+        schemaVersion: 2,
         marketplaces: {
           mp: {
             name: "mp",
@@ -95,6 +95,7 @@ test("importClaudeSettings skips matching existing marketplaces and already-inst
                 resolvedSource: "/tmp/mp/plugins/plugin",
                 compatibility: { installable: true, notes: [], supported: [], unsupported: [] },
                 resources: { skills: [], prompts: [], agents: [], mcpServers: [], hooks: [] },
+                enabled: true,
                 installedAt: "2026-01-01T00:00:00.000Z",
                 updatedAt: "2026-01-01T00:00:00.000Z",
               },
@@ -257,7 +258,7 @@ test("importClaudeSettings skips when github source matches owner and repo", asy
         diagnostics: [],
       }),
       loadState: async () => ({
-        schemaVersion: 1,
+        schemaVersion: 2,
         marketplaces: {
           mp: {
             name: "mp",
@@ -278,6 +279,7 @@ test("importClaudeSettings skips when github source matches owner and repo", asy
                 resolvedSource: "/tmp/mp/plugins/plugin",
                 compatibility: { installable: true, notes: [], supported: [], unsupported: [] },
                 resources: { skills: [], prompts: [], agents: [], mcpServers: [], hooks: [] },
+                enabled: true,
                 installedAt: "2026-01-01T00:00:00.000Z",
                 updatedAt: "2026-01-01T00:00:00.000Z",
               },

--- a/tests/orchestrators/marketplace/autoupdate.test.ts
+++ b/tests/orchestrators/marketplace/autoupdate.test.ts
@@ -667,17 +667,17 @@ test("CFG-03 / T-56-02-05: invalid local config aborts the flip; basename-only m
 // D-UPD: autoupdate flag-flip must leave a DISABLED plugin record alone.
 // `setMarketplaceAutoupdate` flips a config flag; it does NOT update plugins.
 // This test pins that the flip never accidentally re-materializes a
-// disabled-but-recorded plugin's resources (the canonical
-// isRecordedButDisabled marker: empty resources.* + installable=true).
+// disabled-but-recorded plugin's resources (ENBL-02 marker: enabled=false +
+// installable=true).
 // ──────────────────────────────────────────────────────────────────────────
 
 test("D-UPD: setMarketplaceAutoupdate leaves a disabled plugin record untouched (state-side resources stay empty)", async () => {
   await withHermeticHome(async ({ cwd }) => {
     const locations = locationsFor("project", cwd);
     await mkdir(locations.extensionRoot, { recursive: true });
-    // Seed a marketplace with a disabled plugin row: empty resources.* +
-    // installable:true. The autoupdate flag-flip is a config-only mutation;
-    // it must never re-materialize.
+    // Seed a marketplace with a disabled plugin row: enabled:false +
+    // installable:true (ENBL-02). The autoupdate flag-flip is a config-only
+    // mutation; it must never re-materialize.
     const seededMp = makeMarketplaceRecord("mp", "project", cwd, false);
     (seededMp as { plugins: Record<string, unknown> }).plugins = {
       foo: {
@@ -690,7 +690,7 @@ test("D-UPD: setMarketplaceAutoupdate leaves a disabled plugin record untouched 
           unsupported: [],
         },
         resources: { skills: [], prompts: [], agents: [], mcpServers: [], hooks: [] },
-        enabled: true,
+        enabled: false,
         installedAt: "2026-01-01T00:00:00.000Z",
         updatedAt: "2026-01-01T00:00:00.000Z",
       },

--- a/tests/orchestrators/marketplace/autoupdate.test.ts
+++ b/tests/orchestrators/marketplace/autoupdate.test.ts
@@ -690,12 +690,13 @@ test("D-UPD: setMarketplaceAutoupdate leaves a disabled plugin record untouched 
           unsupported: [],
         },
         resources: { skills: [], prompts: [], agents: [], mcpServers: [], hooks: [] },
+        enabled: true,
         installedAt: "2026-01-01T00:00:00.000Z",
         updatedAt: "2026-01-01T00:00:00.000Z",
       },
     };
     await saveState(locations.extensionRoot, {
-      schemaVersion: 1,
+      schemaVersion: 2,
       marketplaces: { mp: seededMp },
     });
 

--- a/tests/orchestrators/marketplace/cascade.test.ts
+++ b/tests/orchestrators/marketplace/cascade.test.ts
@@ -30,6 +30,7 @@ function makePluginRecord(
       mcpServers: over.resources?.mcpServers ?? [],
       hooks: over.resources?.hooks ?? [],
     },
+    enabled: over.enabled ?? true,
     installedAt: over.installedAt ?? "2026-01-01T00:00:00.000Z",
     updatedAt: over.updatedAt ?? "2026-01-01T00:00:00.000Z",
   };

--- a/tests/orchestrators/marketplace/remove.test.ts
+++ b/tests/orchestrators/marketplace/remove.test.ts
@@ -67,6 +67,7 @@ function makePluginRecord(resources: Partial<PluginRecord["resources"]> = {}): P
       mcpServers: resources.mcpServers ?? [],
       hooks: resources.hooks ?? [],
     },
+    enabled: true,
     installedAt: "2026-01-01T00:00:00.000Z",
     updatedAt: "2026-01-01T00:00:00.000Z",
   };

--- a/tests/orchestrators/marketplace/update.test.ts
+++ b/tests/orchestrators/marketplace/update.test.ts
@@ -148,6 +148,7 @@ function makePluginRecord(): ExtensionState["marketplaces"][string]["plugins"][s
     resolvedSource: "/tmp",
     compatibility: { installable: true, notes: [], supported: [], unsupported: [] },
     resources: { skills: [], prompts: [], agents: [], mcpServers: [], hooks: [] },
+    enabled: true,
     installedAt: "2026-01-01T00:00:00.000Z",
     updatedAt: "2026-01-01T00:00:00.000Z",
   };

--- a/tests/orchestrators/plugin/enable-disable.test.ts
+++ b/tests/orchestrators/plugin/enable-disable.test.ts
@@ -341,6 +341,7 @@ test("ENBL-02: disable preserves version pin and empties resources arrays", asyn
               };
               compatibility: { installable: boolean };
               installedAt: string;
+              enabled: boolean;
             }
           >;
         }
@@ -354,6 +355,10 @@ test("ENBL-02: disable preserves version pin and empties resources arrays", asyn
     assert.deepEqual(rec.resources.prompts, [], "resources.prompts emptied");
     assert.deepEqual(rec.resources.agents, [], "resources.agents emptied");
     assert.deepEqual(rec.resources.mcpServers, [], "resources.mcpServers emptied");
+    // ENBL-02: the explicit disabled marker must be written -- without this
+    // assertion, a regression dropping `enabled = false` in runDisableBranch
+    // would pass while isRecordedButDisabled silently breaks.
+    assert.equal(rec.enabled, false, "enabled field must be false after disable");
   });
 });
 

--- a/tests/orchestrators/plugin/enable-disable.test.ts
+++ b/tests/orchestrators/plugin/enable-disable.test.ts
@@ -103,7 +103,7 @@ async function writeUserState(
   }
 
   const state = {
-    schemaVersion: 1,
+    schemaVersion: 2,
     marketplaces: {
       [opts.marketplaceName]: {
         name: opts.marketplaceName,
@@ -111,7 +111,7 @@ async function writeUserState(
         source: {
           kind: "path" as const,
           raw: "/tmp/dummy-mp",
-          absPath: "/tmp/dummy-mp",
+          logical: "/tmp/dummy-mp",
         },
         addedFromCwd: "/tmp",
         marketplaceRoot: "/tmp/dummy-mp",
@@ -127,6 +127,7 @@ async function writeUserState(
               unsupported: [],
             },
             resources,
+            enabled: !opts.disabled,
             installedAt: "2026-01-01T00:00:00.000Z",
             updatedAt: "2026-01-01T00:00:00.000Z",
           },
@@ -186,16 +187,16 @@ async function seedRealDisabledMarketplace(
     }),
   );
 
-  // State: the KEPT disabled record (ENBL-02) -- empty resources +
-  // installable: true + the pinned version.
+  // State: the KEPT disabled record -- empty resources + installable: true +
+  // the pinned version + explicit enabled: false.
   const statePath = path.join(extRoot, "state.json");
   const state = {
-    schemaVersion: 1,
+    schemaVersion: 2,
     marketplaces: {
       [opts.marketplaceName]: {
         name: opts.marketplaceName,
         scope: "user",
-        source: { kind: "path" as const, raw: mpRoot, absPath: mpRoot },
+        source: { kind: "path" as const, raw: mpRoot, logical: mpRoot },
         addedFromCwd: home,
         marketplaceRoot: mpRoot,
         manifestPath,
@@ -205,6 +206,7 @@ async function seedRealDisabledMarketplace(
             resolvedSource: pluginRoot,
             compatibility: { installable: true, notes: [], supported: [], unsupported: [] },
             resources: { skills: [], prompts: [], agents: [], mcpServers: [], hooks: [] },
+            enabled: false,
             installedAt: "2026-01-01T00:00:00.000Z",
             updatedAt: "2026-01-01T00:00:00.000Z",
           },

--- a/tests/orchestrators/plugin/info.test.ts
+++ b/tests/orchestrators/plugin/info.test.ts
@@ -155,12 +155,11 @@ async function seedPathMarketplace(opts: SeedPathMarketplaceOpts): Promise<strin
       version: info.version,
       resolvedSource: "./placeholder",
       compatibility: { installable: true, notes: [], supported: [], unsupported: [] },
-      // ENBL-04: empty resources + installable:true IS the disabled marker;
-      // an enabled installed record always has >= 1 populated array.
       resources:
         info.disabled === true
           ? { skills: [], prompts: [], agents: [], mcpServers: [], hooks: [] }
           : { skills: [`${name}-skill`], prompts: [], agents: [], mcpServers: [], hooks: [] },
+      enabled: info.disabled !== true,
       installedAt: "2026-01-01T00:00:00.000Z",
       updatedAt: "2026-01-01T00:00:00.000Z",
     };
@@ -189,7 +188,7 @@ async function seedPathMarketplace(opts: SeedPathMarketplaceOpts): Promise<strin
   }
 
   await saveState(locations.extensionRoot, {
-    schemaVersion: 1,
+    schemaVersion: 2,
     marketplaces: { ...existing.marketplaces, [mpName]: record },
   } as unknown as Parameters<typeof saveState>[1]);
 
@@ -816,7 +815,7 @@ test("WR-03: marketplace.json missing on disk surfaces `{source missing}` failur
     await mkdir(path.dirname(manifestPath), { recursive: true });
 
     await saveState(locations.extensionRoot, {
-      schemaVersion: 1,
+      schemaVersion: 2,
       marketplaces: {
         mp: {
           name: "mp",
@@ -1164,7 +1163,7 @@ test("NFR-5 end-to-end: github-source marketplace record resolves plugin info fr
     await mkdir(path.join(mpRoot, "local-plug", "skills", "s1"), { recursive: true });
 
     await saveState(locations.extensionRoot, {
-      schemaVersion: 1,
+      schemaVersion: 2,
       marketplaces: {
         "gh-mp": {
           name: "gh-mp",
@@ -1188,6 +1187,7 @@ test("NFR-5 end-to-end: github-source marketplace record resolves plugin info fr
                 mcpServers: [],
                 hooks: [],
               },
+              enabled: true,
               installedAt: "2026-01-01T00:00:00.000Z",
               updatedAt: "2026-01-01T00:00:00.000Z",
             },

--- a/tests/orchestrators/plugin/install.test.ts
+++ b/tests/orchestrators/plugin/install.test.ts
@@ -257,7 +257,7 @@ async function seedPathMarketplaceWithPlugin(opts: {
   await mkdir(locations.extensionRoot, { recursive: true });
 
   const state: ExtensionState = {
-    schemaVersion: 1,
+    schemaVersion: 2,
     marketplaces: {
       [marketplaceName]: {
         name: marketplaceName,
@@ -279,6 +279,7 @@ async function seedPathMarketplaceWithPlugin(opts: {
                     unsupported: [],
                   },
                   resources: { skills: [], prompts: [], agents: [], mcpServers: [], hooks: [] },
+                  enabled: true,
                   installedAt: "2026-01-01T00:00:00.000Z",
                   updatedAt: "2026-01-01T00:00:00.000Z",
                 },
@@ -314,6 +315,7 @@ async function seedPathMarketplaceWithPlugin(opts: {
             mcpServers: [],
             hooks: [],
           },
+          enabled: true,
           installedAt: "2026-01-01T00:00:00.000Z",
           updatedAt: "2026-01-01T00:00:00.000Z",
         },

--- a/tests/orchestrators/plugin/list.test.ts
+++ b/tests/orchestrators/plugin/list.test.ts
@@ -190,7 +190,7 @@ async function seedMarketplace(opts: SeedMarketplaceOpts): Promise<void> {
       resolvedSource: "./placeholder",
       compatibility: { installable: true, notes: [], supported: [], unsupported: [] },
       resources,
-      enabled: true,
+      enabled: info.disabled !== true,
       installedAt: "2026-01-01T00:00:00.000Z",
       updatedAt: "2026-01-01T00:00:00.000Z",
     };

--- a/tests/orchestrators/plugin/list.test.ts
+++ b/tests/orchestrators/plugin/list.test.ts
@@ -190,6 +190,7 @@ async function seedMarketplace(opts: SeedMarketplaceOpts): Promise<void> {
       resolvedSource: "./placeholder",
       compatibility: { installable: true, notes: [], supported: [], unsupported: [] },
       resources,
+      enabled: true,
       installedAt: "2026-01-01T00:00:00.000Z",
       updatedAt: "2026-01-01T00:00:00.000Z",
     };
@@ -209,7 +210,7 @@ async function seedMarketplace(opts: SeedMarketplaceOpts): Promise<void> {
   }
 
   await saveState(locations.extensionRoot, {
-    schemaVersion: 1,
+    schemaVersion: 2,
     marketplaces: { ...existing.marketplaces, [mpName]: record },
     // saveState validates -- the merged shape must satisfy STATE_SCHEMA.
   } as unknown as Parameters<typeof saveState>[1]);
@@ -666,7 +667,7 @@ test("CR-01 / G-21-01: project-scope plugin under a CLONED user marketplace fold
     const projectLocations = locationsFor("project", cwd);
     await mkdir(projectLocations.extensionRoot, { recursive: true });
     await saveState(projectLocations.extensionRoot, {
-      schemaVersion: 1,
+      schemaVersion: 2,
       marketplaces: {
         mp1: {
           name: "mp1",
@@ -691,6 +692,7 @@ test("CR-01 / G-21-01: project-scope plugin under a CLONED user marketplace fold
                 mcpServers: [],
                 hooks: [],
               },
+              enabled: true,
               installedAt: "2026-01-01T00:00:00.000Z",
               updatedAt: "2026-01-01T00:00:00.000Z",
             },

--- a/tests/orchestrators/plugin/shared.test.ts
+++ b/tests/orchestrators/plugin/shared.test.ts
@@ -32,7 +32,10 @@ type MarketplaceRecord = ExtensionState["marketplaces"][string];
  * the surrounding fields so the fixture matches what `saveState` would
  * accept -- prevents accidental schema-drift fixtures.
  */
-function makePluginRecord(over: { resources?: Partial<PluginRecord["resources"]> }): PluginRecord {
+function makePluginRecord(over: {
+  resources?: Partial<PluginRecord["resources"]>;
+  enabled?: boolean;
+}): PluginRecord {
   return {
     version: "0.0.1",
     resolvedSource: "/tmp",
@@ -49,6 +52,7 @@ function makePluginRecord(over: { resources?: Partial<PluginRecord["resources"]>
       mcpServers: over.resources?.mcpServers ?? [],
       hooks: over.resources?.hooks ?? [],
     },
+    enabled: over.enabled ?? true,
     installedAt: "2026-01-01T00:00:00.000Z",
     updatedAt: "2026-01-01T00:00:00.000Z",
   };

--- a/tests/orchestrators/plugin/uninstall.test.ts
+++ b/tests/orchestrators/plugin/uninstall.test.ts
@@ -100,6 +100,7 @@ function makePluginRecord(resources: Partial<PluginRecord["resources"]> = {}): P
       mcpServers: resources.mcpServers ?? [],
       hooks: resources.hooks ?? [],
     },
+    enabled: true,
     installedAt: "2026-01-01T00:00:00.000Z",
     updatedAt: "2026-01-01T00:00:00.000Z",
   };

--- a/tests/orchestrators/plugin/update.test.ts
+++ b/tests/orchestrators/plugin/update.test.ts
@@ -123,7 +123,14 @@ function makePluginRecord(
  * disabled (artefacts re-materialize on the next `enable`).
  */
 function makeDisabledPluginRecord(version: string): PluginRecord {
-  return makePluginRecord(version, { enabled: false });
+  return makePluginRecord(version, {
+    enabled: false,
+    skills: [],
+    prompts: [],
+    agents: [],
+    mcpServers: [],
+    hooks: [],
+  });
 }
 
 interface SeededPathMp {

--- a/tests/orchestrators/plugin/update.test.ts
+++ b/tests/orchestrators/plugin/update.test.ts
@@ -94,18 +94,15 @@ type PluginRecord = ExtensionState["marketplaces"][string]["plugins"][string];
 
 function makePluginRecord(
   version: string,
-  resources: Partial<PluginRecord["resources"]> = {},
+  overrides: Partial<PluginRecord["resources"]> & { enabled?: boolean } = {},
 ): PluginRecord {
+  const { enabled = true, ...resources } = overrides;
   return {
     version,
     resolvedSource: "/tmp",
     compatibility: { installable: true, notes: [], supported: [], unsupported: [] },
-    // D-UPD: a record with empty resources.* + installable=true is the
-    // disabled-but-recorded marker (the same intersection
-    // `isRecordedButDisabled` reads in plan.ts). Default to a populated
-    // skill so the update flow exercises the enabled-update path, not
-    // the disabled-record short-circuit. Tests that need a disabled
-    // record pass `resources.skills: []` explicitly.
+    // Default to a populated skill so the update flow exercises the
+    // enabled-update path, not the disabled-record short-circuit (ENBL-02).
     resources: {
       skills: resources.skills ?? ["seeded-skill"],
       prompts: resources.prompts ?? [],
@@ -113,25 +110,20 @@ function makePluginRecord(
       mcpServers: resources.mcpServers ?? [],
       hooks: resources.hooks ?? [],
     },
-    enabled: true,
+    enabled,
     installedAt: "2026-01-01T00:00:00.000Z",
     updatedAt: "2026-01-01T00:00:00.000Z",
   };
 }
 
 /**
- * D-UPD test helper: seeded record with EMPTY resources.* -- the canonical
- * "currently disabled" marker that `isRecordedButDisabled` reads. The
- * `update` orchestrator must refresh the version/source pin but keep
- * resources empty (the artefacts re-materialize on the next `enable`).
+ * D-UPD test helper: seeded record with `enabled: false` -- the ENBL-02
+ * disabled marker that `isRecordedButDisabled` reads. The `update`
+ * orchestrator must refresh the version/source pin but keep the record
+ * disabled (artefacts re-materialize on the next `enable`).
  */
 function makeDisabledPluginRecord(version: string): PluginRecord {
-  return makePluginRecord(version, {
-    skills: [],
-    prompts: [],
-    agents: [],
-    mcpServers: [],
-  });
+  return makePluginRecord(version, { enabled: false });
 }
 
 interface SeededPathMp {

--- a/tests/orchestrators/plugin/update.test.ts
+++ b/tests/orchestrators/plugin/update.test.ts
@@ -113,6 +113,7 @@ function makePluginRecord(
       mcpServers: resources.mcpServers ?? [],
       hooks: resources.hooks ?? [],
     },
+    enabled: true,
     installedAt: "2026-01-01T00:00:00.000Z",
     updatedAt: "2026-01-01T00:00:00.000Z",
   };

--- a/tests/orchestrators/reconcile/apply.test.ts
+++ b/tests/orchestrators/reconcile/apply.test.ts
@@ -1050,16 +1050,16 @@ test("Y3 / PR #51: a recorded-but-disabled plugin declared enabled in config dri
       "utf8",
     );
 
-    // State: recorded plugin in the disabled marker shape (installable: true
-    // + every resources axis empty) so the planner classifies the entry as
-    // `pluginsToEnable` rather than `pluginsToInstall`. The marketplaceRoot
-    // points at the same non-existent path so the enable branch's cached
-    // manifest read fails ENOENT.
+    // State: recorded plugin in the ENBL-02 disabled marker shape
+    // (enabled:false + installable:true) so the planner classifies the
+    // entry as `pluginsToEnable` rather than `pluginsToInstall`. The
+    // marketplaceRoot points at the same non-existent path so the enable
+    // branch's cached manifest read fails ENOENT.
     await writeFile(
       path.join(extensionRoot, "state.json"),
       JSON.stringify(
         {
-          schemaVersion: 1,
+          schemaVersion: 2,
           marketplaces: {
             mp: {
               name: "mp",
@@ -1078,7 +1078,8 @@ test("Y3 / PR #51: a recorded-but-disabled plugin declared enabled in config dri
                     supported: [],
                     unsupported: [],
                   },
-                  resources: { skills: [], prompts: [], agents: [], mcpServers: [] },
+                  resources: { skills: [], prompts: [], agents: [], mcpServers: [], hooks: [] },
+                  enabled: false,
                   installedAt: "2026-01-01T00:00:00.000Z",
                   updatedAt: "2026-01-01T00:00:00.000Z",
                 },
@@ -1273,13 +1274,13 @@ test("T1 / PR #51: load-time ENABLE through applyReconcile -- disabled record + 
       "utf8",
     );
 
-    // State: KEPT disabled record (ENBL-02 marker) -- installable: true +
-    // every resources axis empty. Planner classifies as pluginsToEnable.
+    // State: KEPT disabled record (ENBL-02 marker) -- enabled:false +
+    // installable:true. Planner classifies as pluginsToEnable.
     await writeFile(
       path.join(extensionRoot, "state.json"),
       JSON.stringify(
         {
-          schemaVersion: 1,
+          schemaVersion: 2,
           marketplaces: {
             mp: {
               name: "mp",
@@ -1298,7 +1299,8 @@ test("T1 / PR #51: load-time ENABLE through applyReconcile -- disabled record + 
                     supported: [],
                     unsupported: [],
                   },
-                  resources: { skills: [], prompts: [], agents: [], mcpServers: [] },
+                  resources: { skills: [], prompts: [], agents: [], mcpServers: [], hooks: [] },
+                  enabled: false,
                   installedAt: "2026-01-01T00:00:00.000Z",
                   updatedAt: "2026-01-01T00:00:00.000Z",
                 },

--- a/tests/orchestrators/reconcile/plan.test.ts
+++ b/tests/orchestrators/reconcile/plan.test.ts
@@ -605,24 +605,24 @@ test("Plugin key parser: lastIndexOf('@') admits plugin names containing '@'", (
 // (enable-disable.ts). The two predicates are deliberately duplicated --
 // enable-disable.ts duplicates the marker locally to avoid pulling the
 // reconcile module into the orchestrator's import graph (see the JSDoc on
-// `isCurrentlyDisabled` at enable-disable.ts:172-178). The duplication is
+// `isCurrentlyDisabled` at enable-disable.ts). The duplication is
 // load-bearing for the convergence proof at plan-convergence.test.ts: a
-// soft-degraded (installable: false) plugin records all four resource
-// arrays empty AND must NOT be classified as `pluginsToEnable`, so both
-// predicates must read the installable axis the same way.
+// soft-degraded (installable: false) plugin has `enabled: true` and must
+// NOT be classified as `pluginsToEnable`; both predicates read the
+// installable axis for this guard.
+//
+// ENBL-02: the disabled marker is now an explicit `enabled: false`
+// boolean on the install record. This replaces the old five-resource-array-
+// emptiness heuristic. The truth table collapses to two boolean axes:
+// installable x enabled.
 //
 // This drift gate has two parts:
 //   1. A matrix truth-table assertion on `isRecordedButDisabled` over
-//      `installable: true | false` x `resources: empty | populated`,
-//      pinning the documented "all four empty + installable: true" cell as
-//      the only "disabled" cell.
+//      `installable: true | false` x `enabled: true | false`, pinning the
+//      (installable: true, enabled: false) cell as the only "disabled" cell.
 //   2. A source-shape pin: `isCurrentlyDisabled`'s function body in
-//      enable-disable.ts is the same `installable && skills.length===0 &&
-//      prompts.length===0 && agents.length===0 && mcpServers.length===0`
-//      conjunction. Since `isCurrentlyDisabled` is module-private (kept
-//      out of the reconcile import graph by design), the structural pin
-//      protects against a hand-edit that flips one branch but forgets the
-//      other.
+//      enable-disable.ts must carry the same boolean axes as
+//      `isRecordedButDisabled` (installable && !enabled).
 // ──────────────────────────────────────────────────────────────────────────
 
 interface DisabledMarkerRecord {
@@ -646,94 +646,62 @@ interface DisabledMarkerRecord {
   updatedAt: string;
 }
 
-function recordWith(
-  installable: boolean,
-  populated: boolean,
-  hooksPopulated = false,
-): DisabledMarkerRecord {
+function recordWith(installable: boolean, enabled: boolean): DisabledMarkerRecord {
   return {
     version: "1.0.0",
     resolvedSource: "/abs/whatever",
     compatibility: { installable, notes: [], supported: [], unsupported: [] },
     resources: {
-      skills: populated ? ["s1"] : [],
+      skills: enabled ? ["s1"] : [],
       prompts: [],
       agents: [],
       mcpServers: [],
-      hooks: hooksPopulated ? ["h1"] : [],
+      hooks: [],
     },
-    enabled: true,
+    enabled,
     installedAt: "2026-01-01T00:00:00.000Z",
     updatedAt: "2026-01-01T00:00:00.000Z",
   };
 }
 
-test("T5 / PR #51: isRecordedButDisabled truth table over the installable x populated x hooksPopulated matrix -- only the (installable: true, populated: false, hooksPopulated: false) cell is 'disabled'", () => {
-  // D-63-04: hooks is the fifth resource axis. The truth table now has
-  // three boolean dimensions; only the all-empty + installable: true cell
-  // is the ENBL-02 disabled marker. A hooks-only installed plugin
-  // (installable: true, populated: false, hooksPopulated: true) must NOT
-  // be classified as disabled -- that is the hooks-only-list-disabled
-  // regression this matrix pins.
+test("T5 / ENBL-02: isRecordedButDisabled truth table over installable x enabled -- only (installable:true, enabled:false) is 'disabled'", () => {
+  // ENBL-02: the disabled marker is an explicit `enabled: false` boolean.
+  // The truth table has two boolean axes: installable x enabled.
+  // Soft-degraded plugins (installable: false) are never classified as
+  // disabled regardless of their enabled field.
   const cases: ReadonlyArray<{
     name: string;
     installable: boolean;
-    populated: boolean;
-    hooksPopulated: boolean;
+    enabled: boolean;
     expected: boolean;
   }> = [
     {
-      name: "installable: true,  populated: true,  hooksPopulated: false (installed + enabled, classic resources)",
+      name: "installable: true,  enabled: true  (installed + enabled -- normal state)",
       installable: true,
-      populated: true,
-      hooksPopulated: false,
+      enabled: true,
       expected: false,
     },
     {
-      name: "installable: true,  populated: false, hooksPopulated: false (the ENBL-02 disabled marker)",
+      name: "installable: true,  enabled: false (the ENBL-02 disabled marker)",
       installable: true,
-      populated: false,
-      hooksPopulated: false,
+      enabled: false,
       expected: true,
     },
     {
-      name: "installable: true,  populated: false, hooksPopulated: true  (hooks-only installed -- D-63-04 regression cell)",
-      installable: true,
-      populated: false,
-      hooksPopulated: true,
-      expected: false,
-    },
-    {
-      name: "installable: true,  populated: true,  hooksPopulated: true  (installed + enabled, mixed resources)",
-      installable: true,
-      populated: true,
-      hooksPopulated: true,
-      expected: false,
-    },
-    {
-      name: "installable: false, populated: true,  hooksPopulated: false (impossible by construction; never disabled)",
+      name: "installable: false, enabled: true  (soft-degraded -- D-04; never disabled)",
       installable: false,
-      populated: true,
-      hooksPopulated: false,
+      enabled: true,
       expected: false,
     },
     {
-      name: "installable: false, populated: false, hooksPopulated: false (soft-degraded -- D-04 / Rule 2; never disabled)",
+      name: "installable: false, enabled: false (soft-degraded disabled -- edge; never classifiable as pluginsToEnable)",
       installable: false,
-      populated: false,
-      hooksPopulated: false,
-      expected: false,
-    },
-    {
-      name: "installable: false, populated: false, hooksPopulated: true  (soft-degraded with hooks; never disabled)",
-      installable: false,
-      populated: false,
-      hooksPopulated: true,
+      enabled: false,
       expected: false,
     },
   ];
   for (const c of cases) {
-    const rec = recordWith(c.installable, c.populated, c.hooksPopulated);
+    const rec = recordWith(c.installable, c.enabled);
     assert.equal(
       isRecordedButDisabled(rec),
       c.expected,
@@ -742,23 +710,21 @@ test("T5 / PR #51: isRecordedButDisabled truth table over the installable x popu
   }
 });
 
-test("T5 / PR #51: isCurrentlyDisabled (enable-disable.ts) source-shape pin -- same installable + four-axis-empty conjunction as isRecordedButDisabled (drift gate)", async () => {
+test("T5 / ENBL-02: isCurrentlyDisabled (enable-disable.ts) source-shape pin -- same installable + !enabled axes as isRecordedButDisabled (drift gate)", async () => {
   // The two predicates are deliberately duplicated (see the JSDoc on
-  // `isCurrentlyDisabled` at enable-disable.ts:172-178) to keep the
-  // orchestrator import graph free of the reconcile module. The drift
-  // gate: assert the function body still names the same boolean axes in
-  // the same conjunction, so a hand-edit that flips one side without the
-  // other trips this test before it reaches the convergence proof.
+  // `isCurrentlyDisabled` in enable-disable.ts) to keep the orchestrator
+  // import graph free of the reconcile module. The drift gate: assert the
+  // function body still names the same boolean axes in the same conjunction,
+  // so a hand-edit that flips one side without the other trips this test.
   const { readFile } = await import("node:fs/promises");
   const enableSrc = await readFile(
     "extensions/pi-claude-marketplace/orchestrators/plugin/enable-disable.ts",
     "utf8",
   );
 
-  // Extract the isCurrentlyDisabled function body (signature + return
-  // expression). The function is module-private; we match its declaration
-  // textually and assert the body carries every axis isRecordedButDisabled
-  // also tests.
+  // Extract the isCurrentlyDisabled function body. The function is
+  // module-private; we match its declaration textually and assert the body
+  // carries every axis isRecordedButDisabled also tests.
   const fnMatch = /function isCurrentlyDisabled\([\s\S]*?\): boolean \{([\s\S]*?)\n\}/.exec(
     enableSrc,
   );
@@ -768,36 +734,18 @@ test("T5 / PR #51: isCurrentlyDisabled (enable-disable.ts) source-shape pin -- s
   );
   const body = fnMatch[1]!;
 
-  // Each axis from isRecordedButDisabled must appear in the
-  // isCurrentlyDisabled body (same conjunction). If any axis is missing or
-  // renamed, the predicates have drifted.
-  const requiredAxes: ReadonlyArray<string> = [
-    "compatibility.installable",
-    "resources.skills.length === 0",
-    "resources.prompts.length === 0",
-    "resources.agents.length === 0",
-    "resources.mcpServers.length === 0",
-    // D-63-04: hooks is the fifth resource axis. A drift twin that omits
-    // it (the v1.13 hook-bridge regression that surfaced as
-    // hooks-only-list-disabled) would misclassify a hooks-only installed
-    // plugin as disabled.
-    "resources.hooks.length === 0",
-  ];
+  // ENBL-02: the required axes are now `compatibility.installable` and
+  // `!installed.enabled`. A drift twin that reverts to the resource-emptiness
+  // heuristic would misclassify hooks-only installed plugins as disabled
+  // (the regression D-63-04 originally caught).
+  const requiredAxes: ReadonlyArray<string> = ["compatibility.installable", "!installed.enabled"];
   for (const axis of requiredAxes) {
     assert.ok(
       body.includes(axis) ||
-        // The orchestrator destructures `installed.resources` / `installed.compatibility`
-        // before the conjunction, so the textual form drops the `installed.` prefix.
+        // The orchestrator may alias `installed.compatibility.installable`
+        // via a local binding -- also accept the un-prefixed forms.
         body.includes(axis.replace("compatibility.installable", "installable")),
       `T5 drift: isCurrentlyDisabled body must reference \`${axis}\` (same axis as isRecordedButDisabled); body was:\n${body}`,
     );
   }
-
-  // The connectives must all be conjunctions (&&) -- a stray || would flip
-  // the predicate to "disabled if ANY axis is empty", catastrophically
-  // misclassifying populated records.
-  assert.ok(
-    !body.includes("||"),
-    `T5 drift: isCurrentlyDisabled body must NOT contain || (disjunction would flip the truth table); body was:\n${body}`,
-  );
 });

--- a/tests/orchestrators/reconcile/plan.test.ts
+++ b/tests/orchestrators/reconcile/plan.test.ts
@@ -332,7 +332,30 @@ function stateWithDisabledRecord(
   };
 }
 
-test("ENBL-02 (a): recorded + empty resources + enabled!==false -> pluginsToEnable non-empty (isRecordedButDisabled fires)", () => {
+test("ENBL-02 self-heal: migrated legacy-disabled record (state enabled:true + empty resources) + config-disabled -> pluginsToDisable non-empty", () => {
+  // After migration a legacy-disabled plugin is mislabeled state enabled:true
+  // while its resources stay empty (see migrate.test.ts). The config still
+  // carries enabled:false, so reconcile must emit exactly one disable to
+  // re-converge: isRecordedButDisabled is false (enabled:true), so the
+  // declared-disabled branch fires the disable action rather than treating it
+  // as steady state.
+  const state = stateWithDisabledRecord("mp", "acme/tools", "cr");
+  state.marketplaces["mp"]!.plugins["cr"]!.enabled = true;
+  const merged = mergeScopeConfigs(
+    configWith({ mp: { source: "acme/tools" } }, { "cr@mp": { enabled: false } }),
+    {},
+  );
+  const plan = planReconcile(merged, state, "project");
+  assert.equal(plan.pluginsToDisable.length, 1);
+  assert.deepEqual(plan.pluginsToDisable[0], {
+    scope: "project",
+    plugin: "cr",
+    marketplace: "mp",
+  });
+  assert.equal(plan.pluginsToEnable.length, 0);
+});
+
+test("ENBL-02 (a): recorded + state enabled:false + config-enabled -> pluginsToEnable non-empty (isRecordedButDisabled fires)", () => {
   const state = stateWithDisabledRecord("mp", "acme/tools", "cr");
   const merged = mergeScopeConfigs(
     configWith({ mp: { source: "acme/tools" } }, { "cr@mp": { enabled: true } }),

--- a/tests/orchestrators/reconcile/plan.test.ts
+++ b/tests/orchestrators/reconcile/plan.test.ts
@@ -36,19 +36,15 @@ function stateWithOneGithubMarketplace(
       version: "1.0.0",
       resolvedSource: "/abs/whatever",
       compatibility: { installable: true, notes: [], supported: [], unsupported: [] },
-      // ENBL-02: a non-empty resources array signals "currently installed
-      // and enabled" (the install path's statePhase populates at least one
-      // array for any installable plugin per `requireInstallable`). Tests
-      // that need a "currently disabled" record use `stateWithDisabledRecord`
-      // (all four arrays empty -- A1).
       resources: { skills: ["s1"], prompts: [], agents: [], mcpServers: [], hooks: [] },
+      enabled: true,
       installedAt: "2025-01-01T00:00:00.000Z",
       updatedAt: "2025-01-01T00:00:00.000Z",
     };
   }
 
   return {
-    schemaVersion: 1,
+    schemaVersion: 2,
     marketplaces: {
       [mpName]: {
         name: mpName,
@@ -74,19 +70,15 @@ function stateWithOnePathMarketplace(
       version: "1.0.0",
       resolvedSource: "/abs/whatever",
       compatibility: { installable: true, notes: [], supported: [], unsupported: [] },
-      // ENBL-02: a non-empty resources array signals "currently installed
-      // and enabled" (the install path's statePhase populates at least one
-      // array for any installable plugin per `requireInstallable`). Tests
-      // that need a "currently disabled" record use `stateWithDisabledRecord`
-      // (all four arrays empty -- A1).
       resources: { skills: ["s1"], prompts: [], agents: [], mcpServers: [], hooks: [] },
+      enabled: true,
       installedAt: "2025-01-01T00:00:00.000Z",
       updatedAt: "2025-01-01T00:00:00.000Z",
     };
   }
 
   return {
-    schemaVersion: 1,
+    schemaVersion: 2,
     marketplaces: {
       [mpName]: {
         name: mpName,
@@ -315,7 +307,7 @@ function stateWithDisabledRecord(
   plugin: string,
 ): ExtensionState {
   return {
-    schemaVersion: 1,
+    schemaVersion: 2,
     marketplaces: {
       [mpName]: {
         name: mpName,
@@ -329,10 +321,8 @@ function stateWithDisabledRecord(
             version: "1.0.0",
             resolvedSource: "/abs/whatever",
             compatibility: { installable: true, notes: [], supported: [], unsupported: [] },
-            // All four arrays empty -- the disabled marker per A1.
-            // HOOK-02 / D-57-01: `hooks: []` is the additive required field
-            // (also empty in the disabled-marker shape).
             resources: { skills: [], prompts: [], agents: [], mcpServers: [], hooks: [] },
+            enabled: false,
             installedAt: "2025-01-01T00:00:00.000Z",
             updatedAt: "2025-01-01T00:00:00.000Z",
           },
@@ -649,6 +639,7 @@ interface DisabledMarkerRecord {
     mcpServers: string[];
     hooks: string[];
   };
+  enabled: boolean;
   version: string;
   resolvedSource: string;
   installedAt: string;
@@ -671,6 +662,7 @@ function recordWith(
       mcpServers: [],
       hooks: hooksPopulated ? ["h1"] : [],
     },
+    enabled: true,
     installedAt: "2026-01-01T00:00:00.000Z",
     updatedAt: "2026-01-01T00:00:00.000Z",
   };

--- a/tests/persistence/fixtures/legacy/state-populated-mixed.json
+++ b/tests/persistence/fixtures/legacy/state-populated-mixed.json
@@ -20,8 +20,10 @@
             "skills": ["mp-path-cr-skill"],
             "prompts": [],
             "agents": [],
-            "mcpServers": []
+            "mcpServers": [],
+            "hooks": []
           },
+          "enabled": true,
           "installedAt": "2025-01-01T00:00:00.000Z",
           "updatedAt": "2025-01-01T00:00:00.000Z"
         },
@@ -38,8 +40,10 @@
             "skills": [],
             "prompts": [],
             "agents": [],
-            "mcpServers": []
+            "mcpServers": [],
+            "hooks": []
           },
+          "enabled": true,
           "installedAt": "2025-01-01T00:00:00.000Z",
           "updatedAt": "2025-01-01T00:00:00.000Z"
         }
@@ -64,8 +68,10 @@
             "skills": ["mp-github-cr-skill"],
             "prompts": ["mp-github-cr-prompt"],
             "agents": [],
-            "mcpServers": []
+            "mcpServers": [],
+            "hooks": []
           },
+          "enabled": true,
           "installedAt": "2025-01-02T00:00:00.000Z",
           "updatedAt": "2025-01-02T00:00:00.000Z"
         }

--- a/tests/persistence/migrate.test.ts
+++ b/tests/persistence/migrate.test.ts
@@ -334,6 +334,35 @@ test("ENBL-02: ensurePluginEnabled preserves enabled: false (disabled record)", 
   assert.equal(mp.plugins["p1"]?.enabled, false);
 });
 
+test("ENBL-02: ensurePluginEnabled skips a marketplace whose plugins field is not an object", () => {
+  // Defensive guard: a malformed marketplace record whose `plugins` is not an
+  // object must be skipped (the helper returns false), not crash. Paths are
+  // present so ensureMarketplacePaths is a no-op and the whole pass reports
+  // mutated=false.
+  const fixture = {
+    schemaVersion: 1,
+    marketplaces: {
+      mp: {
+        name: "mp",
+        scope: "user",
+        source: { kind: "path", raw: "./mp", logical: "./mp" },
+        addedFromCwd: "/cwd",
+        manifestPath: "/abs/mp/.claude-plugin/marketplace.json",
+        marketplaceRoot: "/abs/mp",
+        plugins: "not-an-object",
+      },
+    },
+  };
+  const { marketplaces, mutated } = migrateLegacyMarketplaceRecords(
+    fixture,
+    "/ext-root",
+    GATE_CLOSED,
+  );
+  assert.equal(mutated, false);
+  const mp = marketplaces["mp"] as { plugins: unknown };
+  assert.equal(mp.plugins, "not-an-object");
+});
+
 test("ENBL-02: legacy-disabled shape (empty resources + absent enabled) over-fills to enabled: true (mislabel self-heals on reconcile)", () => {
   // A plugin disabled via `/claude:plugin disable` on a pre-ENBL-02 build
   // persists as installable: true + all-empty resources + NO `enabled`

--- a/tests/persistence/migrate.test.ts
+++ b/tests/persistence/migrate.test.ts
@@ -180,6 +180,8 @@ test("D-13 idempotency: second migrate on already-scrubbed input returns mutated
 function buildLegacyMigrationInput(opts: {
   resources?: Record<string, unknown> | undefined;
   omitResources?: boolean;
+  enabled?: unknown;
+  omitEnabled?: boolean;
 }): { schemaVersion: 1; marketplaces: Record<string, unknown> } {
   const plugin: Record<string, unknown> = {
     version: "1.0.0",
@@ -195,6 +197,10 @@ function buildLegacyMigrationInput(opts: {
       agents: [],
       mcpServers: [],
     };
+  }
+
+  if (!opts.omitEnabled) {
+    plugin["enabled"] = opts.enabled ?? true;
   }
 
   return {
@@ -274,6 +280,58 @@ test("HOOK-02 / D-57-01: ensurePluginResources fills hooks: [] when the entire r
   assert.deepEqual(p1.resources["agents"], []);
   assert.deepEqual(p1.resources["mcpServers"], []);
   assert.deepEqual(p1.resources["hooks"], []);
+});
+
+// ===================================================================
+// ENBL-02: additive `enabled: boolean` field on the plugin install
+// record. The default-fill `ensurePluginEnabled` in migrate.ts adds
+// `enabled: true` for any record that does not carry the field.
+// ===================================================================
+
+test("ENBL-02: ensurePluginEnabled fills enabled: true when absent", () => {
+  // Legacy-shaped record with no `enabled` field.
+  const fixture = buildLegacyMigrationInput({
+    resources: { skills: [], prompts: [], agents: [], mcpServers: [], hooks: [] },
+    omitEnabled: true,
+  });
+  const { marketplaces, mutated } = migrateLegacyMarketplaceRecords(
+    fixture,
+    "/ext-root",
+    GATE_CLOSED,
+  );
+  assert.equal(mutated, true);
+  const mp = marketplaces["mp"] as {
+    plugins: Record<string, { enabled: unknown }>;
+  };
+  assert.equal(mp.plugins["p1"]?.enabled, true);
+});
+
+test("ENBL-02: ensurePluginEnabled is idempotent when enabled is already set", () => {
+  // Already-normalized record with enabled: true -- no mutation.
+  const fixture = buildLegacyMigrationInput({
+    resources: { skills: [], prompts: [], agents: [], mcpServers: [], hooks: [] },
+    enabled: true,
+  });
+  const { mutated } = migrateLegacyMarketplaceRecords(fixture, "/ext-root", GATE_CLOSED);
+  assert.equal(mutated, false);
+});
+
+test("ENBL-02: ensurePluginEnabled preserves enabled: false (disabled record)", () => {
+  // A record explicitly marked disabled must not be overwritten.
+  const fixture = buildLegacyMigrationInput({
+    resources: { skills: [], prompts: [], agents: [], mcpServers: [], hooks: [] },
+    enabled: false,
+  });
+  const { marketplaces, mutated } = migrateLegacyMarketplaceRecords(
+    fixture,
+    "/ext-root",
+    GATE_CLOSED,
+  );
+  assert.equal(mutated, false);
+  const mp = marketplaces["mp"] as {
+    plugins: Record<string, { enabled: unknown }>;
+  };
+  assert.equal(mp.plugins["p1"]?.enabled, false);
 });
 
 test("IL-3 persistMigratedState swallows write failures and emits ONE console.warn", async (t) => {

--- a/tests/persistence/migrate.test.ts
+++ b/tests/persistence/migrate.test.ts
@@ -334,6 +334,37 @@ test("ENBL-02: ensurePluginEnabled preserves enabled: false (disabled record)", 
   assert.equal(mp.plugins["p1"]?.enabled, false);
 });
 
+test("ENBL-02: legacy-disabled shape (empty resources + absent enabled) over-fills to enabled: true (mislabel self-heals on reconcile)", () => {
+  // A plugin disabled via `/claude:plugin disable` on a pre-ENBL-02 build
+  // persists as installable: true + all-empty resources + NO `enabled`
+  // field. The migrator cannot tell it apart from an enabled record, so it
+  // over-fills enabled: true. The record emerges "enabled but empty";
+  // reconcile then reads the still-`enabled: false` config entry and emits
+  // one redundant disable to re-converge (that self-heal is pinned by the
+  // reconcile test in tests/orchestrators/reconcile/plan.test.ts).
+  const fixture = buildLegacyMigrationInput({
+    resources: { skills: [], prompts: [], agents: [], mcpServers: [], hooks: [] },
+    omitEnabled: true,
+  });
+  const { marketplaces, mutated } = migrateLegacyMarketplaceRecords(
+    fixture,
+    "/ext-root",
+    GATE_CLOSED,
+  );
+  assert.equal(mutated, true);
+  const mp = marketplaces["mp"] as {
+    plugins: Record<string, { enabled: unknown; resources: Record<string, unknown> }>;
+  };
+  const p1 = mp.plugins["p1"];
+  assert.ok(p1);
+  // Over-filled to enabled: true despite being a legacy-disabled record.
+  assert.equal(p1.enabled, true);
+  // Resources are NOT repopulated -- the record stays "enabled but empty",
+  // exactly the shape reconcile self-heals.
+  assert.deepEqual(p1.resources["skills"], []);
+  assert.deepEqual(p1.resources["hooks"], []);
+});
+
 test("IL-3 persistMigratedState swallows write failures and emits ONE console.warn", async (t) => {
   // Force atomicWriteJson to fail by passing a path whose dirname is an
   // existing FILE (not a directory). atomicWriteJson runs `mkdir(parent)`

--- a/tests/persistence/state-io.test.ts
+++ b/tests/persistence/state-io.test.ts
@@ -9,9 +9,13 @@ import { locationsFor } from "../../extensions/pi-claude-marketplace/persistence
 import {
   DEFAULT_STATE,
   STATE_VALIDATOR,
+  type DisabledPluginRecord,
+  type EnabledPluginRecord,
   type ExtensionState,
+  type PluginInstallRecord,
   loadState,
   saveState,
+  toDisabledRecord,
 } from "../../extensions/pi-claude-marketplace/persistence/state-io.ts";
 
 /**
@@ -549,4 +553,80 @@ test("ENBL-02: STATE_SCHEMA.schemaVersion accepts 1 and 2 (saveState accepts bot
   } finally {
     await cleanup();
   }
+});
+
+// ===================================================================
+// ENBL-02 two-signal invariant: EnabledPluginRecord / DisabledPluginRecord
+// branded types + the toDisabledRecord factory.
+// ===================================================================
+
+test("ENBL-02: toDisabledRecord empties all resources, sets enabled:false, preserves identity + restamps updatedAt", () => {
+  const record: PluginInstallRecord = {
+    version: "9.9.9",
+    resolvedSource: "/abs/mp/foo",
+    compatibility: { installable: true, notes: [], supported: [], unsupported: [] },
+    resources: { skills: ["s"], prompts: ["p"], agents: ["a"], mcpServers: ["m"], hooks: ["h"] },
+    enabled: true,
+    installedAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  };
+  const disabled = toDisabledRecord(record, "2026-02-02T00:00:00.000Z");
+  assert.equal(disabled.enabled, false);
+  assert.deepEqual(disabled.resources, {
+    skills: [],
+    prompts: [],
+    agents: [],
+    mcpServers: [],
+    hooks: [],
+  });
+  // Identity fields preserved.
+  assert.equal(disabled.version, "9.9.9");
+  assert.equal(disabled.resolvedSource, "/abs/mp/foo");
+  assert.deepEqual(disabled.compatibility, record.compatibility);
+  assert.equal(disabled.installedAt, "2026-01-01T00:00:00.000Z");
+  // updatedAt restamped.
+  assert.equal(disabled.updatedAt, "2026-02-02T00:00:00.000Z");
+  // The disabled + empty shape is a legal stored record.
+  assert.equal(
+    STATE_VALIDATOR.Check({
+      schemaVersion: 2,
+      marketplaces: {
+        mp: {
+          name: "mp",
+          scope: "user",
+          source: { kind: "path", raw: "./mp", logical: "./mp" },
+          addedFromCwd: "/cwd",
+          manifestPath: "/m",
+          marketplaceRoot: "/r",
+          plugins: { foo: disabled },
+        },
+      },
+    }),
+    true,
+  );
+});
+
+test("ENBL-02: DisabledPluginRecord forbids non-empty resources at compile time", () => {
+  // Compile-time guard: gated by `npm run typecheck` (tests/**/*.ts is in the
+  // tsconfig include). If the branded type regresses to permissive arrays,
+  // the @ts-expect-error below stops erroring and typecheck fails.
+  type DisabledSkills = DisabledPluginRecord["resources"]["skills"];
+  // @ts-expect-error a disabled record's resources arrays must be empty ([])
+  const badSkills: DisabledSkills = ["x"];
+  void badSkills;
+
+  // The empty form type-checks, and an enabled record may carry populated
+  // resources (the normal active shape) -- proving the asymmetry is intended.
+  const okSkills: DisabledSkills = [];
+  const active: EnabledPluginRecord = {
+    version: "1.0.0",
+    resolvedSource: "/abs",
+    compatibility: { installable: true, notes: [], supported: [], unsupported: [] },
+    resources: { skills: ["x"], prompts: [], agents: [], mcpServers: [], hooks: [] },
+    enabled: true,
+    installedAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  };
+  assert.deepEqual(okSkills, []);
+  assert.equal(active.enabled, true);
 });

--- a/tests/persistence/state-io.test.ts
+++ b/tests/persistence/state-io.test.ts
@@ -55,7 +55,7 @@ test("loadState on missing state.json returns DEFAULT_STATE", async () => {
   const { root, cleanup } = await tmpExtensionRoot();
   try {
     const got = await loadState(root);
-    assert.deepEqual(got, { schemaVersion: 1, marketplaces: {} });
+    assert.deepEqual(got, { schemaVersion: 2, marketplaces: {} });
   } finally {
     await cleanup();
   }
@@ -66,7 +66,7 @@ test("loadState on empty {} state.json returns DEFAULT_STATE shape", async () =>
   try {
     await writeFile(path.join(root, "state.json"), "{}");
     const got = await loadState(root);
-    assert.equal(got.schemaVersion, 1);
+    assert.equal(got.schemaVersion, 2);
     assert.deepEqual(got.marketplaces, {});
   } finally {
     await cleanup();
@@ -119,7 +119,7 @@ test("ST-6 loadState classifies legacy raw-string source via pathSource (v0 fixt
     const fixtureRaw = await readFile(path.join(FIXTURES, "v0-no-schemaversion.json"), "utf8");
     await writeFile(path.join(root, "state.json"), fixtureRaw);
     const got = await loadState(root);
-    assert.equal(got.schemaVersion, 1);
+    assert.equal(got.schemaVersion, 2);
     const mp = (got.marketplaces as Record<string, { source: unknown }>)["alpha"];
     assert.ok(mp);
     // Source revalidated to ParsedSource object form
@@ -213,7 +213,10 @@ test("saveState refuses invalid in-memory state (caller-bug guard)", async () =>
 test("STATE_VALIDATOR exports a JIT-compiled validator (D-07)", () => {
   assert.equal(typeof STATE_VALIDATOR.Check, "function");
   assert.equal(STATE_VALIDATOR.Check(DEFAULT_STATE), true);
-  assert.equal(STATE_VALIDATOR.Check({ schemaVersion: 2, marketplaces: {} }), false);
+  // ENBL-02: schemaVersion 2 is the new normal; both 1 and 2 are valid.
+  assert.equal(STATE_VALIDATOR.Check({ schemaVersion: 2, marketplaces: {} }), true);
+  // schemaVersion 3 is unknown and must be rejected.
+  assert.equal(STATE_VALIDATOR.Check({ schemaVersion: 3, marketplaces: {} }), false);
 });
 
 test("SPLIT-01: legacy state.json with autoupdate still loads (typebox lenient)", async (t) => {
@@ -233,7 +236,7 @@ test("SPLIT-01: legacy state.json with autoupdate still loads (typebox lenient)"
     // means the lenient typebox default ACCEPTS the extra property at the
     // schema gate. Both halves must hold for the load to succeed.
     const got = await loadState(root);
-    assert.equal(got.schemaVersion, 1);
+    assert.equal(got.schemaVersion, 2);
     const mp = (got.marketplaces as Record<string, { name: string }>)["mp-with-autoupdate"];
     assert.ok(mp);
     assert.equal(mp.name, "mp-with-autoupdate");
@@ -308,16 +311,21 @@ test("D-13 drift guard: loadState's configJsonPath derivation matches locationsF
 
 // ===================================================================
 // HOOK-02 / D-57-01: additive `resources.hooks` field on the plugin
-// install record. STATE_SCHEMA.schemaVersion stays Type.Literal(1) -- the
-// migration is purely additive (every v1.0..v1.12 hook-using plugin was
-// rejected as UNSUPPORTED_COMPONENT_KIND, so no existing state.json
-// record carries hook resources to "migrate"). The validator is the
-// schema gate; the default-fill in persistence/migrate.ts is the
-// responsibility for adding `hooks: []` before validation runs.
+// install record. The validator is the schema gate; the default-fill in
+// persistence/migrate.ts is the responsibility for adding `hooks: []`
+// before validation runs.
+//
+// ENBL-02: `enabled: boolean` is REQUIRED from schemaVersion 2.
+// The fixture builder includes it so STATE_VALIDATOR.Check passes.
 // ===================================================================
 
-function buildValidatorFixture(opts: { hooks?: unknown; omitHooks?: boolean }): {
-  schemaVersion: 1;
+function buildValidatorFixture(opts: {
+  hooks?: unknown;
+  omitHooks?: boolean;
+  enabled?: unknown;
+  omitEnabled?: boolean;
+}): {
+  schemaVersion: 2;
   marketplaces: Record<string, unknown>;
 } {
   const resources: Record<string, unknown> = {
@@ -330,8 +338,25 @@ function buildValidatorFixture(opts: { hooks?: unknown; omitHooks?: boolean }): 
     resources["hooks"] = opts.hooks ?? [];
   }
 
+  const plugin: Record<string, unknown> = {
+    version: "1.0.0",
+    resolvedSource: "/abs/mp/p1",
+    compatibility: {
+      installable: true,
+      notes: [],
+      supported: [],
+      unsupported: [],
+    },
+    resources,
+    installedAt: "2025-01-01T00:00:00.000Z",
+    updatedAt: "2025-01-01T00:00:00.000Z",
+  };
+  if (!opts.omitEnabled) {
+    plugin["enabled"] = opts.enabled ?? true;
+  }
+
   return {
-    schemaVersion: 1,
+    schemaVersion: 2,
     marketplaces: {
       mp: {
         name: "mp",
@@ -340,21 +365,7 @@ function buildValidatorFixture(opts: { hooks?: unknown; omitHooks?: boolean }): 
         addedFromCwd: "/cwd",
         manifestPath: "/abs/mp/.claude-plugin/marketplace.json",
         marketplaceRoot: "/abs/mp",
-        plugins: {
-          p1: {
-            version: "1.0.0",
-            resolvedSource: "/abs/mp/p1",
-            compatibility: {
-              installable: true,
-              notes: [],
-              supported: [],
-              unsupported: [],
-            },
-            resources,
-            installedAt: "2025-01-01T00:00:00.000Z",
-            updatedAt: "2025-01-01T00:00:00.000Z",
-          },
-        },
+        plugins: { p1: plugin },
       },
     },
   };
@@ -452,17 +463,19 @@ test("HOOK-02 / D-57-01: v1.12-shaped state.json round-trips through loadState; 
   }
 });
 
-test("SPLIT-01 / D-12: STATE_SCHEMA.schemaVersion stays Type.Literal(1) (saveState refuses schemaVersion: 2)", async () => {
+test("ENBL-02: STATE_SCHEMA.schemaVersion accepts 1 and 2 (saveState accepts both; rejects 3+)", async () => {
   const { root, cleanup } = await tmpExtensionRoot();
   try {
-    // The compile-time `Type.Literal(1)` forces the cast below; the runtime
-    // STATE_VALIDATOR.Check inside saveState must REFUSE because the on-disk
-    // contract is locked at schemaVersion 1 (D-12: no STATE_SCHEMA bump).
-    const bumped = {
-      schemaVersion: 2 as 1,
-      marketplaces: {},
-    } as ExtensionState;
-    await assert.rejects(() => saveState(root, bumped), /failed schema validation/);
+    // schemaVersion 2 is the ENBL-02 shape and must be accepted.
+    const v2 = { schemaVersion: 2, marketplaces: {} } as ExtensionState;
+    await saveState(root, v2); // must not throw
+    // schemaVersion 1 is the pre-ENBL-02 shape and must still be accepted
+    // (migration is additive; old files with no plugin records are valid v1).
+    const v1 = { schemaVersion: 1, marketplaces: {} } as ExtensionState;
+    await saveState(root, v1); // must not throw
+    // schemaVersion 3 is unknown and must be refused.
+    const v3 = { schemaVersion: 3 as unknown as 1, marketplaces: {} } as ExtensionState;
+    await assert.rejects(() => saveState(root, v3), /failed schema validation/);
   } finally {
     await cleanup();
   }

--- a/tests/persistence/state-io.test.ts
+++ b/tests/persistence/state-io.test.ts
@@ -391,6 +391,15 @@ test("HOOK-02 / D-57-01: STATE_VALIDATOR rejects a record missing resources.hook
   assert.equal(STATE_VALIDATOR.Check(fixture), false);
 });
 
+test("ENBL-02: STATE_VALIDATOR rejects a record missing `enabled` (fill-before-validate is the migrator's responsibility)", () => {
+  // Guards the fill-before-validate contract: if `enabled` ever became
+  // optional in the schema, the migrator's default-fill could silently
+  // regress to a no-op and a field-less record would validate. This pins
+  // `enabled` as REQUIRED.
+  const fixture = buildValidatorFixture({ omitEnabled: true });
+  assert.equal(STATE_VALIDATOR.Check(fixture), false);
+});
+
 test("HOOK-02 / D-57-01: v1.12-shaped state.json round-trips through loadState; every plugin record gains resources.hooks default", async (t) => {
   const { root, cleanup } = await tmpExtensionRoot();
   // Suppress IL-3 sanctioned warn: ST-4 fire-and-forget persist may race
@@ -455,6 +464,67 @@ test("HOOK-02 / D-57-01: v1.12-shaped state.json round-trips through loadState; 
     assert.deepEqual(mp.plugins["needs-default"]?.resources["hooks"], []);
     // The migrator leaves an existing hooks array untouched (D-57-03).
     assert.deepEqual(mp.plugins["has-preexisting"]?.resources["hooks"], ["pre-existing"]);
+    // Flush fire-and-forget persist before cleanup races.
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    await new Promise<void>((resolve) => setImmediate(resolve));
+  } finally {
+    await cleanup();
+  }
+});
+
+test("ENBL-02: pre-enabled state.json round-trips through loadState; every plugin record gains enabled: true", async (t) => {
+  const { root, cleanup } = await tmpExtensionRoot();
+  // Suppress IL-3 sanctioned warn: ST-4 fire-and-forget persist may race
+  // the cleanup `rm`, surfacing as a harmless persist failure.
+  t.mock.method(console, "warn", () => {
+    // suppress noise
+  });
+  try {
+    // A pre-ENBL-02 state.json: plugin records carry full resources
+    // (including hooks, so this exercises the `enabled` arm in isolation)
+    // but NO `enabled` field. schemaVersion stays 1. This pins loadState's
+    // integration: the migrator's enabled-fill MUST run before
+    // STATE_VALIDATOR.Check -- a reorder would throw on this file undetected.
+    const preEnabledState = {
+      schemaVersion: 1,
+      marketplaces: {
+        mp: {
+          name: "mp",
+          scope: "user",
+          source: { kind: "path", raw: "./mp", logical: "./mp" },
+          addedFromCwd: "/cwd",
+          manifestPath: "/abs/mp/.claude-plugin/marketplace.json",
+          marketplaceRoot: "/abs/mp",
+          plugins: {
+            one: {
+              version: "1.0.0",
+              resolvedSource: "/abs/mp/one",
+              compatibility: { installable: true, notes: [], supported: [], unsupported: [] },
+              resources: { skills: [], prompts: [], agents: [], mcpServers: [], hooks: [] },
+              installedAt: "2025-01-01T00:00:00.000Z",
+              updatedAt: "2025-01-01T00:00:00.000Z",
+            },
+            two: {
+              version: "2.0.0",
+              resolvedSource: "/abs/mp/two",
+              compatibility: { installable: true, notes: [], supported: [], unsupported: [] },
+              resources: { skills: ["s"], prompts: [], agents: [], mcpServers: [], hooks: [] },
+              installedAt: "2025-01-02T00:00:00.000Z",
+              updatedAt: "2025-01-02T00:00:00.000Z",
+            },
+          },
+        },
+      },
+    };
+    await writeFile(path.join(root, "state.json"), JSON.stringify(preEnabledState));
+
+    const got = await loadState(root);
+    const mp = (
+      got.marketplaces as Record<string, { plugins: Record<string, { enabled: boolean }> }>
+    )["mp"];
+    assert.ok(mp);
+    assert.equal(mp.plugins["one"]?.enabled, true);
+    assert.equal(mp.plugins["two"]?.enabled, true);
     // Flush fire-and-forget persist before cleanup races.
     await new Promise<void>((resolve) => setImmediate(resolve));
     await new Promise<void>((resolve) => setImmediate(resolve));

--- a/tests/transaction/with-state-guard.test.ts
+++ b/tests/transaction/with-state-guard.test.ts
@@ -68,6 +68,7 @@ function withInstalledPlugin(
         resolvedSource: `/abs/${plName}`,
         compatibility: { installable: true, notes: [], supported: [], unsupported: [] },
         resources: { skills: [], prompts: [], agents: [], mcpServers: [], hooks: [] },
+        enabled: true,
         installedAt: "2025-01-01T00:00:00.000Z",
         updatedAt: "2025-01-01T00:00:00.000Z",
       },
@@ -228,7 +229,8 @@ test("D-06 save failure releases the lock for the next state guard call", async 
     await assert.rejects(
       () =>
         withStateGuard(loc, (state) => {
-          (state as { schemaVersion: number }).schemaVersion = 2;
+          // schemaVersion 3 is unknown to the schema; saveState must reject.
+          (state as { schemaVersion: number }).schemaVersion = 3;
         }),
       /saveState refused/,
     );


### PR DESCRIPTION
## Summary

Disabled plugins were tracked by an implicit heuristic: a recorded plugin counted as disabled when all five of its resource arrays were empty. That breaks for a plugin with no materialized resources of its own, a hooks-only plugin being the clearest case. This PR replaces the heuristic with an explicit `enabled` boolean on each plugin record, so `enable`/`disable`, `list`, and the reconcile planner all read one marker.

It is backwards compatible. The `state.json` schema version goes to 2, and old files migrate on load (every existing record is filled `enabled: true`). A plugin you had disabled before the upgrade stays disabled after the next reload, because the config still carries `enabled: false` and the next reconcile re-converges. No reinstall or manual edit is needed. Patch release: 0.6.1.

## What's in here

- Schema + migration: `enabled: Type.Boolean()` on the plugin record, a `schemaVersion` 1|2 union, and an additive `ensurePluginEnabled` fill (base feature, already on the branch).
- Predicate swap: `isRecordedButDisabled` / `isCurrentlyDisabled` now read `installable && !enabled` instead of resource emptiness.
- PR review fixes: corrected migration comments, a stale reconcile file-header and the event-router error fallback, plus new tests (legacy-disabled migration + reconcile self-heal, the `enabled: false` write-back, a pre-enabled `loadState` round-trip, and a validator rejection).
- Type-level guard: `EnabledPluginRecord` / `DisabledPluginRecord` branded types and a `toDisabledRecord` factory. A disabled record with non-empty resources is now a compile error; the disable path builds through the factory and replaces the record in state.
- Docs: README links Pi Coding Agent and describes the `/claude:plugin` desired-state config files.

## Testing

`npm run check` green: typecheck, eslint, prettier, 2320 unit pass / 0 fail (2 pre-existing skips), 16 integration pass. One flaky `autoupdate` cleanup race (ENOTEMPTY on rmdir) is pre-existing and unrelated; it passes in isolation.

## Release

0.6.1. Version bumped in `package.json`, `package-lock.json`, and `sonar-project.properties`; CHANGELOG updated. Tagging `v0.6.1` after merge triggers the npm publish job in CI.
