### PR TITLE
Support string mcp server references

### DIFF
--- a/extensions/pi-claude-marketplace/domain/manifest.ts
+++ b/extensions/pi-claude-marketplace/domain/manifest.ts
@@ -7,11 +7,13 @@
 // is `typebox/compile` (the package is `typebox` with no scope).
 
 import { readFile } from "node:fs/promises";
+import path from "node:path";
 
 import Type from "typebox";
 import { Compile } from "typebox/compile";
 
 import { InvalidMarketplaceManifestError } from "../shared/errors.ts";
+import { assertPathInside } from "../shared/path-safety.ts";
 
 import { PLUGIN_ENTRY_SCHEMA } from "./components/plugin.ts";
 import { createManifestCache } from "./manifest-cache.ts";
@@ -42,12 +44,13 @@ export const MARKETPLACE_VALIDATOR = Compile(MARKETPLACE_SCHEMA);
 /**
  * NFR-8 / D-14: the sole marketplace.json read+parse+validate. This is the ONLY
  * marketplace.json file read in the repo (CACHE-06) and the injected loader
- * behind the cache. It returns the RAW JSON.parse value (WR-01) -- it does NOT
- * route the result back through the validator's coercing parse, a schema clean,
- * or a deep clone -- so key order and extra fields survive (`update.ts`
- * JSON.stringifys it; `info.ts` reads `parsed.description`). Keep this focused on
- * path-based reads only: no cache state, invalidation, or caller-specific error
- * wrapping belongs here.
+ * behind the cache. It preserves the parsed manifest except that plugin-local
+ * `mcpServers` file references are inlined before validation. It does NOT route
+ * the result through the validator's coercing parse, a schema clean, or a deep
+ * clone -- so key order and extra fields survive (`update.ts` JSON.stringifys
+ * it; `info.ts` reads `parsed.description`). Keep this focused on path-based
+ * reads only: no cache state, invalidation, or caller-specific error wrapping
+ * belongs here.
  */
 async function loadMarketplaceManifestUncached(manifestPath: string): Promise<MarketplaceManifest> {
   const raw = await readFile(manifestPath, "utf8");
@@ -67,6 +70,8 @@ async function loadMarketplaceManifestUncached(manifestPath: string): Promise<Ma
     );
   }
 
+  await inlineMcpServerReferences(parsed, manifestPath);
+
   if (!MARKETPLACE_VALIDATOR.Check(parsed)) {
     const firstErr = MARKETPLACE_VALIDATOR.Errors(parsed)[0];
     const detail = firstErr
@@ -76,6 +81,44 @@ async function loadMarketplaceManifestUncached(manifestPath: string): Promise<Ma
   }
 
   return parsed;
