### PR TITLE
feat: support git-subdir plugin sources

### DIFF
--- a/extensions/pi-claude-marketplace/domain/resolver.ts
+++ b/extensions/pi-claude-marketplace/domain/resolver.ts
@@ -495,13 +495,24 @@ async function collectUnsupportedKinds(
 }
 
 function sourceUnsupportedReason(parsedSource: ParsedSource): string | undefined {
-  if (parsedSource.kind === "path") {
+  if (parsedSource.kind === "path" || parsedSource.kind === "git-subdir") {
     return undefined;
   }
 
   return parsedSource.kind === "unknown"
     ? `unsupported source kind: unknown (${parsedSource.reason})`
     : `unsupported source kind: ${parsedSource.kind}`;
+}
+
+function sourcePathWithinMarketplace(parsedSource: ParsedSource): string | undefined {
+  switch (parsedSource.kind) {
+    case "path":
+      return parsedSource.raw;
+    case "git-subdir":
+      return parsedSource.path;
+    default:
+      return undefined;
+  }
 }
 
 async function sourceEscapeReason(
@@ -590,8 +601,19 @@ async function preflightStages(
   }
 
   // PR-2 case 2: source path escape.
-  const pluginRoot = path.resolve(ctx.marketplaceRoot, parsedSource.raw);
-  const escapeReason = await sourceEscapeReason(ctx, pluginRoot, parsedSource.raw);
+  const sourcePath = sourcePathWithinMarketplace(parsedSource);
+  if (sourcePath === undefined) {
+    return {
+      kind: "unavailable",
+      result: unavailable(entry.name, [
+        ...partial.notes,
+        `unsupported source kind: ${parsedSource.kind}`,
+      ]),
+    };
+  }
+
+  const pluginRoot = path.resolve(ctx.marketplaceRoot, sourcePath);
+  const escapeReason = await sourceEscapeReason(ctx, pluginRoot, sourcePath);
 
   if (escapeReason !== undefined) {
     return {

--- a/tests/domain/resolver-strict.test.ts
+++ b/tests/domain/resolver-strict.test.ts
@@ -104,6 +104,25 @@ test("PR-2(1) upstream object source kind (url) -> notInstallable", async () => 
   assert.ok(r.notes.includes("unsupported source kind: url"), `notes: ${r.notes.join(" / ")}`);
 });
 
+test("PR-2(1) upstream object source kind (git-subdir) -> installable when path exists", async () => {
+  const ctx = mockCtx(MP, { [ROOT("./plugins/p1")]: "dir" });
+  const r = await resolveStrict(
+    basicEntry({
+      source: {
+        source: "git-subdir",
+        url: "https://github.com/acme/marketplace.git",
+        path: "./plugins/p1",
+        ref: "main",
+      },
+    }),
+    ctx,
+  );
+  assert.equal(r.state, "installable", `notes: ${r.notes.join(" / ")}`);
+  if (r.state === "installable") {
+    assert.equal(r.pluginRoot, ROOT("./plugins/p1"));
+  }
+});
+
 test("PR-2(2) source path escape -> notInstallable", async () => {
   const ctx = mockCtx(MP, {});
   const r = await resolveStrict(basicEntry({ source: "../escape" }), ctx);
@@ -117,6 +136,44 @@ test("PR-2(2) source path escape -> notInstallable", async () => {
 test("PR-2(3) source dir does not exist -> notInstallable", async () => {
   const ctx = mockCtx(MP, {}); // no entries -> statKind returns null
   const r = await resolveStrict(basicEntry({ source: "./missing" }), ctx);
+  assert.equal(r.state, "unavailable");
+  assert.ok(
+    r.notes.some((n) => n.includes("source dir does not exist")),
+    `notes: ${r.notes.join(" / ")}`,
+  );
+});
+
+test("PR-2(2) git-subdir path escape -> notInstallable", async () => {
+  const ctx = mockCtx(MP, {});
+  const r = await resolveStrict(
+    basicEntry({
+      source: {
+        source: "git-subdir",
+        url: "https://github.com/acme/marketplace.git",
+        path: "../escape",
+      },
+    }),
+    ctx,
+  );
+  assert.equal(r.state, "unavailable");
+  assert.ok(
+    r.notes.some((n) => n.includes("escapes marketplace root")),
+    `notes: ${r.notes.join(" / ")}`,
+  );
+});
+
+test("PR-2(3) git-subdir source dir does not exist -> notInstallable", async () => {
+  const ctx = mockCtx(MP, {});
+  const r = await resolveStrict(
+    basicEntry({
+      source: {
+        source: "git-subdir",
+        url: "https://github.com/acme/marketplace.git",
+        path: "./plugins/missing",
+      },
+    }),
+    ctx,
+  );
   assert.equal(r.state, "unavailable");
   assert.ok(
     r.notes.some((n) => n.includes("source dir does not exist")),


### PR DESCRIPTION
## Summary
- treat marketplace plugin entries with `source: { source: "git-subdir", ... }` as paths rooted inside the already-fetched marketplace checkout
- keep external plugin sources like `github`, `url`, and `npm` unavailable
- add strict resolver coverage for installable, escaping, and missing `git-subdir` paths

## Why
`pi-claude-marketplace` already parses `git-subdir` plugin sources, but the resolver currently marks them unavailable because only `path` sources are considered installable.

This change keeps the existing no-network install/list/update behavior intact and simply resolves `git-subdir.path` relative to `marketplaceRoot`, which makes marketplace manifests that point at plugin subdirectories work as expected.

## Validation
- `node --test tests/domain/resolver-strict.test.ts`
- `npm run typecheck`
- `pre-commit run --files extensions/pi-claude-marketplace/domain/resolver.ts tests/domain/resolver-strict.test.ts`
