### PR TITLE
chore: remove orphaned GSD graphify hook from project settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,19 +2,5 @@
   "enabledPlugins": {
     "context7@claude-plugins-official": true,
     "typescript-lsp@claude-plugins-official": true
-  },
-  "hooks": {
-    "PostToolUse": [
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/gsd-graphify-update.sh",
-            "timeout": 5
-          }
-        ]
-      }
-    ]
   }
 }


### PR DESCRIPTION
## Summary

Removes the leftover GSD graphify hook from the tracked `.claude/settings.json`.

The file had one `PostToolUse` Bash hook running
`$CLAUDE_PROJECT_DIR/.claude/hooks/gsd-graphify-update.sh`. That script sits
under `.claude/hooks/`, which `.gitignore` excludes, so it never gets committed.
Anyone who clones the repo ends up with a settings file pointing at a script
that isn't in their checkout, so the hook fails on every Bash call.

It was missed by #48, which pulled the other GSD lifecycle hooks out of the
tracked config. GSD hooks are personal tooling and live in the user-global
`~/.claude` config, so dropping the project copy loses nothing.

## Test plan

- [ ] `.claude/settings.json` no longer references any `gsd-*.sh` hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLsTuarcXk9XMyvFFnnoZ5