+}
+
+async function inlineMcpServerReferences(manifest: unknown, manifestPath: string): Promise<void> {
+  if (
+    typeof manifest !== "object" ||
+    manifest === null ||
+    !Array.isArray((manifest as { plugins?: unknown }).plugins)
+  ) {
+    return;
+  }
+
+  const marketplaceRoot = path.dirname(path.dirname(manifestPath));
+  for (const plugin of (manifest as { plugins: unknown[] }).plugins) {
+    if (
+      typeof plugin !== "object" ||
+      plugin === null ||
+      typeof (plugin as { source?: unknown }).source !== "string" ||
+      typeof (plugin as { mcpServers?: unknown }).mcpServers !== "string"
+    ) {
+      continue;
+    }
+
+    const entry = plugin as { source: string; mcpServers: unknown };
+    const mcpReference = entry.mcpServers as string;
+    const pluginRoot = path.resolve(marketplaceRoot, entry.source);
+    const mcpPath = path.resolve(pluginRoot, mcpReference);
+    await assertPathInside(marketplaceRoot, pluginRoot, `plugin source path "${entry.source}"`);
+    await assertPathInside(pluginRoot, mcpPath, `mcpServers path "${mcpReference}"`);
+
+    try {
+      const mcpDoc = JSON.parse(await readFile(mcpPath, "utf8")) as { mcpServers?: unknown };
+      entry.mcpServers = mcpDoc.mcpServers;
+    } catch (err) {
+      throw new InvalidMarketplaceManifestError(`mcpServers file is invalid: ${String(err)}`, {
+        cause: err,
+      });
+    }
+  }
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       },
       "devDependencies": {
         "@earendil-works/pi-coding-agent": "^0.80.10",
-        "@earendil-works/pi-tui": "^0.79.0",
+        "@earendil-works/pi-tui": "^0.80.7",
         "@eslint/js": "^10.0.1",
         "@stylistic/eslint-plugin": "^5.10.0",
         "@types/proper-lockfile": "^4.1.4",
@@ -580,7 +580,7 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "./dist/cli.js"
+        "pi-ai": "dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -2021,14 +2021,14 @@
       }
     },
     "node_modules/@earendil-works/pi-tui": {
-      "version": "0.79.4",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.79.4.tgz",
-      "integrity": "sha512-/ZhfFiHSBMH7AbDrBQIN+UWlJnl9tSEpLYICRGGMzmNfyCqX+30NYacIhyOEaD8R5rS6wJZysAOPU0yNwigbXw==",
+      "version": "0.80.7",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.7.tgz",
+      "integrity": "sha512-1B2++fLZfgI3XMzW2BTpuDuam2uyHnUUEmsOvi5R0Ne9RAt59WjFV0G8ozX6l1Xafa9P5Y3eT4aDtRr/v/CUTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-east-asian-width": "1.6.0",
-        "marked": "15.0.12"
+        "marked": "18.0.5"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -4626,16 +4626,16 @@
       "license": "MIT"
     },
     "node_modules/marked": {
-      "version": "15.0.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
-      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
       "dev": true,
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 20"
       }
     },
     "node_modules/math-intrinsics": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "description": "Access Claude plugin marketplaces from Pi.",
   "devDependencies": {
     "@earendil-works/pi-coding-agent": "^0.80.10",
-    "@earendil-works/pi-tui": "^0.79.0",
+    "@earendil-works/pi-tui": "^0.80.7",
     "@eslint/js": "^10.0.1",
     "@stylistic/eslint-plugin": "^5.10.0",
     "@types/proper-lockfile": "^4.1.4",

--- a/tests/domain/manifest.test.ts
+++ b/tests/domain/manifest.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -86,6 +86,45 @@ test("NFR-8 loadMarketplaceManifest reads and validates marketplace.json through
 
     assert.equal(manifest.name, "test-marketplace");
     assert.equal(manifest.plugins[0]?.name, "p");
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("loadMarketplaceManifest inlines string mcpServers file references before validation", async () => {
+  const tmp = await mkdtemp(path.join(os.tmpdir(), "pi-cm-manifest-mcp-ref-"));
+  try {
+    const manifestDir = path.join(tmp, ".claude-plugin");
+    const pluginRoot = path.join(tmp, "plugins/example-plugin");
+    const manifestPath = path.join(manifestDir, "marketplace.json");
+    const mcpServers = {
+      "example-plugin": {
+        command: "bash",
+        args: ["${CLAUDE_PLUGIN_ROOT}/scripts/example-mcp.sh"],
+      },
+    };
+
+    await mkdir(pluginRoot, { recursive: true });
+    await mkdir(manifestDir, { recursive: true });
+    await writeFile(
+      manifestPath,
+      JSON.stringify({
+        name: "example-marketplace",
+        plugins: [
+          {
+            name: "example-plugin",
+            source: "./plugins/example-plugin",
+            mcpServers: "./.mcp.json",
+          },
+        ],
+      }),
+      "utf8",
+    );
+    await writeFile(path.join(pluginRoot, ".mcp.json"), JSON.stringify({ mcpServers }), "utf8");
+
+    const manifest = await loadMarketplaceManifest(manifestPath);
+
+    assert.deepEqual(manifest.plugins[0]?.mcpServers, mcpServers);
   } finally {
     await rm(tmp, { recursive: true, force: true });
   }


### PR DESCRIPTION
Following [this request](https://github.com/lucatume/pi-claude-marketplace/commit/4f9b73c4cf4b0c9c82eb4147d3aaa1788f976e3e#commitcomment-193354483).

 String mcpServers references are now supported when source is also a local string path.

 ### Example 1: conventional .mcp.json

 .claude-plugin/marketplace.json:

 ```json
   {
     "name": "example-marketplace",
     "plugins": [
       {
         "name": "weather",
         "source": "./plugins/weather",
         "mcpServers": "./.mcp.json"
       }
     ]
   }
 ```

 plugins/weather/.mcp.json:

 ```json
   {
     "mcpServers": {
       "weather": {
         "command": "node",
         "args": ["${CLAUDE_PLUGIN_ROOT}/server.js"]
       }
     }
   }
 ```

 ### Example 2: nested file with multiple servers

 ```json
   {
     "name": "example-marketplace",
     "plugins": [
       {
         "name": "developer-tools",
         "source": "./plugins/developer-tools",
         "mcpServers": "./config/servers.json"
       }
     ]
   }
 ```

 plugins/developer-tools/config/servers.json:

 ```json
   {
     "mcpServers": {
       "search": {
         "command": "npx",
         "args": ["-y", "search-mcp"]
       },
       "database": {
         "command": "node",
         "args": ["${CLAUDE_PLUGIN_ROOT}/servers/database.js"],
         "env": {
           "DATABASE_URL": "${DATABASE_URL}"
         }
       }
     }
   }
 ```

 The referenced file must:

 - Be inside the plugin’s source directory.
 - Contain a top-level mcpServers object.
 - Contain valid JSON.