### PR TITLE
ci: pin pre-commit prettier mirror to 3.8.3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,11 @@ repos:
     hooks:
       - id: prettier
         files: '\.(js|json|ts)$'
+        # Pin prettier to match the npm devDependency (the mirror otherwise
+        # floats and CI resolved a version that reformats TS union types
+        # differently from the local check).
+        additional_dependencies:
+          - prettier@3.8.3
 
   - repo: https://github.com/sirosen/texthooks
     rev: 0.7.1


### PR DESCRIPTION
## What

The `mirrors-prettier` pre-commit hook pins no prettier version, so its environment resolves whatever prettier is current when the env is built. CI resolved a different prettier than the local/cached env and reformatted TypeScript union types, which fails `pre-commit` on every PR — including all five open dependabot PRs (#72–#76), whose only red check is `pre-commit`.

## Fix

Pin the mirror hook to `prettier@3.8.3` via `additional_dependencies`, matching the `prettier` npm devDependency, so the hook and `npm run format:check` use the identical prettier deterministically everywhere.

Verified: `pre-commit run --all-files` is green on `main`'s code with the pin (no reformatting).

This unblocks the dependabot PRs once it lands on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pqo9vrTXMmTYM6FWQMWVj2