### PR TITLE
fix: skill and command frontmatter compliance (0.11.1)

### DIFF
--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -10,7 +10,21 @@ Fifteen milestones have shipped: v1.0 (PRD-derived successor architecture), v1.1
 
 A Pi user can run `/claude:plugin install <plugin>@<marketplace>` and, after `/reload`, have every supported Claude plugin component appear as a working Pi-native artefact -- atomically, recoverably, and with soft-dependency degradation that never blocks the install.
 
-## Current Milestone: mcp-string-refs MCP Server String References (branch: features/mcp-string-refs, started 2026-07-22, target npm 0.11.0)
+## Current Milestone: v1.15 frontmatter-compliance — Skill and Command Frontmatter Compliance (branch: features/frontmatter-compliance, started 2026-07-25, target npm 0.12.0)
+
+**Goal:** The skills and commands bridges reach full compliance with Claude Code's observable frontmatter-loading behavior: they never write bytes Pi rejects, they degrade a component the same way Claude Code does (a skill stays invocable by name but is never auto-invoked; a command stays invocable by its filename), they fold `when_to_use` into the description Pi actually reads, and they tell the user which component failed and why (GitHub issue #101).
+
+**Target features:**
+
+- **Two-gate parse model** — source frontmatter is parsed with Pi's own `parseFrontmatter` *before* name-rewrite and variable substitution (attribution + degrade trigger), and the staged bytes are re-parsed afterwards as a Pi-acceptability backstop; a valid source whose staged output fails is a self-inflicted defect, surfaced loudly, never attributed to the author.
+- **Claude-parity skill degradation** — unparseable skill frontmatter → synthesized block (`disable-model-invocation: true` + short fixed placeholder description, body verbatim, install never hard-fails); absent/empty description → first-paragraph-of-body fallback (stays model-invocable); the written `name` always equals the generated name (folded-scalar corruption caught).
+- **`when_to_use` folding** — a skill's `when_to_use` is appended to the Pi `description` (Pi's skill loader reads only `name`/`description`/`disable-model-invocation`), truncated at Claude Code's 1,536-char listing cap, so converted skills keep their auto-invocation triggers.
+- **Literal command degradation** — unparseable command frontmatter is neutralized so Pi loads the command with name-from-filename + description-from-first-body-line, matching Claude Code's malformed-frontmatter behavior exactly (no placeholder, no disable flag; Pi's command loader has no non-empty-description gate).
+- **Surfaced diagnostics + classification** — each degraded/neutralized component emits an install-time warning row naming the source component and the parse error (the surfaced analog of Claude Code's `--debug`-only message); the failure is failure-class (a new reason token paralleling `malformed mcp`, filed under `FAILURE_REASONS`), not soft-degrade; the `REASONS` amendment stays byte-stable (OUT-08).
+
+**Key context:** Design diagnosed in `docs/research/issue-101-skill-frontmatter-diagnosis.md`. The doc's Prevalence section is now stale — the two example skills (`stocks-murphy-technical-analysis`, `llm-wiki-scaffold`) were fixed upstream in `acolomba/claude-plugins` PR #17 (`eac8606`, folding descriptions to `>-` block scalars); the code gap remains real for any third-party plugin that ships a plain-scalar `: ` description (issue #101 is reported against another plugin). Verified inline: `parseFrontmatter` is a Pi root export since the `>=0.74.0` peer floor with byte-identical throw-on-malformed semantics; the bridge does NOT corrupt a valid `>-` source (name-rewrite touches only the `name:` line, substitution only `${…}` literals). Pi's skill loader (`core/skills.js`) reads only `name`/`description`/`disable-model-invocation` and returns `skill: null` on empty description, while the command loader (`core/prompt-templates.js`) derives name-from-filename + first-body-line description with no empty gate — the asymmetry driving the skill-synthesize-vs-command-neutralize split. "Full compliance" = observable-behavior parity (literal empty-metadata parity is impossible in Pi); `yaml` ≡ `js-yaml` failure policy treated as safe-divergent.
+
+## Previous Milestone: mcp-string-refs MCP Server String References (branch: features/mcp-string-refs, started 2026-07-22, target npm 0.11.0)
 
 **Goal:** A Claude plugin that declares `mcpServers` as a string file-path reference (a path to a `.mcp.json`-shaped file inside the plugin's source dir) resolves and installs its MCP servers at parity with the inline-object form — resolved in the resolver layer so a broken reference isolates to a single `unavailable` plugin, never failing the whole marketplace read.
 
@@ -252,6 +266,18 @@ Four distinct categories of unsupported Claude hook events. All cause plugin `(u
 
 ### Active
 
+<!-- Milestone v1.15 frontmatter-compliance (branch features/frontmatter-compliance, started 2026-07-25). GitHub issue #101. Full REQ set in .planning/REQUIREMENTS.md. -->
+
+- [ ] Two-gate parse model: source parsed before rewrite/substitution (attribution + degrade trigger); staged bytes re-parsed as Pi-acceptability backstop (PARSE-01/02)
+- [ ] Unparseable skill → synthesized `disable-model-invocation` block + placeholder description, body verbatim, install never hard-fails (SKILL-01)
+- [ ] Absent/empty skill description → first-paragraph fallback, stays model-invocable (SKILL-02)
+- [ ] Written skill `name` always equals the generated name; folded-scalar corruption caught (SKILL-03)
+- [ ] Skill `when_to_use` folded into the Pi description, truncated at 1,536 chars (WTU-01/02)
+- [ ] Unparseable command frontmatter neutralized → name-from-filename + first-body-line description (CMD-01)
+- [ ] Each degraded component emits an install-time warning row naming the source + parse error (WARN-01)
+- [ ] Frontmatter-parse failure is failure-class (new reason paralleling `malformed mcp`), byte-stable REASONS (CLASS-01)
+- [ ] Components that already parse cleanly (non-empty description, no `when_to_use`) are written unchanged (NREG-01)
+
 <!-- Milestone agent-skill-preloads (workstream issue-86-agent-skill-preloads, shipped 2026-07-20 as npm 0.10.0). Fixed GitHub issue #86. -->
 
 - [x] Source agents using the documented YAML block-list form for `skills:`/`tools:` convert with preloads intact (AGSK-01) — shipped npm 0.10.0
@@ -387,7 +413,9 @@ This document evolves at phase transitions and milestone boundaries.
 
 ______________________________________________________________________
 
-*Last updated: 2026-07-23 after completing Phase 85 (milestone v1.14 mcp-string-refs) — `mcpServers` string file-path references shipped in the resolver layer with per-plugin soft-degrade and a new `{malformed mcp}` failure-class reason (MCPR-01..04 validated; provisional MCPR-03 refined to wrapped-only per D-04, provisional MCPR-05 shipped as MCPR-04). Prior updates below.*
+*Last updated: 2026-07-25 after starting milestone v1.15 frontmatter-compliance (branch features/frontmatter-compliance, GitHub issue #101) — full Claude Code frontmatter-loading compliance for the skills and commands bridges: two-gate parse model (source parsed pre-substitution for attribution, staged bytes re-parsed for Pi-acceptability), Claude-parity skill degradation (`disable-model-invocation` synthesized block, first-paragraph fallback, name-integrity assert), `when_to_use` folding at the 1,536-char cap, literal command neutralize, surfaced warning rows, and a `malformed mcp`-parallel failure-class reason. 11 requirements across PARSE/SKILL/WTU/CMD/WARN/CLASS/NREG. Prior updates below.*
+
+*Prior update: 2026-07-23 after completing Phase 85 (milestone v1.14 mcp-string-refs) — `mcpServers` string file-path references shipped in the resolver layer with per-plugin soft-degrade and a new `{malformed mcp}` failure-class reason (MCPR-01..04 validated; provisional MCPR-03 refined to wrapped-only per D-04, provisional MCPR-05 shipped as MCPR-04). Prior updates below.*
 
 *Prior update: 2026-07-19 after starting milestone agent-skill-preloads (workstream: issue-86-agent-skill-preloads, shipped 2026-07-20 as npm 0.10.0) — GitHub issue #86 fix: block-list frontmatter parsing, plugin-qualified skill mapping, `Skill`-tool drop warning, body advisory note (AGSK-01..04).*
 

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -1,0 +1,87 @@
+# Requirements: frontmatter-compliance (v1.15)
+
+**Defined:** 2026-07-25
+**Core Value:** A Pi user can run `/claude:plugin install <plugin>@<marketplace>` and, after `/reload`, have every supported Claude plugin component appear as a working Pi-native artefact — atomically, recoverably, and with soft-dependency degradation that never blocks the install.
+
+**Milestone goal:** The skills and commands bridges reach full compliance with Claude Code's *observable* frontmatter-loading behavior — they never write bytes Pi rejects, they degrade a component the same way Claude Code does, they fold `when_to_use` into the description Pi reads, and they attribute failures to the right component (GitHub issue #101). "Full compliance" is observable-behavior parity: literal empty-metadata parity is impossible because Pi's skill loader returns `skill: null` on an empty description.
+
+## v1 Requirements
+
+### Parse gate (PARSE)
+
+- [ ] **PARSE-01**: The source frontmatter is parsed with Pi's own `parseFrontmatter` **before** name-rewrite and variable substitution, at both the skills and commands staging seams — establishing source validity and the true field values as the attribution ground truth and the degrade trigger.
+- [ ] **PARSE-02**: The staged (post-rewrite, post-substitution) bytes are re-parsed as the Pi-acceptability backstop. A source that parsed but whose staged output does not is surfaced as a self-inflicted defect (loud failure / test-guarded), never attributed to the plugin author.
+
+### Skill degradation (SKILL)
+
+- [ ] **SKILL-01**: A skill whose source frontmatter cannot be parsed installs with a synthesized frontmatter block (generated `name`, short fixed placeholder `description`, `disable-model-invocation: true`); the markdown body is preserved verbatim and the plugin install does not hard-fail. Result matches Claude Code observably: invocable by `/skill:<name>`, never auto-invoked.
+- [ ] **SKILL-02**: A skill with an absent or empty `description` (well-formed frontmatter) gets a first-paragraph-of-body fallback description and remains model-invocable — Claude Code's documented "if omitted, uses the first paragraph of markdown content" behavior.
+- [ ] **SKILL-03**: The written skill `name` always equals the generated name; a folded or multi-line source `name` scalar cannot silently corrupt it (the rewrite is verified against the parsed value, not a blind line regex).
+
+### `when_to_use` folding (WTU)
+
+- [ ] **WTU-01**: A skill's `when_to_use` text is folded into the Pi `description` (appended, as Claude Code combines them in its skill listing), so a converted skill retains its auto-invocation triggers even though Pi's skill loader reads only `description`.
+- [ ] **WTU-02**: The combined `description` + `when_to_use` text is truncated at 1,536 characters, matching Claude Code's skill-listing cap.
+
+### Command degradation (CMD)
+
+- [ ] **CMD-01**: A command whose source frontmatter cannot be parsed installs with the unparseable frontmatter neutralized, so Pi loads it with name-from-filename and description-from-first-body-line — the literal Claude Code malformed-frontmatter behavior (no synthesized placeholder and no disable flag, because Pi's command loader has no non-empty-description gate).
+
+### Diagnostics (WARN)
+
+- [ ] **WARN-01**: Each degraded or neutralized component (skill or command) produces an install-time warning row naming the source component and the parse error — the surfaced analog of Claude Code's `--debug`-only parse message. Satisfies issue #101's core ask that the failure stop being silent.
+
+### Classification (CLASS)
+
+- [ ] **CLASS-01**: A frontmatter-parse failure is classified failure-class (a new reason token paralleling `malformed mcp`, filed under `FAILURE_REASONS`, not the unsupported family), not soft-degrade — it is a malformation of a *supported* component, not an unsupported kind. The `REASONS` tuple amendment is byte-stable (OUT-08).
+
+### Non-regression (NREG)
+
+- [ ] **NREG-01**: A component that already parses, has a non-empty `description`, and has no `when_to_use` to fold is written byte-for-byte as it is today — no behavior change for the ~99% of components that already work.
+
+## Future Requirements
+
+Deferred to a later milestone. Tracked but not in this roadmap.
+
+### Reason taxonomy
+
+- **REASON-01**: Unify all parse-error reasons under a single `{malformed <feature>}` reason family (carried from v1.14 backlog). This milestone adds one more failure-class member paralleling `malformed mcp`; the broader unification stays deferred.
+
+## Out of Scope
+
+Explicitly excluded. Documented to prevent scope creep.
+
+| Feature | Reason |
+|---------|--------|
+| Non-`description` skill frontmatter fields (`allowed-tools`, `disallowed-tools`, `model`, `context: fork`) | Pi's skill loader reads none of them; they are silently dropped today and are not a frontmatter-*validity* concern. No Pi analog to comply against. |
+| Quote-repair heuristic (parse-leniently, re-quote offending plain scalars) | Rejected in the diagnosis: it rewrites third-party content the issue author flagged as undesirable and adds an unbounded heuristic to maintain. |
+| Whole-block frontmatter re-emit (agents-bridge style) | Rejected: skills' target format is real structured YAML; flattening would damage ~13% of real skills (nested maps, block scalars, flow collections). Only the specific fields we compute (`name`, `description`) are re-emitted safely. |
+| Exhaustive `yaml` ≡ `js-yaml` parser equivalence | Safe-divergence accepted: the failure policy makes either-direction divergence safe (a skill Pi rejects but Claude accepts degrades to `disable-model-invocation`; the reverse loads normally). Chasing rare parser-corner equivalence adds no user-visible value. |
+| Fixing the maintainer's own example skills | Already fixed upstream in `acolomba/claude-plugins` PR #17 (`>-` block scalars). The code gap remains the target, not those specific files. |
+
+## Traceability
+
+Which phases cover which requirements. Populated during roadmap creation.
+
+| Requirement | Phase | Status |
+|-------------|-------|--------|
+| PARSE-01 | — | Pending |
+| PARSE-02 | — | Pending |
+| SKILL-01 | — | Pending |
+| SKILL-02 | — | Pending |
+| SKILL-03 | — | Pending |
+| WTU-01 | — | Pending |
+| WTU-02 | — | Pending |
+| CMD-01 | — | Pending |
+| WARN-01 | — | Pending |
+| CLASS-01 | — | Pending |
+| NREG-01 | — | Pending |
+
+**Coverage:**
+- v1 requirements: 11 total
+- Mapped to phases: 0 (roadmap pending)
+- Unmapped: 11 ⚠️
+
+---
+*Requirements defined: 2026-07-25*
+*Last updated: 2026-07-25 after milestone v1.15 requirements definition*

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -9,12 +9,12 @@
 
 ### Parse gate (PARSE)
 
-- [ ] **PARSE-01**: The source frontmatter is parsed with Pi's own `parseFrontmatter` **before** name-rewrite and variable substitution, at both the skills and commands staging seams — establishing source validity and the true field values as the attribution ground truth and the degrade trigger.
-- [ ] **PARSE-02**: The staged (post-rewrite, post-substitution) bytes are re-parsed as the Pi-acceptability backstop. A source that parsed but whose staged output does not is surfaced as a self-inflicted defect (loud failure / test-guarded), never attributed to the plugin author.
+- [x] **PARSE-01**: The source frontmatter is parsed with Pi's own `parseFrontmatter` **before** name-rewrite and variable substitution, at both the skills and commands staging seams — establishing source validity and the true field values as the attribution ground truth and the degrade trigger.
+- [x] **PARSE-02**: The staged (post-rewrite, post-substitution) bytes are re-parsed as the Pi-acceptability backstop. A source that parsed but whose staged output does not is surfaced as a self-inflicted defect (loud failure / test-guarded), never attributed to the plugin author.
 
 ### Skill degradation (SKILL)
 
-- [ ] **SKILL-01**: A skill whose source frontmatter cannot be parsed installs with a synthesized frontmatter block (generated `name`, short fixed placeholder `description`, `disable-model-invocation: true`); the markdown body is preserved verbatim and the plugin install does not hard-fail. Result matches Claude Code observably: invocable by `/skill:<name>`, never auto-invoked.
+- [x] **SKILL-01**: A skill whose source frontmatter cannot be parsed installs with a synthesized frontmatter block (generated `name`, short fixed placeholder `description`, `disable-model-invocation: true`); the markdown body is preserved verbatim and the plugin install does not hard-fail. Result matches Claude Code observably: invocable by `/skill:<name>`, never auto-invoked.
 - [x] **SKILL-02**: A skill with an absent or empty `description` (well-formed frontmatter) gets a first-paragraph-of-body fallback description and remains model-invocable — Claude Code's documented "if omitted, uses the first paragraph of markdown content" behavior.
 - [ ] **SKILL-03**: The written skill `name` always equals the generated name; a folded or multi-line source `name` scalar cannot silently corrupt it (the rewrite is verified against the parsed value, not a blind line regex).
 
@@ -29,7 +29,7 @@
 
 ### Diagnostics (WARN)
 
-- [ ] **WARN-01**: Each degraded or neutralized component (skill or command) produces an install-time warning row naming the source component and the parse error — the surfaced analog of Claude Code's `--debug`-only parse message. Satisfies issue #101's core ask that the failure stop being silent.
+- [x] **WARN-01**: Each degraded or neutralized component (skill or command) produces an install-time warning row naming the source component and the parse error — the surfaced analog of Claude Code's `--debug`-only parse message. Satisfies issue #101's core ask that the failure stop being silent.
 
 ### Classification (CLASS)
 
@@ -37,7 +37,7 @@
 
 ### Non-regression (NREG)
 
-- [ ] **NREG-01**: A component that already parses, has a non-empty `description`, and has no `when_to_use` to fold is written byte-for-byte as it is today — no behavior change for the ~99% of components that already work.
+- [x] **NREG-01**: A component that already parses, has a non-empty `description`, and has no `when_to_use` to fold is written byte-for-byte as it is today — no behavior change for the ~99% of components that already work.
 
 ## Future Requirements
 
@@ -65,17 +65,17 @@ Which phases cover which requirements. Populated during roadmap creation.
 
 | Requirement | Phase | Status |
 |-------------|-------|--------|
-| PARSE-01 | Phase 86 | Pending |
-| PARSE-02 | Phase 86 | Pending |
-| SKILL-01 | Phase 86 | Pending |
+| PARSE-01 | Phase 86 | Complete |
+| PARSE-02 | Phase 86 | Complete |
+| SKILL-01 | Phase 86 | Complete |
 | SKILL-02 | Phase 86 | Complete |
 | SKILL-03 | Phase 86 | Pending |
 | WTU-01 | Phase 86 | Complete |
 | WTU-02 | Phase 86 | Complete |
 | CMD-01 | Phase 86 | Pending |
-| WARN-01 | Phase 86 | Pending |
+| WARN-01 | Phase 86 | Complete |
 | CLASS-01 | Phase 86 | Complete |
-| NREG-01 | Phase 86 | Pending |
+| NREG-01 | Phase 86 | Complete |
 
 **Coverage:**
 

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -25,7 +25,7 @@
 
 ### Command degradation (CMD)
 
-- [ ] **CMD-01**: A command whose source frontmatter cannot be parsed installs with the unparseable frontmatter neutralized, so Pi loads it with name-from-filename and description-from-first-body-line — the literal Claude Code malformed-frontmatter behavior (no synthesized placeholder and no disable flag, because Pi's command loader has no non-empty-description gate).
+- [x] **CMD-01**: A command whose source frontmatter cannot be parsed installs with the unparseable frontmatter neutralized, so Pi loads it with name-from-filename and description-from-first-body-line — the literal Claude Code malformed-frontmatter behavior (no synthesized placeholder and no disable flag, because Pi's command loader has no non-empty-description gate).
 
 ### Diagnostics (WARN)
 
@@ -72,7 +72,7 @@ Which phases cover which requirements. Populated during roadmap creation.
 | SKILL-03 | Phase 86 | Complete |
 | WTU-01 | Phase 86 | Complete |
 | WTU-02 | Phase 86 | Complete |
-| CMD-01 | Phase 86 | Pending |
+| CMD-01 | Phase 86 | Complete |
 | WARN-01 | Phase 86 | Complete |
 | CLASS-01 | Phase 86 | Complete |
 | NREG-01 | Phase 86 | Complete |

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -15,13 +15,13 @@
 ### Skill degradation (SKILL)
 
 - [ ] **SKILL-01**: A skill whose source frontmatter cannot be parsed installs with a synthesized frontmatter block (generated `name`, short fixed placeholder `description`, `disable-model-invocation: true`); the markdown body is preserved verbatim and the plugin install does not hard-fail. Result matches Claude Code observably: invocable by `/skill:<name>`, never auto-invoked.
-- [ ] **SKILL-02**: A skill with an absent or empty `description` (well-formed frontmatter) gets a first-paragraph-of-body fallback description and remains model-invocable — Claude Code's documented "if omitted, uses the first paragraph of markdown content" behavior.
+- [x] **SKILL-02**: A skill with an absent or empty `description` (well-formed frontmatter) gets a first-paragraph-of-body fallback description and remains model-invocable — Claude Code's documented "if omitted, uses the first paragraph of markdown content" behavior.
 - [ ] **SKILL-03**: The written skill `name` always equals the generated name; a folded or multi-line source `name` scalar cannot silently corrupt it (the rewrite is verified against the parsed value, not a blind line regex).
 
 ### `when_to_use` folding (WTU)
 
-- [ ] **WTU-01**: A skill's `when_to_use` text is folded into the Pi `description` (appended, as Claude Code combines them in its skill listing), so a converted skill retains its auto-invocation triggers even though Pi's skill loader reads only `description`.
-- [ ] **WTU-02**: The combined `description` + `when_to_use` text is truncated at 1,536 characters, matching Claude Code's skill-listing cap.
+- [x] **WTU-01**: A skill's `when_to_use` text is folded into the Pi `description` (appended, as Claude Code combines them in its skill listing), so a converted skill retains its auto-invocation triggers even though Pi's skill loader reads only `description`.
+- [x] **WTU-02**: The combined `description` + `when_to_use` text is truncated at 1,536 characters, matching Claude Code's skill-listing cap.
 
 ### Command degradation (CMD)
 
@@ -33,7 +33,7 @@
 
 ### Classification (CLASS)
 
-- [ ] **CLASS-01**: A frontmatter-parse failure is classified failure-class (a new reason token paralleling `malformed mcp`, filed under `FAILURE_REASONS`, not the unsupported family), not soft-degrade — it is a malformation of a *supported* component, not an unsupported kind. The `REASONS` tuple amendment is byte-stable (OUT-08).
+- [x] **CLASS-01**: A frontmatter-parse failure is classified failure-class (a new reason token paralleling `malformed mcp`, filed under `FAILURE_REASONS`, not the unsupported family), not soft-degrade — it is a malformation of a *supported* component, not an unsupported kind. The `REASONS` tuple amendment is byte-stable (OUT-08).
 
 ### Non-regression (NREG)
 
@@ -68,16 +68,17 @@ Which phases cover which requirements. Populated during roadmap creation.
 | PARSE-01 | Phase 86 | Pending |
 | PARSE-02 | Phase 86 | Pending |
 | SKILL-01 | Phase 86 | Pending |
-| SKILL-02 | Phase 86 | Pending |
+| SKILL-02 | Phase 86 | Complete |
 | SKILL-03 | Phase 86 | Pending |
-| WTU-01 | Phase 86 | Pending |
-| WTU-02 | Phase 86 | Pending |
+| WTU-01 | Phase 86 | Complete |
+| WTU-02 | Phase 86 | Complete |
 | CMD-01 | Phase 86 | Pending |
 | WARN-01 | Phase 86 | Pending |
-| CLASS-01 | Phase 86 | Pending |
+| CLASS-01 | Phase 86 | Complete |
 | NREG-01 | Phase 86 | Pending |
 
 **Coverage:**
+
 - v1 requirements: 11 total
 - Mapped to phases: 11 ✓
 - Unmapped: 0

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -16,7 +16,7 @@
 
 - [x] **SKILL-01**: A skill whose source frontmatter cannot be parsed installs with a synthesized frontmatter block (generated `name`, short fixed placeholder `description`, `disable-model-invocation: true`); the markdown body is preserved verbatim and the plugin install does not hard-fail. Result matches Claude Code observably: invocable by `/skill:<name>`, never auto-invoked.
 - [x] **SKILL-02**: A skill with an absent or empty `description` (well-formed frontmatter) gets a first-paragraph-of-body fallback description and remains model-invocable — Claude Code's documented "if omitted, uses the first paragraph of markdown content" behavior.
-- [ ] **SKILL-03**: The written skill `name` always equals the generated name; a folded or multi-line source `name` scalar cannot silently corrupt it (the rewrite is verified against the parsed value, not a blind line regex).
+- [x] **SKILL-03**: The written skill `name` always equals the generated name; a folded or multi-line source `name` scalar cannot silently corrupt it (the rewrite is verified against the parsed value, not a blind line regex).
 
 ### `when_to_use` folding (WTU)
 
@@ -69,7 +69,7 @@ Which phases cover which requirements. Populated during roadmap creation.
 | PARSE-02 | Phase 86 | Complete |
 | SKILL-01 | Phase 86 | Complete |
 | SKILL-02 | Phase 86 | Complete |
-| SKILL-03 | Phase 86 | Pending |
+| SKILL-03 | Phase 86 | Complete |
 | WTU-01 | Phase 86 | Complete |
 | WTU-02 | Phase 86 | Complete |
 | CMD-01 | Phase 86 | Pending |

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -65,23 +65,23 @@ Which phases cover which requirements. Populated during roadmap creation.
 
 | Requirement | Phase | Status |
 |-------------|-------|--------|
-| PARSE-01 | — | Pending |
-| PARSE-02 | — | Pending |
-| SKILL-01 | — | Pending |
-| SKILL-02 | — | Pending |
-| SKILL-03 | — | Pending |
-| WTU-01 | — | Pending |
-| WTU-02 | — | Pending |
-| CMD-01 | — | Pending |
-| WARN-01 | — | Pending |
-| CLASS-01 | — | Pending |
-| NREG-01 | — | Pending |
+| PARSE-01 | Phase 86 | Pending |
+| PARSE-02 | Phase 86 | Pending |
+| SKILL-01 | Phase 86 | Pending |
+| SKILL-02 | Phase 86 | Pending |
+| SKILL-03 | Phase 86 | Pending |
+| WTU-01 | Phase 86 | Pending |
+| WTU-02 | Phase 86 | Pending |
+| CMD-01 | Phase 86 | Pending |
+| WARN-01 | Phase 86 | Pending |
+| CLASS-01 | Phase 86 | Pending |
+| NREG-01 | Phase 86 | Pending |
 
 **Coverage:**
 - v1 requirements: 11 total
-- Mapped to phases: 0 (roadmap pending)
-- Unmapped: 11 ⚠️
+- Mapped to phases: 11 ✓
+- Unmapped: 0
 
 ---
 *Requirements defined: 2026-07-25*
-*Last updated: 2026-07-25 after milestone v1.15 requirements definition*
+*Last updated: 2026-07-26 after milestone v1.15 roadmap creation (all 11 requirements mapped to Phase 86)*

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -44,12 +44,12 @@
   4. Each degraded skill or neutralized command emits an install-time warning row naming the source component and its parse error — the surfaced analog of Claude Code's `--debug`-only message — classified as a new failure-class reason token paralleling `malformed mcp` (filed under `FAILURE_REASONS`, not the unsupported family); the `REASONS` tuple amendment is byte-stable (OUT-08) (WARN-01, CLASS-01).
   5. A skill or command that already parses, has a non-empty `description`, and has no `when_to_use` to fold is written byte-for-byte as it is today: the source is parsed as attribution ground truth, the written skill `name` is verified to equal the generated name (a folded or multi-line source scalar cannot silently corrupt it), and the staged bytes are re-parsed as a self-inflicted-defect backstop — all with no behavior change for the ~99% that already work (NREG-01, SKILL-03, PARSE-02).
 
-**Plans**: 5 plans
+**Plans**: 1/5 plans executed
 
 Plans:
 **Wave 1**
 
-- [ ] 86-01-PLAN.md — Foundation: `parseFrontmatter` re-export, `malformed skill`/`malformed command` catalog tokens, and the skills degrade-helper module (SKILL-02/WTU helpers)
+- [x] 86-01-PLAN.md — Foundation: `parseFrontmatter` re-export, `malformed skill`/`malformed command` catalog tokens, and the skills degrade-helper module (SKILL-02/WTU helpers)
 
 **Wave 2** *(blocked on Wave 1 completion)*
 
@@ -68,5 +68,5 @@ Single phase: 86
 
 | Phase | Milestone | Plans Complete | Status | Completed |
 |-------|-----------|----------------|--------|-----------|
-| 86. Skill and command frontmatter compliance | v1.15 | 0/5 | Not started | — |
+| 86. Skill and command frontmatter compliance | v1.15 | 1/5 | In Progress|  |
 | 85. `mcpServers` string file-path references | v1.14 | 2/2 | Complete | 2026-07-23 |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -16,7 +16,7 @@
 
 - Decimal phases (86.1, 86.2): Urgent insertions (marked with INSERTED).
 
-- [ ] **Phase 86: Skill and command frontmatter compliance** — The skills and commands bridges parse source frontmatter with Pi's own `parseFrontmatter` before rewriting, never stage bytes Pi rejects, degrade a broken skill (synthesized `disable-model-invocation` block, body verbatim) or command (neutralized, name-from-filename) at Claude-Code parity, fold a skill's `when_to_use` into the description Pi actually reads, and surface + classify each failure as a warning — while the ~99% of already-valid components stay byte-for-byte unchanged (GitHub issue #101).
+- [x] **Phase 86: Skill and command frontmatter compliance** — The skills and commands bridges parse source frontmatter with Pi's own `parseFrontmatter` before rewriting, never stage bytes Pi rejects, degrade a broken skill (synthesized `disable-model-invocation` block, body verbatim) or command (neutralized, name-from-filename) at Claude-Code parity, fold a skill's `when_to_use` into the description Pi actually reads, and surface + classify each failure as a warning — while the ~99% of already-valid components stay byte-for-byte unchanged (GitHub issue #101). (completed 2026-07-26)
 
 <details>
 <summary>✅ v1.14 mcp-string-refs (Phase 85) — SHIPPED 2026-07-23</summary>
@@ -68,5 +68,5 @@ Single phase: 86
 
 | Phase | Milestone | Plans Complete | Status | Completed |
 |-------|-----------|----------------|--------|-----------|
-| 86. Skill and command frontmatter compliance | v1.15 | 5/5 | In Progress|  |
+| 86. Skill and command frontmatter compliance | v1.15 | 5/5 | Complete    | 2026-07-26 |
 | 85. `mcpServers` string file-path references | v1.14 | 2/2 | Complete | 2026-07-23 |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -13,6 +13,7 @@
 
 - Integer phases (86): Planned milestone work (continues the global counter from
   Phase 85, the v1.14 mcp-string-refs phase).
+
 - Decimal phases (86.1, 86.2): Urgent insertions (marked with INSERTED).
 
 - [ ] **Phase 86: Skill and command frontmatter compliance** — The skills and commands bridges parse source frontmatter with Pi's own `parseFrontmatter` before rewriting, never stage bytes Pi rejects, degrade a broken skill (synthesized `disable-model-invocation` block, body verbatim) or command (neutralized, name-from-filename) at Claude-Code parity, fold a skill's `when_to_use` into the description Pi actually reads, and surface + classify each failure as a warning — while the ~99% of already-valid components stay byte-for-byte unchanged (GitHub issue #101).
@@ -46,8 +47,16 @@
 **Plans**: 5 plans
 
 Plans:
+**Wave 1**
+
 - [ ] 86-01-PLAN.md — Foundation: `parseFrontmatter` re-export, `malformed skill`/`malformed command` catalog tokens, and the skills degrade-helper module (SKILL-02/WTU helpers)
+
+**Wave 2** *(blocked on Wave 1 completion)*
+
 - [ ] 86-02-PLAN.md — Tracer: end-to-end unparseable-skill degrade (source+staged gates, synth block, degrade-record wire, standalone `(installed) {malformed skill}`) + NREG byte-equality
+
+**Wave 3** *(blocked on Wave 2 completion)*
+
 - [ ] 86-03-PLAN.md — Skill augment arms: first-paragraph description, `when_to_use` fold + 1,536 truncation, SKILL-03 name verification
 - [ ] 86-04-PLAN.md — Command neutralize: parse gates + strip-malformed-block so Pi loads name-from-filename + first-body-line (CMD-01)
 - [ ] 86-05-PLAN.md — Orchestrated reason-token wire: `PluginInstalledOutcome.degradedKinds` -> reconcile row token at warning severity + redacted detail (WARN-01)

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -2,11 +2,20 @@
 
 ## Milestones
 
+- 🚧 **v1.15 frontmatter-compliance** — Phase 86 (in progress, target npm 0.12.0) — skills & commands bridge frontmatter parity with Claude Code (issue #101)
 - ✅ **v1.14 mcp-string-refs** — Phase 85 (shipped 2026-07-23) — full detail: `milestones/v1.14-ROADMAP.md`
 
-_No active milestone. Run `/gsd-new-milestone` to start the next one (continue the global phase counter from Phase 85)._
-
 ## Phases
+
+### In progress v1.15 frontmatter-compliance
+
+**Phase Numbering:**
+
+- Integer phases (86): Planned milestone work (continues the global counter from
+  Phase 85, the v1.14 mcp-string-refs phase).
+- Decimal phases (86.1, 86.2): Urgent insertions (marked with INSERTED).
+
+- [ ] **Phase 86: Skill and command frontmatter compliance** — The skills and commands bridges parse source frontmatter with Pi's own `parseFrontmatter` before rewriting, never stage bytes Pi rejects, degrade a broken skill (synthesized `disable-model-invocation` block, body verbatim) or command (neutralized, name-from-filename) at Claude-Code parity, fold a skill's `when_to_use` into the description Pi actually reads, and surface + classify each failure as a warning — while the ~99% of already-valid components stay byte-for-byte unchanged (GitHub issue #101).
 
 <details>
 <summary>✅ v1.14 mcp-string-refs (Phase 85) — SHIPPED 2026-07-23</summary>
@@ -19,8 +28,29 @@ _No active milestone. Run `/gsd-new-milestone` to start the next one (continue t
 
 </details>
 
+## Phase Details
+
+### Phase 86: Skill and command frontmatter compliance
+
+**Goal**: The skills and commands bridges reach observable parity with Claude Code's frontmatter-loading behavior. Source frontmatter is parsed with Pi's own `parseFrontmatter` (re-exported through the `platform/pi-api.ts` boundary) *before* name-rewrite and variable substitution — establishing attribution ground truth and the degrade trigger — and the staged bytes are re-parsed afterward as a Pi-acceptability backstop. A skill whose source cannot be parsed installs with a synthesized `disable-model-invocation` block (body verbatim); a command whose source cannot be parsed installs neutralized (name-from-filename, description-from-first-body-line); a description-less skill gets a first-paragraph fallback; `when_to_use` triggers are folded into the description Pi reads. Every degraded/neutralized component surfaces an install-time warning row classified under a new `FAILURE_REASONS` token paralleling `malformed mcp`. The ~99% of already-valid components are written byte-for-byte unchanged.
+**Depends on**: Nothing (single phase of this milestone; extends the existing skills/commands staging seams — `bridges/skills/stage.ts`, `bridges/skills/rewrite-frontmatter.ts`, `bridges/commands/stage.ts` — the `platform/pi-api.ts` Pi-API boundary, and the `shared/notify-reasons.ts` REASONS tuple).
+**Requirements**: PARSE-01, PARSE-02, SKILL-01, SKILL-02, SKILL-03, WTU-01, WTU-02, CMD-01, WARN-01, CLASS-01, NREG-01
+**Success Criteria** (what must be TRUE):
+
+  1. A skill whose source frontmatter cannot be parsed still installs (the plugin never hard-fails); after `/reload`, `/skill:<generated-name>` resolves and the model never auto-invokes it — the synthesized frontmatter block carries the generated `name`, a short fixed placeholder `description`, and `disable-model-invocation: true`, with the markdown body preserved verbatim, matching Claude Code's observable malformed-skill behavior (SKILL-01, PARSE-01).
+  2. A skill with an absent or empty `description` (well-formed frontmatter) installs with a first-paragraph-of-body fallback description and stays model-invocable; a skill's `when_to_use` text is appended to the Pi `description`, and the combined text is truncated at 1,536 characters — so a converted skill keeps its auto-invocation triggers even though Pi's loader reads only `description` (SKILL-02, WTU-01, WTU-02).
+  3. A command whose source frontmatter cannot be parsed still loads after `/reload`, taking its name from the filename and its description from the first body line — the literal Claude Code malformed-command behavior, with no synthesized placeholder and no disable flag (Pi's command loader has no non-empty-description gate) (CMD-01).
+  4. Each degraded skill or neutralized command emits an install-time warning row naming the source component and its parse error — the surfaced analog of Claude Code's `--debug`-only message — classified as a new failure-class reason token paralleling `malformed mcp` (filed under `FAILURE_REASONS`, not the unsupported family); the `REASONS` tuple amendment is byte-stable (OUT-08) (WARN-01, CLASS-01).
+  5. A skill or command that already parses, has a non-empty `description`, and has no `when_to_use` to fold is written byte-for-byte as it is today: the source is parsed as attribution ground truth, the written skill `name` is verified to equal the generated name (a folded or multi-line source scalar cannot silently corrupt it), and the staged bytes are re-parsed as a self-inflicted-defect backstop — all with no behavior change for the ~99% that already work (NREG-01, SKILL-03, PARSE-02).
+
+**Plans**: TBD
+
 ## Progress
+
+**Execution Order:**
+Single phase: 86
 
 | Phase | Milestone | Plans Complete | Status | Completed |
 |-------|-----------|----------------|--------|-----------|
+| 86. Skill and command frontmatter compliance | v1.15 | 0/? | Not started | — |
 | 85. `mcpServers` string file-path references | v1.14 | 2/2 | Complete | 2026-07-23 |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -44,7 +44,7 @@
   4. Each degraded skill or neutralized command emits an install-time warning row naming the source component and its parse error — the surfaced analog of Claude Code's `--debug`-only message — classified as a new failure-class reason token paralleling `malformed mcp` (filed under `FAILURE_REASONS`, not the unsupported family); the `REASONS` tuple amendment is byte-stable (OUT-08) (WARN-01, CLASS-01).
   5. A skill or command that already parses, has a non-empty `description`, and has no `when_to_use` to fold is written byte-for-byte as it is today: the source is parsed as attribution ground truth, the written skill `name` is verified to equal the generated name (a folded or multi-line source scalar cannot silently corrupt it), and the staged bytes are re-parsed as a self-inflicted-defect backstop — all with no behavior change for the ~99% that already work (NREG-01, SKILL-03, PARSE-02).
 
-**Plans**: 4/5 plans executed
+**Plans**: 5/5 plans executed
 
 Plans:
 **Wave 1**
@@ -59,7 +59,7 @@ Plans:
 
 - [x] 86-03-PLAN.md — Skill augment arms: first-paragraph description, `when_to_use` fold + 1,536 truncation, SKILL-03 name verification
 - [x] 86-04-PLAN.md — Command neutralize: parse gates + strip-malformed-block so Pi loads name-from-filename + first-body-line (CMD-01)
-- [ ] 86-05-PLAN.md — Orchestrated reason-token wire: `PluginInstalledOutcome.degradedKinds` -> reconcile row token at warning severity + redacted detail (WARN-01)
+- [x] 86-05-PLAN.md — Orchestrated reason-token wire: `PluginInstalledOutcome.degradedKinds` -> reconcile row token at warning severity + redacted detail (WARN-01)
 
 ## Progress
 
@@ -68,5 +68,5 @@ Single phase: 86
 
 | Phase | Milestone | Plans Complete | Status | Completed |
 |-------|-----------|----------------|--------|-----------|
-| 86. Skill and command frontmatter compliance | v1.15 | 4/5 | In Progress|  |
+| 86. Skill and command frontmatter compliance | v1.15 | 5/5 | In Progress|  |
 | 85. `mcpServers` string file-path references | v1.14 | 2/2 | Complete | 2026-07-23 |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -44,7 +44,7 @@
   4. Each degraded skill or neutralized command emits an install-time warning row naming the source component and its parse error — the surfaced analog of Claude Code's `--debug`-only message — classified as a new failure-class reason token paralleling `malformed mcp` (filed under `FAILURE_REASONS`, not the unsupported family); the `REASONS` tuple amendment is byte-stable (OUT-08) (WARN-01, CLASS-01).
   5. A skill or command that already parses, has a non-empty `description`, and has no `when_to_use` to fold is written byte-for-byte as it is today: the source is parsed as attribution ground truth, the written skill `name` is verified to equal the generated name (a folded or multi-line source scalar cannot silently corrupt it), and the staged bytes are re-parsed as a self-inflicted-defect backstop — all with no behavior change for the ~99% that already work (NREG-01, SKILL-03, PARSE-02).
 
-**Plans**: 1/5 plans executed
+**Plans**: 2/5 plans executed
 
 Plans:
 **Wave 1**
@@ -53,7 +53,7 @@ Plans:
 
 **Wave 2** *(blocked on Wave 1 completion)*
 
-- [ ] 86-02-PLAN.md — Tracer: end-to-end unparseable-skill degrade (source+staged gates, synth block, degrade-record wire, standalone `(installed) {malformed skill}`) + NREG byte-equality
+- [x] 86-02-PLAN.md — Tracer: end-to-end unparseable-skill degrade (source+staged gates, synth block, degrade-record wire, standalone `(installed) {malformed skill}`) + NREG byte-equality
 
 **Wave 3** *(blocked on Wave 2 completion)*
 
@@ -68,5 +68,5 @@ Single phase: 86
 
 | Phase | Milestone | Plans Complete | Status | Completed |
 |-------|-----------|----------------|--------|-----------|
-| 86. Skill and command frontmatter compliance | v1.15 | 1/5 | In Progress|  |
+| 86. Skill and command frontmatter compliance | v1.15 | 2/5 | In Progress|  |
 | 85. `mcpServers` string file-path references | v1.14 | 2/2 | Complete | 2026-07-23 |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -44,7 +44,7 @@
   4. Each degraded skill or neutralized command emits an install-time warning row naming the source component and its parse error — the surfaced analog of Claude Code's `--debug`-only message — classified as a new failure-class reason token paralleling `malformed mcp` (filed under `FAILURE_REASONS`, not the unsupported family); the `REASONS` tuple amendment is byte-stable (OUT-08) (WARN-01, CLASS-01).
   5. A skill or command that already parses, has a non-empty `description`, and has no `when_to_use` to fold is written byte-for-byte as it is today: the source is parsed as attribution ground truth, the written skill `name` is verified to equal the generated name (a folded or multi-line source scalar cannot silently corrupt it), and the staged bytes are re-parsed as a self-inflicted-defect backstop — all with no behavior change for the ~99% that already work (NREG-01, SKILL-03, PARSE-02).
 
-**Plans**: 2/5 plans executed
+**Plans**: 3/5 plans executed
 
 Plans:
 **Wave 1**
@@ -57,7 +57,7 @@ Plans:
 
 **Wave 3** *(blocked on Wave 2 completion)*
 
-- [ ] 86-03-PLAN.md — Skill augment arms: first-paragraph description, `when_to_use` fold + 1,536 truncation, SKILL-03 name verification
+- [x] 86-03-PLAN.md — Skill augment arms: first-paragraph description, `when_to_use` fold + 1,536 truncation, SKILL-03 name verification
 - [ ] 86-04-PLAN.md — Command neutralize: parse gates + strip-malformed-block so Pi loads name-from-filename + first-body-line (CMD-01)
 - [ ] 86-05-PLAN.md — Orchestrated reason-token wire: `PluginInstalledOutcome.degradedKinds` -> reconcile row token at warning severity + redacted detail (WARN-01)
 
@@ -68,5 +68,5 @@ Single phase: 86
 
 | Phase | Milestone | Plans Complete | Status | Completed |
 |-------|-----------|----------------|--------|-----------|
-| 86. Skill and command frontmatter compliance | v1.15 | 2/5 | In Progress|  |
+| 86. Skill and command frontmatter compliance | v1.15 | 3/5 | In Progress|  |
 | 85. `mcpServers` string file-path references | v1.14 | 2/2 | Complete | 2026-07-23 |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -44,7 +44,7 @@
   4. Each degraded skill or neutralized command emits an install-time warning row naming the source component and its parse error — the surfaced analog of Claude Code's `--debug`-only message — classified as a new failure-class reason token paralleling `malformed mcp` (filed under `FAILURE_REASONS`, not the unsupported family); the `REASONS` tuple amendment is byte-stable (OUT-08) (WARN-01, CLASS-01).
   5. A skill or command that already parses, has a non-empty `description`, and has no `when_to_use` to fold is written byte-for-byte as it is today: the source is parsed as attribution ground truth, the written skill `name` is verified to equal the generated name (a folded or multi-line source scalar cannot silently corrupt it), and the staged bytes are re-parsed as a self-inflicted-defect backstop — all with no behavior change for the ~99% that already work (NREG-01, SKILL-03, PARSE-02).
 
-**Plans**: 3/5 plans executed
+**Plans**: 4/5 plans executed
 
 Plans:
 **Wave 1**
@@ -58,7 +58,7 @@ Plans:
 **Wave 3** *(blocked on Wave 2 completion)*
 
 - [x] 86-03-PLAN.md — Skill augment arms: first-paragraph description, `when_to_use` fold + 1,536 truncation, SKILL-03 name verification
-- [ ] 86-04-PLAN.md — Command neutralize: parse gates + strip-malformed-block so Pi loads name-from-filename + first-body-line (CMD-01)
+- [x] 86-04-PLAN.md — Command neutralize: parse gates + strip-malformed-block so Pi loads name-from-filename + first-body-line (CMD-01)
 - [ ] 86-05-PLAN.md — Orchestrated reason-token wire: `PluginInstalledOutcome.degradedKinds` -> reconcile row token at warning severity + redacted detail (WARN-01)
 
 ## Progress
@@ -68,5 +68,5 @@ Single phase: 86
 
 | Phase | Milestone | Plans Complete | Status | Completed |
 |-------|-----------|----------------|--------|-----------|
-| 86. Skill and command frontmatter compliance | v1.15 | 3/5 | In Progress|  |
+| 86. Skill and command frontmatter compliance | v1.15 | 4/5 | In Progress|  |
 | 85. `mcpServers` string file-path references | v1.14 | 2/2 | Complete | 2026-07-23 |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -43,7 +43,14 @@
   4. Each degraded skill or neutralized command emits an install-time warning row naming the source component and its parse error — the surfaced analog of Claude Code's `--debug`-only message — classified as a new failure-class reason token paralleling `malformed mcp` (filed under `FAILURE_REASONS`, not the unsupported family); the `REASONS` tuple amendment is byte-stable (OUT-08) (WARN-01, CLASS-01).
   5. A skill or command that already parses, has a non-empty `description`, and has no `when_to_use` to fold is written byte-for-byte as it is today: the source is parsed as attribution ground truth, the written skill `name` is verified to equal the generated name (a folded or multi-line source scalar cannot silently corrupt it), and the staged bytes are re-parsed as a self-inflicted-defect backstop — all with no behavior change for the ~99% that already work (NREG-01, SKILL-03, PARSE-02).
 
-**Plans**: TBD
+**Plans**: 5 plans
+
+Plans:
+- [ ] 86-01-PLAN.md — Foundation: `parseFrontmatter` re-export, `malformed skill`/`malformed command` catalog tokens, and the skills degrade-helper module (SKILL-02/WTU helpers)
+- [ ] 86-02-PLAN.md — Tracer: end-to-end unparseable-skill degrade (source+staged gates, synth block, degrade-record wire, standalone `(installed) {malformed skill}`) + NREG byte-equality
+- [ ] 86-03-PLAN.md — Skill augment arms: first-paragraph description, `when_to_use` fold + 1,536 truncation, SKILL-03 name verification
+- [ ] 86-04-PLAN.md — Command neutralize: parse gates + strip-malformed-block so Pi loads name-from-filename + first-body-line (CMD-01)
+- [ ] 86-05-PLAN.md — Orchestrated reason-token wire: `PluginInstalledOutcome.degradedKinds` -> reconcile row token at warning severity + redacted detail (WARN-01)
 
 ## Progress
 
@@ -52,5 +59,5 @@ Single phase: 86
 
 | Phase | Milestone | Plans Complete | Status | Completed |
 |-------|-----------|----------------|--------|-----------|
-| 86. Skill and command frontmatter compliance | v1.15 | 0/? | Not started | — |
+| 86. Skill and command frontmatter compliance | v1.15 | 0/5 | Not started | — |
 | 85. `mcpServers` string file-path references | v1.14 | 2/2 | Complete | 2026-07-23 |

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,10 +3,10 @@ gsd_state_version: 1.0
 milestone: v1.15
 milestone_name: frontmatter-compliance
 status: planning
-last_updated: "2026-07-26T03:01:59.228Z"
+last_updated: "2026-07-26T03:10:56.000Z"
 last_activity: 2026-07-25
 progress:
-  total_phases: 0
+  total_phases: 1
   completed_phases: 0
   total_plans: 0
   completed_plans: 0
@@ -17,41 +17,73 @@ progress:
 
 ## Current Position
 
-Phase: Not started (defining requirements)
+Phase: 86 — Skill and command frontmatter compliance (not started)
 Plan: —
-Status: Defining requirements
-Last activity: 2026-07-25 — Milestone v1.15 started
+Status: Roadmap created; ready to plan Phase 86
+Last activity: 2026-07-25 — Milestone v1.15 roadmap created (1 phase, 11/11 requirements mapped)
 
 ## Roadmap Summary
 
-- 1 phase (Phase 85), continuing the global counter from Phase 84 (agent-skill-preloads).
-- All four requirements resolve in one seam: `domain/resolver.ts::applyStrictMcp`
-  string-reference resolution (before `applyMcpValue`) + `assertPathInside` containment.
+- 1 phase (Phase 86), continuing the global counter from Phase 85 (v1.14
+  mcp-string-refs).
+- All 11 requirements (PARSE-01/02, SKILL-01/02/03, WTU-01/02, CMD-01, WARN-01,
+  CLASS-01, NREG-01) land in one cohesive phase. Rationale: the two-gate parse model
+  spans BOTH the skills and commands staging seams (PARSE-01), and the new
+  failure-class REASONS token (CLASS-01), the install-time warning surface (WARN-01),
+  and the verbatim-write guarantee (NREG-01) are shared machinery both bridges consume.
+  The only bridge-specific work is skill *synthesize* (SKILL-01/02/03 + WTU folding) vs
+  command *neutralize* (CMD-01). Splitting skills-from-commands would strand a
+  single-requirement commands phase or leave a parse gate wired but degradation
+  deferred — both anti-patterns. One phase delivers the whole capability.
 
-- Locked design decisions carried into the phase: resolve in the resolver layer (not
-  the cached manifest loader); referenced file is a WRAPPED `.mcp.json` only; malformed
-  / missing / out-of-root reference → single `(unavailable)` plugin, never a
-  whole-manifest throw and never a soft-degrade; D-14 symlink refusal stays strict;
-  `plugin.json` `mcpServers` array form deferred (MCPR-F1).
+- Locked design decisions carried into the phase (from
+  `docs/research/issue-101-skill-frontmatter-diagnosis.md`):
+  - Mirror Claude Code's *observable* behavior via Pi's own machinery — literal
+    empty-metadata parity is impossible (Pi returns `skill: null` on empty
+    description). Unparseable skill → synthesized `disable-model-invocation: true`
+    block + short fixed placeholder description, body verbatim, install never
+    hard-fails. Unparseable command → neutralize (Pi's command loader has no
+    non-empty-description gate).
+  - Parse with Pi's own `parseFrontmatter` (public root export since peer floor
+    `>=0.74.0`; import via the `platform/pi-api.ts` boundary for byte-identical
+    accept/reject). Verify it was already exported at the declared floor.
+  - Two gates: source frontmatter parsed BEFORE rewrite/substitution (attribution +
+    trigger); staged bytes re-parsed AFTER as a Pi-acceptability backstop (a valid
+    source whose staged output fails is self-inflicted — loud/test-guarded, never
+    attributed to the author).
+  - `when_to_use` appended to the Pi `description`, combined text truncated at 1,536
+    chars (Claude Code's skill-listing cap).
+  - Written skill `name` verified against the parsed value (catches folded-scalar
+    corruption), not a blind line regex.
+  - Classification: failure-class, not soft-degrade — a malformation of a *supported*
+    component. New token parallels `malformed mcp` in `FAILURE_REASONS`; `REASONS`
+    tuple amendment stays byte-stable (OUT-08).
+  - Rejected approaches (do NOT rebuild): quote-repair heuristic; whole-block re-emit
+    (agents-bridge style) — skills' target format is real structured YAML.
+  - The diagnosis doc's Prevalence section is STALE: its two example skills were fixed
+    upstream in `acolomba/claude-plugins` PR #17 (`>-` block scalars). The code gap
+    remains real for third-party plugins (issue #101 is against another plugin). The
+    bridge does NOT corrupt a valid source; the fix is a robustness/compliance gate.
 
 ## Session
 
-**Last session:** 2026-07-25T02:13:21.956Z
-**Stopped at:** context exhaustion at 75% (2026-07-25)
+**Last session:** 2026-07-25
+**Stopped at:** Roadmap created for v1.15; Phase 86 ready to plan
 **Resume file:** None
 
 ## Performance Metrics
 
+No plans executed yet for v1.15.
+
 | Plan | Duration | Tasks | Files |
 |------|----------|-------|-------|
-| Phase 85 P01 | 45min | 2 tasks | 4 files |
-| Phase 85 P02 | 35m | 2 tasks | 6 files |
+| —    | —        | —     | —     |
 
 ## Decisions
 
-- [Phase ?]: MCPR: string mcpServers reference resolved in applyStrictMcp string branch; field union widened, server-map validator untouched (D-01/D-04)
-- [Phase ?]: D-02: {malformed mcp} filed failure-class (FAILURE_REASONS), not unsupported; REASONS 34 -> 35
-- [Phase ?]: narrowResolverNotes matches full 'malformed mcp reference' prefix before catch-all; inline 'malformed mcpServers' stays {unsupported source}
+None recorded yet for v1.15 (design decisions are pre-captured in the Roadmap Summary
+above and in `docs/research/issue-101-skill-frontmatter-diagnosis.md`). Plan-phase and
+execution will record per-plan decisions here.
 
 ## Deferred Items
 
@@ -60,6 +92,7 @@ pre-existing (none from v1.14 mcp-string-refs).
 
 | Category | Item | Status |
 |----------|------|--------|
+| backlog | REASON-01 — unify all parse-error reasons under a `{malformed <feature>}` family | deferred (v1.15 adds one more failure-class member; broad unification stays out of scope) |
 | debug | knowledge-base | unknown |
 | quick_task | 260621-kmm-add-explicit-enabled-boolean-field-to-pl | unknown |
 | quick_task | 260718-tli-fix-pr-88-external-contribution-to-pass- | unknown |
@@ -68,4 +101,4 @@ pre-existing (none from v1.14 mcp-string-refs).
 
 ## Operator Next Steps
 
-- Start the next milestone with /gsd-new-milestone
+- Plan Phase 86 with `/gsd-plan-phase 86`

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -5,15 +5,15 @@ milestone_name: frontmatter-compliance
 current_phase: 86
 current_phase_name: Skill and command frontmatter compliance
 status: executing
-stopped_at: Completed 86-03-PLAN.md
-last_updated: "2026-07-26T13:50:05.720Z"
+stopped_at: Completed 86-04-PLAN.md
+last_updated: "2026-07-26T14:05:46.457Z"
 last_activity: 2026-07-26
 last_activity_desc: Phase 86 execution started
 progress:
   total_phases: 1
   completed_phases: 0
   total_plans: 5
-  completed_plans: 3
+  completed_plans: 4
   percent: 0
 ---
 
@@ -22,7 +22,7 @@ progress:
 ## Current Position
 
 Phase: 86 (Skill and command frontmatter compliance) — EXECUTING
-Plan: 4 of 5
+Plan: 5 of 5
 Status: Ready to execute
 Last activity: 2026-07-26 — Phase 86 execution started
 
@@ -80,8 +80,8 @@ Last activity: 2026-07-26 — Phase 86 execution started
 
 ## Session
 
-**Last session:** 2026-07-26T13:49:39.941Z
-**Stopped at:** Completed 86-03-PLAN.md
+**Last session:** 2026-07-26T14:05:46.432Z
+**Stopped at:** Completed 86-04-PLAN.md
 **Resume file:** None
 
 ## Performance Metrics
@@ -94,6 +94,7 @@ No plans executed yet for v1.15.
 | Phase 86 P01 | 35min | 3 tasks | 11 files |
 | Phase 86 P02 | 36min | 2 tasks | 10 files |
 | Phase 86 P03 | 45min | 2 tasks | 5 files |
+| Phase 86 P04 | 22min | 1 tasks | 3 files |
 
 ## Decisions
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -4,17 +4,17 @@ milestone: v1.15
 milestone_name: frontmatter-compliance
 current_phase: 86
 current_phase_name: Skill and command frontmatter compliance
-status: executing
-stopped_at: Completed 86-04-PLAN.md
-last_updated: "2026-07-26T14:05:46.457Z"
+status: verifying
+stopped_at: Completed 86-05-PLAN.md
+last_updated: "2026-07-26T14:28:09.078Z"
 last_activity: 2026-07-26
 last_activity_desc: Phase 86 execution started
 progress:
   total_phases: 1
-  completed_phases: 0
+  completed_phases: 1
   total_plans: 5
-  completed_plans: 4
-  percent: 0
+  completed_plans: 5
+  percent: 100
 ---
 
 # Project State
@@ -23,7 +23,7 @@ progress:
 
 Phase: 86 (Skill and command frontmatter compliance) — EXECUTING
 Plan: 5 of 5
-Status: Ready to execute
+Status: Phase complete — ready for verification
 Last activity: 2026-07-26 — Phase 86 execution started
 
 ## Roadmap Summary
@@ -80,8 +80,8 @@ Last activity: 2026-07-26 — Phase 86 execution started
 
 ## Session
 
-**Last session:** 2026-07-26T14:05:46.432Z
-**Stopped at:** Completed 86-04-PLAN.md
+**Last session:** 2026-07-26T14:27:52.840Z
+**Stopped at:** Completed 86-05-PLAN.md
 **Resume file:** None
 
 ## Performance Metrics
@@ -95,6 +95,7 @@ No plans executed yet for v1.15.
 | Phase 86 P02 | 36min | 2 tasks | 10 files |
 | Phase 86 P03 | 45min | 2 tasks | 5 files |
 | Phase 86 P04 | 22min | 1 tasks | 3 files |
+| Phase 86 P05 | 30min | 1 tasks | 5 files |
 
 ## Decisions
 
@@ -110,6 +111,8 @@ execution will record per-plan decisions here.
 - [Phase ?]: 86-03: augment arm runs only on the gate-1 RETURN branch; NREG-01 keeps a present in-cap description with no when_to_use byte-identical
 - [Phase ?]: 86-03: description-less+bodyless skills fall back to a fixed non-empty placeholder so Pi does not drop them (skill:null on empty description)
 - [Phase ?]: 86-03: SKILL-03 name safety = full name-node-span replacement + re-parse assertion that written name equals generated name
+- [Phase ?]: WARN-01 orchestrated surface: reconcile (installed) row raised to warning with one malformed skill/command token per kind; degraded-but-installed keeps (installed), not (partially-installed) (D-86-03)
+- [Phase ?]: redactAbsolutePaths applied at the surfacePostCommitWarnings emission seam so all post-commit warnings are redacted before notifyDiagnostic (T-86-03/NFR-9)
 
 ## Deferred Items
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,16 +3,17 @@ gsd_state_version: 1.0
 milestone: v1.15
 milestone_name: frontmatter-compliance
 current_phase: 86
-status: planning
-stopped_at: Phase 86 context gathered
-last_updated: "2026-07-26T10:46:58.166Z"
-last_activity: 2026-07-25
-last_activity_desc: Milestone v1.15 roadmap created (1 phase, 11/11 requirements mapped)
+current_phase_name: Skill and command frontmatter compliance
+status: executing
+stopped_at: Completed 86-01-PLAN.md
+last_updated: "2026-07-26T12:31:11.786Z"
+last_activity: 2026-07-26
+last_activity_desc: Phase 86 execution started
 progress:
   total_phases: 1
   completed_phases: 0
-  total_plans: 0
-  completed_plans: 0
+  total_plans: 5
+  completed_plans: 1
   percent: 0
 ---
 
@@ -20,10 +21,10 @@ progress:
 
 ## Current Position
 
-Phase: 86 — Skill and command frontmatter compliance (not started)
-Plan: —
-Status: Roadmap created; ready to plan Phase 86
-Last activity: 2026-07-25 — Milestone v1.15 roadmap created (1 phase, 11/11 requirements mapped)
+Phase: 86 (Skill and command frontmatter compliance) — EXECUTING
+Plan: 2 of 5
+Status: Ready to execute
+Last activity: 2026-07-26 — Phase 86 execution started
 
 ## Roadmap Summary
 
@@ -79,9 +80,9 @@ Last activity: 2026-07-25 — Milestone v1.15 roadmap created (1 phase, 11/11 re
 
 ## Session
 
-**Last session:** 2026-07-26T10:46:58.135Z
-**Stopped at:** Phase 86 context gathered
-**Resume file:** .planning/phases/86-skill-and-command-frontmatter-compliance/86-CONTEXT.md
+**Last session:** 2026-07-26T12:31:11.760Z
+**Stopped at:** Completed 86-01-PLAN.md
+**Resume file:** None
 
 ## Performance Metrics
 
@@ -90,12 +91,17 @@ No plans executed yet for v1.15.
 | Plan | Duration | Tasks | Files |
 |------|----------|-------|-------|
 | —    | —        | —     | —     |
+| Phase 86 P01 | 35min | 3 tasks | 11 files |
 
 ## Decisions
 
 None recorded yet for v1.15 (design decisions are pre-captured in the Roadmap Summary
 above and in `docs/research/issue-101-skill-frontmatter-diagnosis.md`). Plan-phase and
 execution will record per-plan decisions here.
+
+- [Phase 86]: parseFrontmatter re-exported through platform/pi-api.ts as the sole sanctioned import site (PARSE-01)
+- [Phase 86]: REASONS catalog amended 35->37 with per-kind malformed skill / malformed command under FAILURE_REASONS (D-86-01 / CLASS-01)
+- [Phase 86]: setDescriptionScalar replaces the full description node span incl. block scalars, never a lone description: line (SKILL-03 corruption class)
 
 ## Deferred Items
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,9 +2,12 @@
 gsd_state_version: 1.0
 milestone: v1.15
 milestone_name: frontmatter-compliance
+current_phase: 86
 status: planning
-last_updated: "2026-07-26T03:10:56.000Z"
+stopped_at: Phase 86 context gathered
+last_updated: "2026-07-26T10:46:58.166Z"
 last_activity: 2026-07-25
+last_activity_desc: Milestone v1.15 roadmap created (1 phase, 11/11 requirements mapped)
 progress:
   total_phases: 1
   completed_phases: 0
@@ -26,6 +29,7 @@ Last activity: 2026-07-25 — Milestone v1.15 roadmap created (1 phase, 11/11 re
 
 - 1 phase (Phase 86), continuing the global counter from Phase 85 (v1.14
   mcp-string-refs).
+
 - All 11 requirements (PARSE-01/02, SKILL-01/02/03, WTU-01/02, CMD-01, WARN-01,
   CLASS-01, NREG-01) land in one cohesive phase. Rationale: the two-gate parse model
   spans BOTH the skills and commands staging seams (PARSE-01), and the new
@@ -38,28 +42,36 @@ Last activity: 2026-07-25 — Milestone v1.15 roadmap created (1 phase, 11/11 re
 
 - Locked design decisions carried into the phase (from
   `docs/research/issue-101-skill-frontmatter-diagnosis.md`):
+
   - Mirror Claude Code's *observable* behavior via Pi's own machinery — literal
     empty-metadata parity is impossible (Pi returns `skill: null` on empty
     description). Unparseable skill → synthesized `disable-model-invocation: true`
     block + short fixed placeholder description, body verbatim, install never
     hard-fails. Unparseable command → neutralize (Pi's command loader has no
     non-empty-description gate).
+
   - Parse with Pi's own `parseFrontmatter` (public root export since peer floor
     `>=0.74.0`; import via the `platform/pi-api.ts` boundary for byte-identical
     accept/reject). Verify it was already exported at the declared floor.
+
   - Two gates: source frontmatter parsed BEFORE rewrite/substitution (attribution +
     trigger); staged bytes re-parsed AFTER as a Pi-acceptability backstop (a valid
     source whose staged output fails is self-inflicted — loud/test-guarded, never
     attributed to the author).
+
   - `when_to_use` appended to the Pi `description`, combined text truncated at 1,536
     chars (Claude Code's skill-listing cap).
+
   - Written skill `name` verified against the parsed value (catches folded-scalar
     corruption), not a blind line regex.
+
   - Classification: failure-class, not soft-degrade — a malformation of a *supported*
     component. New token parallels `malformed mcp` in `FAILURE_REASONS`; `REASONS`
     tuple amendment stays byte-stable (OUT-08).
+
   - Rejected approaches (do NOT rebuild): quote-repair heuristic; whole-block re-emit
     (agents-bridge style) — skills' target format is real structured YAML.
+
   - The diagnosis doc's Prevalence section is STALE: its two example skills were fixed
     upstream in `acolomba/claude-plugins` PR #17 (`>-` block scalars). The code gap
     remains real for third-party plugins (issue #101 is against another plugin). The
@@ -67,9 +79,9 @@ Last activity: 2026-07-25 — Milestone v1.15 roadmap created (1 phase, 11/11 re
 
 ## Session
 
-**Last session:** 2026-07-25
-**Stopped at:** Roadmap created for v1.15; Phase 86 ready to plan
-**Resume file:** None
+**Last session:** 2026-07-26T10:46:58.135Z
+**Stopped at:** Phase 86 context gathered
+**Resume file:** .planning/phases/86-skill-and-command-frontmatter-compliance/86-CONTEXT.md
 
 ## Performance Metrics
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -5,15 +5,15 @@ milestone_name: frontmatter-compliance
 current_phase: 86
 current_phase_name: Skill and command frontmatter compliance
 status: executing
-stopped_at: Completed 86-02-PLAN.md
-last_updated: "2026-07-26T13:17:46.479Z"
+stopped_at: Completed 86-03-PLAN.md
+last_updated: "2026-07-26T13:50:05.720Z"
 last_activity: 2026-07-26
 last_activity_desc: Phase 86 execution started
 progress:
   total_phases: 1
   completed_phases: 0
   total_plans: 5
-  completed_plans: 2
+  completed_plans: 3
   percent: 0
 ---
 
@@ -22,7 +22,7 @@ progress:
 ## Current Position
 
 Phase: 86 (Skill and command frontmatter compliance) — EXECUTING
-Plan: 3 of 5
+Plan: 4 of 5
 Status: Ready to execute
 Last activity: 2026-07-26 — Phase 86 execution started
 
@@ -80,8 +80,8 @@ Last activity: 2026-07-26 — Phase 86 execution started
 
 ## Session
 
-**Last session:** 2026-07-26T13:17:33.614Z
-**Stopped at:** Completed 86-02-PLAN.md
+**Last session:** 2026-07-26T13:49:39.941Z
+**Stopped at:** Completed 86-03-PLAN.md
 **Resume file:** None
 
 ## Performance Metrics
@@ -93,6 +93,7 @@ No plans executed yet for v1.15.
 | —    | —        | —     | —     |
 | Phase 86 P01 | 35min | 3 tasks | 11 files |
 | Phase 86 P02 | 36min | 2 tasks | 10 files |
+| Phase 86 P03 | 45min | 2 tasks | 5 files |
 
 ## Decisions
 
@@ -105,6 +106,9 @@ execution will record per-plan decisions here.
 - [Phase 86]: setDescriptionScalar replaces the full description node span incl. block scalars, never a lone description: line (SKILL-03 corruption class)
 - [Phase ?]: 86-02: two read-only parseFrontmatter gates wrap the skills staging seam; gate-1 throw synthesizes disable-model-invocation (body verbatim), gate-2 throw is our defect (loud)
 - [Phase ?]: 86-02: degrade record threads bridge -> installCtx.frontmatterDegradations -> standalone {malformed skill} warning row + degradedKinds outcome seam
+- [Phase ?]: 86-03: augment arm runs only on the gate-1 RETURN branch; NREG-01 keeps a present in-cap description with no when_to_use byte-identical
+- [Phase ?]: 86-03: description-less+bodyless skills fall back to a fixed non-empty placeholder so Pi does not drop them (skill:null on empty description)
+- [Phase ?]: 86-03: SKILL-03 name safety = full name-node-span replacement + re-parse assertion that written name equals generated name
 
 ## Deferred Items
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,28 +3,28 @@ gsd_state_version: 1.0
 milestone: v1.15
 milestone_name: frontmatter-compliance
 current_phase: 86
-current_phase_name: Skill and command frontmatter compliance
-status: verifying
+status: completed
 stopped_at: Completed 86-05-PLAN.md
-last_updated: "2026-07-26T14:28:09.078Z"
+last_updated: "2026-07-27T02:30:40.459Z"
 last_activity: 2026-07-26
-last_activity_desc: Phase 86 execution started
+last_activity_desc: Phase 86 complete
 progress:
   total_phases: 1
   completed_phases: 1
   total_plans: 5
   completed_plans: 5
   percent: 100
+current_phase_name: Skill and command frontmatter compliance
 ---
 
 # Project State
 
 ## Current Position
 
-Phase: 86 (Skill and command frontmatter compliance) — EXECUTING
-Plan: 5 of 5
-Status: Phase complete — ready for verification
-Last activity: 2026-07-26 — Phase 86 execution started
+Phase: 86
+Plan: Not started
+Status: All phases complete
+Last activity: 2026-07-26 — Phase 86 complete
 
 ## Roadmap Summary
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,29 +1,26 @@
 ---
 gsd_state_version: 1.0
-milestone: v1.14
-milestone_name: mcp-string-refs
-status: Awaiting next milestone
-stopped_at: Completed 85-02-PLAN.md
-last_updated: "2026-07-23T20:47:48.549Z"
-last_activity: 2026-07-23
-last_activity_desc: Milestone v1.14 completed and archived
+milestone: v1.15
+milestone_name: frontmatter-compliance
+status: planning
+last_updated: "2026-07-26T03:01:59.228Z"
+last_activity: 2026-07-25
 progress:
-  total_phases: 1
-  completed_phases: 1
-  total_plans: 2
-  completed_plans: 2
-current_phase: 85
-current_phase_name: mcpservers-string-file-path-references
+  total_phases: 0
+  completed_phases: 0
+  total_plans: 0
+  completed_plans: 0
+  percent: 0
 ---
 
 # Project State
 
 ## Current Position
 
-Phase: Milestone v1.14 complete
+Phase: Not started (defining requirements)
 Plan: —
-Status: Awaiting next milestone
-Last activity: 2026-07-23 — Milestone v1.14 completed and archived
+Status: Defining requirements
+Last activity: 2026-07-25 — Milestone v1.15 started
 
 ## Roadmap Summary
 
@@ -39,8 +36,8 @@ Last activity: 2026-07-23 — Milestone v1.14 completed and archived
 
 ## Session
 
-**Last session:** 2026-07-23T03:33:50.290Z
-**Stopped at:** Completed 85-02-PLAN.md
+**Last session:** 2026-07-25T02:13:21.956Z
+**Stopped at:** context exhaustion at 75% (2026-07-25)
 **Resume file:** None
 
 ## Performance Metrics

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -5,15 +5,15 @@ milestone_name: frontmatter-compliance
 current_phase: 86
 current_phase_name: Skill and command frontmatter compliance
 status: executing
-stopped_at: Completed 86-01-PLAN.md
-last_updated: "2026-07-26T12:31:11.786Z"
+stopped_at: Completed 86-02-PLAN.md
+last_updated: "2026-07-26T13:17:46.479Z"
 last_activity: 2026-07-26
 last_activity_desc: Phase 86 execution started
 progress:
   total_phases: 1
   completed_phases: 0
   total_plans: 5
-  completed_plans: 1
+  completed_plans: 2
   percent: 0
 ---
 
@@ -22,7 +22,7 @@ progress:
 ## Current Position
 
 Phase: 86 (Skill and command frontmatter compliance) — EXECUTING
-Plan: 2 of 5
+Plan: 3 of 5
 Status: Ready to execute
 Last activity: 2026-07-26 — Phase 86 execution started
 
@@ -80,8 +80,8 @@ Last activity: 2026-07-26 — Phase 86 execution started
 
 ## Session
 
-**Last session:** 2026-07-26T12:31:11.760Z
-**Stopped at:** Completed 86-01-PLAN.md
+**Last session:** 2026-07-26T13:17:33.614Z
+**Stopped at:** Completed 86-02-PLAN.md
 **Resume file:** None
 
 ## Performance Metrics
@@ -92,6 +92,7 @@ No plans executed yet for v1.15.
 |------|----------|-------|-------|
 | —    | —        | —     | —     |
 | Phase 86 P01 | 35min | 3 tasks | 11 files |
+| Phase 86 P02 | 36min | 2 tasks | 10 files |
 
 ## Decisions
 
@@ -102,6 +103,8 @@ execution will record per-plan decisions here.
 - [Phase 86]: parseFrontmatter re-exported through platform/pi-api.ts as the sole sanctioned import site (PARSE-01)
 - [Phase 86]: REASONS catalog amended 35->37 with per-kind malformed skill / malformed command under FAILURE_REASONS (D-86-01 / CLASS-01)
 - [Phase 86]: setDescriptionScalar replaces the full description node span incl. block scalars, never a lone description: line (SKILL-03 corruption class)
+- [Phase ?]: 86-02: two read-only parseFrontmatter gates wrap the skills staging seam; gate-1 throw synthesizes disable-model-invocation (body verbatim), gate-2 throw is our defect (loud)
+- [Phase ?]: 86-02: degrade record threads bridge -> installCtx.frontmatterDegradations -> standalone {malformed skill} warning row + degradedKinds outcome seam
 
 ## Deferred Items
 

--- a/.planning/WINDOWS.md
+++ b/.planning/WINDOWS.md
@@ -1,0 +1,35 @@
+---
+schema_version: 1
+open_count: 1
+waived_count: 0
+fixed_count: 0
+total_count: 1
+last_updated: 2026-07-26T13:18:03.001Z
+---
+
+# Broken Windows Ledger
+
+> Cross-phase defect register. `/gsd-ship` blocks while `open_count > 0`.
+> Waive with `gsd-tools windows waive <id> "<reason>"` (reason required).
+> Mark fixed with `gsd-tools windows fixed <id>`.
+
+| id | phase | kind | file | line | description | status | reason | recorded_at | resolved_at |
+|----|-------|------|------|------|-------------|--------|--------|-------------|-------------|
+| 1 | 86 | unrun-verify | extensions/pi-claude-marketplace/bridges/skills/stage.ts |  | SKILL-01 backstop: after /reload a degraded skill's /skill:<name> resolves and the model never auto-invokes it (disable-model-invocation) — needs a live Pi session, not exercised in unit tests | open |  | 2026-07-26T13:18:03.001Z |  |
+
+````json
+[
+  {
+    "id": 1,
+    "kind": "unrun-verify",
+    "phase": "86",
+    "file": "extensions/pi-claude-marketplace/bridges/skills/stage.ts",
+    "line": null,
+    "description": "SKILL-01 backstop: after /reload a degraded skill's /skill:<name> resolves and the model never auto-invokes it (disable-model-invocation) — needs a live Pi session, not exercised in unit tests",
+    "status": "open",
+    "reason": "",
+    "recorded_at": "2026-07-26T13:18:03.001Z",
+    "resolved_at": null
+  }
+]
+````

--- a/.planning/phases/86-skill-and-command-frontmatter-compliance/86-01-PLAN.md
+++ b/.planning/phases/86-skill-and-command-frontmatter-compliance/86-01-PLAN.md
@@ -1,0 +1,195 @@
+---
+phase: 86-skill-and-command-frontmatter-compliance
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - extensions/pi-claude-marketplace/platform/pi-api.ts
+  - extensions/pi-claude-marketplace/shared/notify.ts
+  - extensions/pi-claude-marketplace/shared/notify-reasons.ts
+  - extensions/pi-claude-marketplace/bridges/skills/frontmatter-degrade.ts
+  - tests/platform/pi-api.test.ts
+  - tests/architecture/notify-closed-set-locks.test.ts
+  - tests/shared/notify-v2.test.ts
+  - tests/bridges/skills/frontmatter-degrade.test.ts
+autonomous: true
+requirements: [CLASS-01, SKILL-02, WTU-01, WTU-02]
+
+must_haves:
+  truths:
+    - "The `parseFrontmatter` re-export is reachable from `platform/pi-api.ts` and every downstream gate imports it from there, never from the peer package directly."
+    - "REASONS grows 35 -> 37: `malformed skill` then `malformed command` are appended AFTER the existing 35 entries; the existing order stays byte-identical (OUT-08)."
+    - "Both new tokens are members of `FAILURE_REASONS` (NOT `UNSUPPORTED_REASONS`); `_ReasonsCoverageProof` still compiles (the compile guard is the lockstep proof) — CLASS-01."
+    - "The closed-set length lock asserts REASONS.length === 37 (was 35) — CLASS-01 (unclassified probe: byte-stable amendment, proof compiles)."
+    - "`synthesizeUnparseableSkill` produces a frontmatter block carrying the generated `name`, a short fixed YAML-safe placeholder `description` (D-86-02 / A4), and `disable-model-invocation: true`, with the markdown body appended verbatim."
+    - "`firstBodyParagraph` skips blank lines, ATX `#` heading lines, and fenced ``` / ~~~ code blocks (and their contents), lands on the first plain body line, and returns the contiguous paragraph up to the next blank line — D-86-06 (SKILL-02 · unclassified probe)."
+    - "`foldWhenToUse` with an empty or absent `when_to_use` appends nothing and adds no trailing separator (WTU-01 · empty probe)."
+    - "`foldWhenToUse` joins `description` and `when_to_use` with a single `\\n` separator (A1) and operates on JS string `.length` (UTF-16 code units) with no byte/codepoint reinterpretation (WTU-01 · encoding probe)."
+    - "`truncate1536` leaves text of length <= 1536 unchanged, cuts exactly at index 1536 for length 1537 (hard cut, no ellipsis), where 1,536 is measured in JS `.length` UTF-16 code units (WTU-02 · boundary/encoding/precision probes; A2)."
+    - "`truncate1536` on empty combined text returns empty without crashing (WTU-02 · empty probe)."
+    - "`setDescriptionScalar` replaces the FULL `description` node span (including a `>-` / `|` block scalar), never a single `^description:` line, emitting the value as a safe double-quoted single-line scalar."
+  prohibitions:
+    - "MUST NOT reuse the existing generic `unparseable` token or introduce a single shared token — truthful per-kind attribution demands two dedicated tokens (D-86-01)."
+    - "MUST NOT reorder or re-space the existing 35 REASONS entries (OUT-08 byte-stability)."
+    - "MUST NOT emit an author scalar unescaped from `setDescriptionScalar` (an unescaped scalar could re-form a new YAML key — the AG-8 provenance-injection class)."
+  artifacts:
+    - "extensions/pi-claude-marketplace/platform/pi-api.ts — adds `export { parseFrontmatter }` plus a doc comment pinning its throw/return semantics"
+    - "extensions/pi-claude-marketplace/bridges/skills/frontmatter-degrade.ts — NEW: `synthesizeUnparseableSkill`, `firstBodyParagraph`, `foldWhenToUse`, `truncate1536`, `setDescriptionScalar`, and a safe double-quoted scalar emitter"
+    - "tests/bridges/skills/frontmatter-degrade.test.ts — NEW helper unit test"
+    - "tests/bridges/_fixtures/ — NEW skill fixtures (description-less; `>-`/`|` block-scalar description; heading+code-block body)"
+  key_links:
+    - "`platform/pi-api.ts` re-export is the ONLY sanctioned import site for `parseFrontmatter` (byte-identical accept/reject parity with Pi's own loaders)"
+    - "`REASONS` (notify.ts) <-> `FAILURE_REASONS` (notify-reasons.ts) must change in lockstep or `_ReasonsCoverageProof` fails to compile"
+---
+
+<objective>
+Lay the three pre-tracer foundations the rest of Phase 86 builds on: (1) surface Pi's own `parseFrontmatter` through the `platform/pi-api.ts` boundary so both staging gates parse with byte-identical accept/reject semantics; (2) amend the closed `REASONS` catalog with the two failure-class tokens `malformed skill` and `malformed command`; (3) create the pure-string skills degrade-helper module (synth block, first-paragraph extraction, `when_to_use` fold, 1,536 truncation, safe single-key `description` set) with its Wave-0 unit tests and fixtures.
+
+Purpose: These are the leaf dependencies of the tracer (Plan 02) and the expansion plans (03/04/05). The catalog amendment is a published-contract change (compile-guarded); the helper concentrates the phase's central technical risk (NREG-safe single-key YAML set) into a pure, unit-testable module.
+Output: A re-export, two catalog tokens, one new helper module, and three new/extended test files with fixtures.
+</objective>
+
+<execution_context>
+@/home/acolomba/pi-claude-marketplace/.claude/gsd-core/workflows/execute-plan.md
+@/home/acolomba/pi-claude-marketplace/.claude/gsd-core/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/86-skill-and-command-frontmatter-compliance/86-CONTEXT.md
+@.planning/phases/86-skill-and-command-frontmatter-compliance/86-RESEARCH.md
+@.planning/phases/86-skill-and-command-frontmatter-compliance/86-PATTERNS.md
+@.claude/rules/typescript-comments.md
+
+# Files touched (read before editing)
+@extensions/pi-claude-marketplace/platform/pi-api.ts
+@extensions/pi-claude-marketplace/shared/notify.ts
+@extensions/pi-claude-marketplace/shared/notify-reasons.ts
+@extensions/pi-claude-marketplace/bridges/agents/frontmatter.ts
+</context>
+
+<artifacts_this_phase>
+New symbols introduced by this plan:
+- `parseFrontmatter` re-export in `platform/pi-api.ts` (signature `<T extends Record<string, unknown>>(content: string) => { frontmatter: T; body: string }`).
+- REASONS tokens `malformed skill`, `malformed command` (notify.ts) + their `FAILURE_REASONS` membership (notify-reasons.ts).
+- `bridges/skills/frontmatter-degrade.ts` exporting `synthesizeUnparseableSkill`, `firstBodyParagraph`, `foldWhenToUse`, `truncate1536`, `setDescriptionScalar`, and an internal safe double-quoted scalar emitter.
+- Fixtures under `tests/bridges/_fixtures/` and the new helper test file.
+</artifacts_this_phase>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Re-export parseFrontmatter through the Pi-API boundary</name>
+  <read_first>
+    - extensions/pi-claude-marketplace/platform/pi-api.ts (the `export { getAgentDir } from ...` sibling at line 15 — the exact re-export idiom to copy; the file header declaring this the ONLY peer-import site)
+    - tests/platform/pi-api.test.ts (existing test style for this boundary)
+    - 86-RESEARCH.md §"Code Examples" (verified signature + the four throw/return semantics rows) and §"Pattern 1" (gate semantics)
+  </read_first>
+  <files>extensions/pi-claude-marketplace/platform/pi-api.ts, tests/platform/pi-api.test.ts</files>
+  <action>
+    Add a named re-export line for `parseFrontmatter` from `@earendil-works/pi-coding-agent` alongside the existing `getAgentDir` export (line 15). Add a doc comment pinning the verified semantics so downstream gates branch correctly: content NOT starting with the `---` delimiter returns an empty `frontmatter` object without throwing; an opening `---` with no closing `\n---` also returns empty without throwing; a closed `---` block containing malformed YAML THROWS; the returned `body` is CRLF-to-LF normalized and trimmed. Cite PARSE-01 as the traceability anchor. In `tests/platform/pi-api.test.ts`, add cases asserting: a valid closed block returns the parsed `frontmatter` fields and normalized `body`; a no-delimiter input returns empty `frontmatter` and does not throw; a closed block with an unquoted `: ` mid-scalar throws.
+  </action>
+  <verify>
+    <automated>node --test "tests/platform/pi-api.test.ts" && npm --prefix . run typecheck</automated>
+  </verify>
+  <acceptance_criteria>
+    - `grep -n "export { parseFrontmatter }" extensions/pi-claude-marketplace/platform/pi-api.ts` matches.
+    - `tests/platform/pi-api.test.ts` passes, including a case that asserts a no-delimiter input returns an empty `frontmatter` WITHOUT throwing and a case that asserts a malformed closed block throws.
+    - `npm run typecheck` is green.
+  </acceptance_criteria>
+  <done>`parseFrontmatter` is importable from `platform/pi-api.ts` and its throw/return semantics are test-pinned.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Amend the closed REASONS catalog with two per-kind failure-class tokens</name>
+  <read_first>
+    - extensions/pi-claude-marketplace/shared/notify.ts §143-152 (the `malformed mcp` member + its truthful-attribution comment — the exact append target and comment style to mirror)
+    - extensions/pi-claude-marketplace/shared/notify-reasons.ts §99-128 (FAILURE_REASONS + the `malformed mcp` comment) and §157-169 (`_ReasonsCoverageProof`)
+    - tests/architecture/notify-closed-set-locks.test.ts (the `assert.equal(REASONS.length, 35)` tripwire to bump)
+    - tests/shared/notify-v2.test.ts (row-render assertion style)
+  </read_first>
+  <files>extensions/pi-claude-marketplace/shared/notify.ts, extensions/pi-claude-marketplace/shared/notify-reasons.ts, tests/architecture/notify-closed-set-locks.test.ts, tests/shared/notify-v2.test.ts</files>
+  <action>
+    Append `malformed skill` then `malformed command` to the `REASONS` tuple in `notify.ts` immediately AFTER `malformed mcp` (positions 36, 37); the existing 35 entries stay byte-identical (OUT-08). Give each a one-line rationale comment mirroring the `malformed mcp` block: a malformation of a SUPPORTED component (skill / command), filed failure-class not unsupported. Add both literals to `FAILURE_REASONS` in `notify-reasons.ts` after `malformed mcp` (NOT `UNSUPPORTED_REASONS`); do not hand-edit `_ReasonsCoverageProof` — it self-satisfies once both have a home. Bump the length assertion in `notify-closed-set-locks.test.ts` from 35 to 37 and update its inline count comment. In `notify-v2.test.ts`, add a case rendering a `PluginInstalledMessage` whose `reasons` include `malformed skill` and asserting the `(installed) {malformed skill}` brace renders on the row at `warning` severity. Anchor comments to CLASS-01 / D-86-01 only; no phase/plan/wave references (see typescript-comments.md).
+  </action>
+  <verify>
+    <automated>npm --prefix . run typecheck && node --test "tests/architecture/notify-closed-set-locks.test.ts" "tests/shared/notify-v2.test.ts"</automated>
+  </verify>
+  <acceptance_criteria>
+    - `grep -n "malformed skill" extensions/pi-claude-marketplace/shared/notify.ts extensions/pi-claude-marketplace/shared/notify-reasons.ts` matches in both files; same for `malformed command`.
+    - The last three REASONS entries are, in order, `malformed mcp`, `malformed skill`, `malformed command` (existing 35 unchanged).
+    - `notify-closed-set-locks.test.ts` asserts `REASONS.length === 37` and passes.
+    - `npm run typecheck` compiles `_ReasonsCoverageProof` with no TS2344.
+  </acceptance_criteria>
+  <done>The catalog carries both failure-class tokens, byte-stable, compile-guarded, and render-tested.</done>
+  <reversibility rating="costly">The `REASONS` tuple is a published closed-set contract with a compile-time completeness proof and byte-stability tests; a later rename/removal touches the tuple, the topic-group view, the proof, and every rendered-row byte assertion (D-86-01). Flagged only — no checkpoint (not one-way).</reversibility>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 3: Create the pure-string skills degrade-helper module + Wave-0 tests</name>
+  <read_first>
+    - extensions/pi-claude-marketplace/bridges/agents/frontmatter.ts §37-59 (`emitYamlScalar` — the CONCEPTUAL precedent for safe scalar emit; NOT a copy target: it flattens to a flat line-based format, wrong for skills' real YAML)
+    - 86-RESEARCH.md §"Pattern 2" (surgical single-key set), §"Common Pitfalls" (multi-line description node corruption; the 1024-vs-1536 divergence), §"Open Questions" Q1 (full node span replacement)
+    - 86-CONTEXT.md D-86-02 (fixed placeholder), D-86-06 (first-body-line rule), A1/A2/A4
+    - tests/bridges/skills/stage.test.ts §1-60 (fixture + tmp-dir test harness style; `tests/bridges/_fixtures` layout)
+  </read_first>
+  <files>extensions/pi-claude-marketplace/bridges/skills/frontmatter-degrade.ts, tests/bridges/skills/frontmatter-degrade.test.ts, tests/bridges/_fixtures/</files>
+  <behavior>
+    - `synthesizeUnparseableSkill(body, generatedName)`: returns `---\nname: <generatedName>\ndescription: <fixed short YAML-safe constant>\ndisable-model-invocation: true\n---\n\n<body verbatim>`.
+    - `firstBodyParagraph(body)`: given a body that opens with blank lines, an ATX `#` heading, and a fenced code block before prose, returns the first prose paragraph (contiguous non-blank body lines) and skips heading/fence/blank constructs.
+    - `foldWhenToUse(description, whenToUse)`: empty/absent `whenToUse` returns `description` unchanged (no trailing `\n`); non-empty returns `description + "\n" + whenToUse`.
+    - `truncate1536(text)`: length <= 1536 unchanged; length 1537 returns exactly the first 1536 UTF-16 code units (no ellipsis); empty returns empty.
+    - `setDescriptionScalar(frontmatter, value)`: on a frontmatter whose `description` is a `>-` block scalar spanning several lines, replaces the entire node span with a single safe double-quoted scalar and leaves sibling keys byte-identical.
+  </behavior>
+  <action>
+    Create `bridges/skills/frontmatter-degrade.ts` exporting `synthesizeUnparseableSkill`, `firstBodyParagraph`, `foldWhenToUse`, `truncate1536`, and `setDescriptionScalar`, plus an internal safe double-quoted scalar emitter that escapes `\` and `"` and collapses embedded newlines to spaces. `setDescriptionScalar` must locate the FULL `description` node span (scan from the `description:` key to the next top-level key or block-scalar dedent boundary) and replace it — never a lone `^description:.*$` line replace (the SKILL-03 corruption class). Keep every function pure string-in/string-out and READ-ONLY toward author input (no eval) — the T-03-17 injection-safety property is preserved because reading-to-validate is not evaluating. Add fixtures under `tests/bridges/_fixtures/` (description-less skill; `>-` block-scalar description skill; heading-then-code-block body) and write `tests/bridges/skills/frontmatter-degrade.test.ts` covering every behavior row above, including the 1535/1536/1537 boundary and the empty inputs. Anchor comments to SKILL-02 / WTU-01 / WTU-02 / D-86-06 only.
+  </action>
+  <verify>
+    <automated>node --test "tests/bridges/skills/frontmatter-degrade.test.ts" && npm --prefix . run typecheck</automated>
+  </verify>
+  <acceptance_criteria>
+    - `tests/bridges/skills/frontmatter-degrade.test.ts` passes with cases for each exported function.
+    - A test asserts `truncate1536` on a 1537-char string returns a string of `.length === 1536` and on a <=1536 string returns it unchanged.
+    - A test asserts `setDescriptionScalar` on a `>-` block-scalar fixture yields output whose re-parse via `parseFrontmatter` returns the intended single-line `description` and leaves sibling keys unchanged.
+    - A test asserts `foldWhenToUse(desc, "")` equals `desc` with no trailing separator.
+    - `npm run typecheck` is green.
+  </acceptance_criteria>
+  <done>The degrade helper exists as a pure, fully unit-tested module with block-scalar-safe `description` setting.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| plugin author -> bridge helper | Untrusted `SKILL.md` frontmatter/body bytes are read to compute a degraded/augmented `description`; the helper emits bytes Pi will later parse. |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Severity | Disposition | Mitigation Plan |
+|-----------|----------|-----------|----------|-------------|-----------------|
+| T-86-01 | Tampering/Elevation | `parseFrontmatter` (re-export used by gates) | high | mitigate | Data-only `yaml.parse` (no tag/`!!` execution surface); READ-ONLY — extract values, never eval (preserves T-03-17) |
+| T-86-02 | Tampering (Injection) | `setDescriptionScalar` safe scalar emitter | high | mitigate | Escape `\`/`"`, collapse newlines; an author scalar cannot re-form a new YAML key (AG-8 class); gate-2 backstop lands in Plan 02 |
+| T-86-04 | DoS (context) | combined description length | low | mitigate | `truncate1536` bounds listing size; unparseable skills carry `disable-model-invocation` (placeholder costs zero model context) |
+| T-86-SC | Tampering | npm/pip/cargo installs | low | accept | No package installs this phase — `parseFrontmatter` is an already-declared peer export; no registry additions |
+
+Block threshold: `high`. Both `high` threats are mitigated in-scope (T-86-01 here; T-86-02's runtime backstop completes in Plan 02).
+</threat_model>
+
+<verification>
+- `npm run typecheck` green (proof compiles with the 37-entry set).
+- `node --test "tests/platform/pi-api.test.ts" "tests/architecture/notify-closed-set-locks.test.ts" "tests/shared/notify-v2.test.ts" "tests/bridges/skills/frontmatter-degrade.test.ts"` all pass.
+</verification>
+
+<success_criteria>
+- `parseFrontmatter` re-exported and semantics-pinned; catalog at 37 byte-stable tokens; degrade helper module complete and unit-green.
+</success_criteria>
+
+<output>
+Create `.planning/phases/86-skill-and-command-frontmatter-compliance/86-01-SUMMARY.md` when done.
+</output>

--- a/.planning/phases/86-skill-and-command-frontmatter-compliance/86-01-SUMMARY.md
+++ b/.planning/phases/86-skill-and-command-frontmatter-compliance/86-01-SUMMARY.md
@@ -1,0 +1,174 @@
+---
+phase: 86-skill-and-command-frontmatter-compliance
+plan: 01
+subsystem: bridges
+tags: [frontmatter, parseFrontmatter, notify-catalog, yaml, skills, degrade]
+
+# Dependency graph
+requires: []
+provides:
+  - "parseFrontmatter re-exported through platform/pi-api.ts as the sole sanctioned import site, with pinned throw/return semantics"
+  - "REASONS catalog amended to 37 entries: malformed skill + malformed command failure-class tokens"
+  - "bridges/skills/frontmatter-degrade.ts pure-string helper module (synth block, first-paragraph, when_to_use fold, 1,536 truncation, block-scalar-safe description set)"
+affects:
+  - "86-02 (tracer: skills/commands staging gates consume parseFrontmatter + degrade helpers)"
+  - "86-03 / 86-04 / 86-05 (expansion: reason-token wiring, command neutralize, gate-2 backstop)"
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - "Read-only parse-to-validate (never eval) preserves T-03-17 injection safety"
+    - "Surgical single-key YAML node-span replacement + safe double-quoted scalar emit (never whole-block re-emit)"
+    - "Closed-set tail append + compile-time completeness proof (_ReasonsCoverageProof) as the lockstep guard"
+
+key-files:
+  created:
+    - extensions/pi-claude-marketplace/bridges/skills/frontmatter-degrade.ts
+    - tests/bridges/skills/frontmatter-degrade.test.ts
+    - tests/bridges/_fixtures/skill-no-description/SKILL.md
+    - tests/bridges/_fixtures/skill-block-scalar-description/SKILL.md
+    - tests/bridges/_fixtures/skill-heading-codeblock-body/SKILL.md
+  modified:
+    - extensions/pi-claude-marketplace/platform/pi-api.ts
+    - extensions/pi-claude-marketplace/shared/notify.ts
+    - extensions/pi-claude-marketplace/shared/notify-reasons.ts
+    - tests/platform/pi-api.test.ts
+    - tests/architecture/notify-closed-set-locks.test.ts
+    - tests/shared/notify-v2.test.ts
+
+key-decisions:
+  - "parseFrontmatter re-export is the ONLY sanctioned import site for byte-identical accept/reject parity with Pi's loaders (PARSE-01)"
+  - "Two dedicated per-kind tokens (malformed skill / malformed command) under FAILURE_REASONS, not a shared bucket (D-86-01 / CLASS-01)"
+  - "setDescriptionScalar replaces the full description node span (incl. >- / | block scalars), never a lone description: line (SKILL-03 corruption class)"
+  - "truncate1536 keeps the 1,536 UTF-16-code-unit cap (D-86-05), not Pi's 1,024 warning threshold"
+
+patterns-established:
+  - "Pure string-in/string-out degrade helpers, READ-ONLY toward author input"
+  - "Safe double-quoted scalar emitter (escape backslash then quote, collapse newlines) blocks AG-8 provenance-injection"
+
+requirements-completed: [CLASS-01, SKILL-02, WTU-01, WTU-02]
+
+coverage:
+  - id: D1
+    description: "parseFrontmatter re-exported through platform/pi-api.ts with test-pinned throw/return semantics (valid closed block parses; missing/unclosed delimiter returns empty without throwing; malformed closed block throws)"
+    requirement: "PARSE-01"
+    verification:
+      - kind: unit
+        ref: "tests/platform/pi-api.test.ts#PARSE-01: parseFrontmatter THROWS on a closed block whose inner YAML is malformed"
+        status: pass
+    human_judgment: false
+  - id: D2
+    description: "REASONS catalog grows 35->37 with malformed skill + malformed command under FAILURE_REASONS; byte-stable tail append; _ReasonsCoverageProof compiles; installed row renders (installed) {malformed skill} at warning severity"
+    requirement: "CLASS-01"
+    verification:
+      - kind: unit
+        ref: "tests/architecture/notify-closed-set-locks.test.ts#OUT-08: REASONS is the closed 37-entry reason set"
+        status: pass
+      - kind: unit
+        ref: "tests/shared/notify-v2.test.ts#CLASS-01 / D-86-01: installed row renders `(installed) {malformed skill}` at warning severity"
+        status: pass
+    human_judgment: false
+  - id: D3
+    description: "firstBodyParagraph derives description from the first genuine body line, skipping blanks/ATX headings/fenced code blocks (D-86-06)"
+    requirement: "SKILL-02"
+    verification:
+      - kind: unit
+        ref: "tests/bridges/skills/frontmatter-degrade.test.ts#SKILL-02 / D-86-06: firstBodyParagraph skips blank lines, ATX headings, and fenced code blocks, then returns the first prose paragraph"
+        status: pass
+    human_judgment: false
+  - id: D4
+    description: "foldWhenToUse joins description + when_to_use with a single \\n and adds no separator when when_to_use is empty/absent (WTU-01)"
+    requirement: "WTU-01"
+    verification:
+      - kind: unit
+        ref: "tests/bridges/skills/frontmatter-degrade.test.ts#WTU-01: foldWhenToUse with an empty or absent when_to_use returns the description unchanged (no trailing separator)"
+        status: pass
+    human_judgment: false
+  - id: D5
+    description: "truncate1536 hard-cuts combined text at 1,536 UTF-16 code units (no ellipsis), leaves <=1536 unchanged, empty returns empty (WTU-02)"
+    requirement: "WTU-02"
+    verification:
+      - kind: unit
+        ref: "tests/bridges/skills/frontmatter-degrade.test.ts#WTU-02: truncate1536 hard-cuts a 1537-char string to exactly 1536 code units (no ellipsis)"
+        status: pass
+    human_judgment: false
+  - id: D6
+    description: "setDescriptionScalar replaces the full description node span incl. >- block scalars with a safe double-quoted scalar, leaving siblings unchanged; author value cannot re-form a YAML key"
+    verification:
+      - kind: unit
+        ref: "tests/bridges/skills/frontmatter-degrade.test.ts#SKILL-03: setDescriptionScalar replaces a `>-` block-scalar description with a single safe scalar and leaves sibling keys unchanged"
+        status: pass
+    human_judgment: false
+
+# Metrics
+duration: 35min
+completed: 2026-07-26
+status: complete
+---
+
+# Phase 86 Plan 01: Pre-tracer foundations Summary
+
+**parseFrontmatter surfaced through the Pi-API boundary, the closed REASONS catalog amended to 37 with per-kind `malformed skill`/`malformed command` tokens, and a pure-string skills degrade-helper module (synth block, first-paragraph, when_to_use fold, 1,536 truncation, block-scalar-safe description set) with full unit coverage.**
+
+## Performance
+
+- **Duration:** ~35 min
+- **Started:** 2026-07-26
+- **Completed:** 2026-07-26
+- **Tasks:** 3
+- **Files modified:** 11 (6 modified, 5 created)
+
+## Accomplishments
+- `parseFrontmatter` is now importable ONLY from `platform/pi-api.ts`, with a doc comment pinning the verified throw/return semantics (missing/unclosed delimiter -> empty without throwing; closed malformed block -> throws) the staging gates branch on.
+- The closed `REASONS` tuple grew 35 -> 37 with `malformed skill` then `malformed command` appended after `malformed mcp` (existing 35 byte-identical); both filed under `FAILURE_REASONS`, the `_ReasonsCoverageProof` self-satisfies, and the `(installed) {malformed skill}` warning row is render-tested.
+- New `bridges/skills/frontmatter-degrade.ts` concentrates the phase's central technical risk (NREG-safe single-key YAML set) into five pure, unit-tested helpers plus a safe double-quoted scalar emitter.
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Re-export parseFrontmatter through the Pi-API boundary** - `ff4b6f88` (feat)
+2. **Task 2: Amend the closed REASONS catalog with two per-kind failure-class tokens** - `e88cc445` (feat)
+3. **Task 3: Create the pure-string skills degrade-helper module + Wave-0 tests** - `a2b0d00f` (feat)
+
+_TDD note: the whole-project `tsc --noEmit` pre-commit hook rejects a RED commit whose test imports a not-yet-created module, so Task 3's test + implementation landed in one atomic commit (GREEN) rather than separate RED/GREEN commits. All behaviors were still written test-first and verified failing→passing locally before the commit._
+
+## Files Created/Modified
+- `extensions/pi-claude-marketplace/platform/pi-api.ts` - re-export `parseFrontmatter` + semantics doc comment (PARSE-01)
+- `extensions/pi-claude-marketplace/shared/notify.ts` - append `malformed skill` / `malformed command` to REASONS; bump tuple-doc count to 37
+- `extensions/pi-claude-marketplace/shared/notify-reasons.ts` - add both tokens to FAILURE_REASONS
+- `extensions/pi-claude-marketplace/bridges/skills/frontmatter-degrade.ts` - NEW helper module (5 exports + safe scalar emitter)
+- `tests/platform/pi-api.test.ts` - PARSE-01 throw/return cases
+- `tests/architecture/notify-closed-set-locks.test.ts` - REASONS.length lock 35 -> 37
+- `tests/shared/notify-v2.test.ts` - tail-order + `(installed) {malformed skill}` render tests
+- `tests/bridges/skills/frontmatter-degrade.test.ts` - NEW helper unit test (14 cases)
+- `tests/bridges/_fixtures/skill-no-description/SKILL.md`, `skill-block-scalar-description/SKILL.md`, `skill-heading-codeblock-body/SKILL.md` - NEW fixtures
+
+## Decisions Made
+None beyond the locked decisions (D-86-01..07) and research assumptions (A1/A2/A4) the plan already fixed. The placeholder description string was chosen within D-86-02's discretion as `Source frontmatter could not be parsed.`
+
+## Deviations from Plan
+
+None - plan executed exactly as written. One precision correction (not a code deviation): the `parseFrontmatter` doc comment and its test were tightened to reflect that the body is `.trim()`ed only on the frontmatter-present path (the no-delimiter path returns the body normalized-but-untrimmed) — the plan/research had stated an unconditional trim.
+
+## Issues Encountered
+- The whole-project `tsc --noEmit` pre-commit hook made a TDD RED-first commit (test importing a missing module) impossible; resolved by landing Task 3's test + module in one atomic GREEN commit (documented above).
+- The `(installed)` warning row prepends an "A plugin operation needs attention." preamble at `warning` severity; the render test's expected value was set to match the actual byte form.
+
+## User Setup Required
+None - no external service configuration required.
+
+## Next Phase Readiness
+- Leaf dependencies for the tracer (Plan 02) are in place: the parse boundary, the two catalog tokens, and the degrade helpers are all committed and unit-green.
+- Plan 02 wires these into `bridges/skills/stage.ts` and `bridges/commands/stage.ts` (gate 1 + gate 2) and threads the degrade signal into the standalone + orchestrated reason-row composers.
+
+## Self-Check: PASSED
+
+- All created files exist on disk (degrade module, test, 3 fixtures).
+- All three task commits present in git history (`ff4b6f88`, `e88cc445`, `a2b0d00f`).
+- `npm run typecheck` green; `node --test` across all four plan test files: 178 pass / 0 fail.
+
+---
+*Phase: 86-skill-and-command-frontmatter-compliance*
+*Completed: 2026-07-26*

--- a/.planning/phases/86-skill-and-command-frontmatter-compliance/86-02-PLAN.md
+++ b/.planning/phases/86-skill-and-command-frontmatter-compliance/86-02-PLAN.md
@@ -1,0 +1,170 @@
+---
+phase: 86-skill-and-command-frontmatter-compliance
+plan: 02
+type: execute
+wave: 2
+depends_on: ["86-01"]
+files_modified:
+  - extensions/pi-claude-marketplace/bridges/skills/stage.ts
+  - extensions/pi-claude-marketplace/bridges/skills/types.ts
+  - extensions/pi-claude-marketplace/bridges/commands/types.ts
+  - extensions/pi-claude-marketplace/orchestrators/plugin/install.ts
+  - tests/bridges/skills/stage.test.ts
+  - tests/orchestrators/plugin/install.test.ts
+autonomous: true
+requirements: [PARSE-01, PARSE-02, SKILL-01, WARN-01, NREG-01]
+
+must_haves:
+  truths:
+    - "Gate 1 parses the SOURCE `SKILL.md` with `parseFrontmatter` BEFORE `rewriteFrontmatterName` and `substituteClaudeVars` — establishing attribution ground truth and the degrade trigger (PARSE-01)."
+    - "A THROW at gate 1 (malformed YAML in a closed `---` block) synthesizes the `disable-model-invocation` block via `synthesizeUnparseableSkill`; the body is preserved verbatim and the plugin install does NOT hard-fail (SKILL-01)."
+    - "An empty / no-delimiter source does NOT throw at gate 1 (parseFrontmatter returns empty); it routes to the augment branch, never the synth branch (PARSE-01 · empty probe; SKILL-01 · empty probe)."
+    - "Gate-1 body is CRLF-to-LF normalized and trimmed by `parseFrontmatter`; the synthesized block's verbatim body is that normalized body (PARSE-01 · encoding probe; SKILL-01 · encoding probe)."
+    - "Gate 2 re-parses the STAGED bytes after write; a THROW on the non-degrade (augment/happy) arm is OUR defect and throws loudly, failing that plugin's install — never masked as author degradation (PARSE-02 / D-86-04; PARSE-02 · unclassified probe)."
+    - "Each degraded skill pushes a `{ generatedName, parseError }` degrade record onto the bridge result; the install orchestrator collects records from both bridges into one per-component list."
+    - "The standalone install row carries ONE `malformed skill` token per plugin regardless of how many of its skills degraded (WARN-01 · adjacency probe); the token rides `PluginInstalledMessage.reasons` on the `(installed)` row at `warning` severity."
+    - "Zero degraded components => no `malformed *` token and no warning stamp on the row (WARN-01 · empty probe)."
+    - "A valid skill (parseable, non-empty `description`, no `when_to_use`) is written byte-for-byte identical after the read-only gates — the gates mutate nothing on the happy path (NREG-01 · unclassified probe)."
+    - "`InstallPluginOutcome`'s installed arm carries a `degradedKinds` flag (the inert seam Plan 05 consumes for the orchestrated row)."
+    - { statement: "After /reload, a degraded skill's `/skill:<generated-name>` resolves and the model never auto-invokes it (disable-model-invocation) — the observable Claude-Code malformed-skill pair (SKILL-01).", verification: backstop }
+  prohibitions:
+    - "MUST NOT rewrite or reformat a valid source's frontmatter — the happy path stays byte-identical (NREG-01)."
+    - "MUST NOT attribute a staged-output (gate-2) failure on the augment/happy arm to the plugin author — that is our defect and throws (PARSE-02 / D-86-04)."
+    - "MUST NOT emit more than one `malformed skill` token per plugin (share the brace, mirror `orphan rewake`)."
+  artifacts:
+    - "extensions/pi-claude-marketplace/bridges/skills/types.ts — adds a `degraded` field to `StageSkillsCommitResult`"
+    - "extensions/pi-claude-marketplace/bridges/commands/types.ts — adds a `degraded` field to `StageCommandsCommitResult` (populated in Plan 04)"
+    - "extensions/pi-claude-marketplace/orchestrators/plugin/install.ts — `frontmatterDegradations` install-ctx list, standalone reason tokens, post-commit detail, `InstallPluginOutcome.degradedKinds`"
+    - "tests/bridges/skills/stage.test.ts — unparseable-skill + NREG byte-equality cases"
+    - "tests/orchestrators/plugin/install.test.ts — standalone `(installed) {malformed skill}` row case"
+  key_links:
+    - "skills/stage.ts seam (readFile -> gate1 -> rewrite -> substitute -> writeFile -> gate2) is where attribution + degrade trigger + Pi-acceptability backstop all live"
+    - "bridge `result.degraded` -> `installCtx.frontmatterDegradations` -> `reasons[]` (standalone) + `postCommitWarnings` (detail) + `InstallPluginOutcome.degradedKinds` (orchestrated seam)"
+---
+
+<objective>
+The phase tracer: wire ONE end-to-end path — a skill whose SOURCE frontmatter cannot be parsed — from the staging seam through the notification renderer. Insert the two read-only `parseFrontmatter` gates into `bridges/skills/stage.ts` (gate 1 before rewrite/substitution, gate 2 after write), synthesize the `disable-model-invocation` degrade on a gate-1 throw, collect a per-component degrade record, and thread it up through `install.ts` so a standalone install renders `(installed) {malformed skill}` at `warning` severity and surfaces the per-component parse-error detail. Prove the ~99% happy path is byte-for-byte unchanged.
+
+Purpose: This is the thinnest production-quality slice through every layer the phase modifies (Pi-API boundary + catalog from Plan 01, skills bridge, install orchestrator, notify renderer). Proving it end-to-end on one path validates the whole degrade-signal architecture before the expansion plans (skills augment, commands neutralize, orchestrated row) build out from it.
+Output: Two live parse gates in the skills bridge, a degrade-record wire into the standalone install row, and byte-equality proof for valid skills.
+</objective>
+
+<execution_context>
+@/home/acolomba/pi-claude-marketplace/.claude/gsd-core/workflows/execute-plan.md
+@/home/acolomba/pi-claude-marketplace/.claude/gsd-core/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/86-skill-and-command-frontmatter-compliance/86-CONTEXT.md
+@.planning/phases/86-skill-and-command-frontmatter-compliance/86-RESEARCH.md
+@.planning/phases/86-skill-and-command-frontmatter-compliance/86-PATTERNS.md
+@.claude/rules/typescript-comments.md
+
+# Prior plan output consumed here
+@.planning/phases/86-skill-and-command-frontmatter-compliance/86-01-SUMMARY.md
+
+# Files touched (read before editing)
+@extensions/pi-claude-marketplace/bridges/skills/stage.ts
+@extensions/pi-claude-marketplace/bridges/skills/types.ts
+@extensions/pi-claude-marketplace/orchestrators/plugin/install.ts
+</context>
+
+<artifacts_this_phase>
+New symbols introduced by this plan:
+- `degraded: readonly { generatedName: string; parseError: string }[]` on `StageSkillsCommitResult` (skills/types.ts) and `StageCommandsCommitResult` (commands/types.ts).
+- `installCtx.frontmatterDegradations: { kind: "skill" | "command"; generatedName: string; parseError: string }[]` (install.ts).
+- `InstallPluginOutcome` installed-arm `degradedKinds?: readonly ("skill" | "command")[]`.
+- Standalone `malformed skill` / `malformed command` reason push + per-component detail lines into `postCommitWarnings`.
+</artifacts_this_phase>
+
+<tasks>
+
+<task type="tracer">
+  <name>Task 1: End-to-end unparseable-skill degrade — source gate to standalone row</name>
+  <read_first>
+    - extensions/pi-claude-marketplace/bridges/skills/stage.ts §159-176 (the exact `readFile -> rewriteFrontmatterName -> substituteClaudeVars -> writeFile` seam and the `appendLeakToError`/`cleanupStaging` catch to ride)
+    - extensions/pi-claude-marketplace/bridges/skills/types.ts §54-59 (`StageSkillsCommitResult` — where `degraded` is added) and commands/types.ts §54-58
+    - extensions/pi-claude-marketplace/orchestrators/plugin/install.ts §358-377 (installCtx fields incl. `agentForeignFailures` shape), §868-903 (skills phase `do`), §905-933 (commands phase `do`), §1637-1646 (`agentForeignFailures` -> postCommitWarnings pattern), §1702-1765 (the `orphan rewake` reason push + `reasons`/severity row composition), §1779-1785 (installed outcome return)
+    - extensions/pi-claude-marketplace/bridges/skills/frontmatter-degrade.ts (from Plan 01 — `synthesizeUnparseableSkill`)
+    - extensions/pi-claude-marketplace/platform/pi-api.ts (`parseFrontmatter` re-export from Plan 01)
+    - 86-PATTERNS.md §"bridges/skills/stage.ts", §"orchestrators/plugin/install.ts", §"Shared Patterns"
+  </read_first>
+  <files>extensions/pi-claude-marketplace/bridges/skills/stage.ts, extensions/pi-claude-marketplace/bridges/skills/types.ts, extensions/pi-claude-marketplace/bridges/commands/types.ts, extensions/pi-claude-marketplace/orchestrators/plugin/install.ts, tests/orchestrators/plugin/install.test.ts</files>
+  <action>
+    In `bridges/skills/stage.ts`, wrap the per-skill seam. GATE 1: call `parseFrontmatter(content)` on the source inside a try BEFORE `rewriteFrontmatterName`. On THROW, replace `content` with `synthesizeUnparseableSkill(body, skill.generatedName)` (extract the verbatim body by splitting the source on the closing delimiter, or from the thrown-branch raw content), record `{ generatedName, parseError }` onto a local degrade list, and SKIP the augment inspection; still run `substituteClaudeVars` and write. On RETURN, keep today's `rewriteFrontmatterName` + `substituteClaudeVars` path unchanged (the augment arm is added in Plan 03; here the return branch is byte-identical passthrough for NREG-01). GATE 2: after `writeFile`, re-read (or reuse the in-memory `content`) and call `parseFrontmatter` again; a THROW here on a non-degrade arm is our defect — rethrow so it rides the existing `appendLeakToError`/`cleanupStaging` catch (PARSE-02 / D-86-04). Add `degraded` to `StageSkillsCommitResult` (skills/types.ts) and `StageCommandsCommitResult` (commands/types.ts) as `readonly { generatedName: string; parseError: string }[]`, and return the collected records from `prepareStageSkills`.
+
+    In `orchestrators/plugin/install.ts`: add `frontmatterDegradations: { kind: "skill" | "command"; generatedName: string; parseError: string }[]` to the installCtx (mirror the `agentForeignFailures` declaration/init). In the skills phase `do`, push `...prep.result.degraded` mapped with `kind: "skill"`; in the commands phase `do`, push `...prep.result.degraded` mapped with `kind: "command"` (inert until Plan 04 populates it). At the surfacing site (mirror §1637-1646 for detail and §1702-1711 for the reason push): if any skill-kind record exists, push `"malformed skill"` ONCE into `reasons[]`; if any command-kind record exists, push `"malformed command"` ONCE; and push per-component detail lines `<plugin>/<component>: <parseError>` into `postCommitWarnings` (orchestrated only, per D-19-01 — standalone drops the detail exactly like `agentForeignFailures`). Add `degradedKinds` to the installed `InstallPluginOutcome` return: the set of kinds present in `frontmatterDegradations` (the seam Plan 05 reads). Keep the row `(installed)` NOT `(partially-installed)` — a degraded-but-installed component is not a dropped supported component (D-86-03). Anchor comments to SKILL-01 / PARSE-01 / PARSE-02 / WARN-01 / D-86-* only. Extend `tests/orchestrators/plugin/install.test.ts` with a standalone case: installing a plugin whose one skill source throws renders an `(installed)` row carrying `malformed skill` at `warning` severity and does not hard-fail.
+  </action>
+  <verify>
+    <automated>node --test "tests/bridges/skills/stage.test.ts" "tests/orchestrators/plugin/install.test.ts" && npm --prefix . run typecheck</automated>
+  </verify>
+  <acceptance_criteria>
+    - A `stage.test.ts` case installs an unparseable-skill fixture and asserts the staged `SKILL.md` contains `disable-model-invocation: true`, the generated `name`, and the original body text verbatim, and that `parseFrontmatter` on the staged bytes returns (does not throw).
+    - A `stage.test.ts` case asserts `prepareStageSkills` result `degraded` carries one record with the generated name and a non-empty `parseError`.
+    - An `install.test.ts` case asserts a standalone install of a one-bad-skill plugin renders `(installed)` with reason `malformed skill` at `warning` severity and returns an `installed` outcome (no hard-fail).
+    - `npm run typecheck` is green.
+  </acceptance_criteria>
+  <done>The full unparseable-skill degrade path works end-to-end at the standalone install surface and is committed.</done>
+  <reversibility rating="reversible">Gate insertion and degrade-record threading are additive to an existing seam; revertible by removing the wrapper.</reversibility>
+</task>
+
+<task type="auto">
+  <name>Task 2: NREG-01 byte-equality regression for the valid-skill happy path</name>
+  <read_first>
+    - tests/bridges/skills/stage.test.ts §102-160 (existing SK-3 prepared-SKILL.md assertions and the tmp-dir harness — extend, do not rewrite)
+    - extensions/pi-claude-marketplace/bridges/skills/stage.ts (the seam edited in Task 1)
+    - 86-VALIDATION.md (NREG-01 byte-equality row) and 86-RESEARCH.md §"Wave 0 Gaps" (byte-equality helper)
+  </read_first>
+  <files>tests/bridges/skills/stage.test.ts</files>
+  <action>
+    Add an NREG-01 case: stage a valid skill fixture (parseable frontmatter, non-empty `description`, no `when_to_use`) through `prepareStageSkills`, then assert the staged `SKILL.md` bytes equal the expected post-rewrite/post-substitution bytes produced by the pre-gate code path — i.e. the ONLY differences from the source are the `name:` rewrite and `${CLAUDE_PLUGIN_ROOT}`/`${CLAUDE_PLUGIN_DATA}` substitution, with no reformatting, re-quoting, or field reordering introduced by the gates. Assert the `degraded` result list is empty and the row would carry no `malformed *` token. Use a byte-for-byte string equality assertion (not a structural/parsed compare).
+  </action>
+  <verify>
+    <automated>node --test "tests/bridges/skills/stage.test.ts"</automated>
+  </verify>
+  <acceptance_criteria>
+    - The NREG case uses `assert.equal` on the full staged string (byte-for-byte), not a parsed-object compare.
+    - The case asserts `result.degraded.length === 0` for the valid skill.
+    - `node --test "tests/bridges/skills/stage.test.ts"` passes.
+  </acceptance_criteria>
+  <done>The 99% valid-skill path is proven byte-for-byte unchanged by the gate insertion.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| plugin author -> skills bridge | Untrusted `SKILL.md` bytes are parsed (read-only) at gate 1 and re-parsed at gate 2; a malformed source triggers synthesis. |
+| bridge -> install orchestrator -> notify | The degrade signal (component + parse error) crosses into user-visible notification text. |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Severity | Disposition | Mitigation Plan |
+|-----------|----------|-----------|----------|-------------|-----------------|
+| T-86-01 | Tampering/Elevation | gate 1 / gate 2 `parseFrontmatter` | high | mitigate | Data-only parse via the `platform/pi-api.ts` re-export; READ-ONLY (extract/validate, never eval) — preserves T-03-17 |
+| T-86-03 | Info Disclosure | per-component parse-error detail line | medium | mitigate | Detail rides `postCommitWarnings` (orchestrated) which is routed through `redactAbsolutePaths` before `notifyDiagnostic` (Plan 05); no absolute source paths leak |
+| T-86-05 | Tampering | path escape via crafted skill dir | low | accept | UNCHANGED — existing `assertPathInside` + `cp` `verbatimSymlinks:true,dereference:false`; this task touches file content, not path selection |
+| T-86-SC | Tampering | npm/pip/cargo installs | low | accept | No package installs this phase |
+
+Block threshold: `high`. T-86-01 is mitigated by construction (read-only parse); no `high` threat is unmitigated.
+</threat_model>
+
+<verification>
+- `node --test "tests/bridges/skills/stage.test.ts" "tests/orchestrators/plugin/install.test.ts"` pass.
+- `npm run typecheck` green.
+- Per-wave merge: `npm test` + `npm run test:integration`.
+</verification>
+
+<success_criteria>
+- An unparseable skill installs (no hard-fail) with a synthesized `disable-model-invocation` block, surfaces `(installed) {malformed skill}` at warning severity, and the valid-skill path is byte-for-byte unchanged.
+</success_criteria>
+
+<output>
+Create `.planning/phases/86-skill-and-command-frontmatter-compliance/86-02-SUMMARY.md` when done.
+</output>

--- a/.planning/phases/86-skill-and-command-frontmatter-compliance/86-02-SUMMARY.md
+++ b/.planning/phases/86-skill-and-command-frontmatter-compliance/86-02-SUMMARY.md
@@ -1,0 +1,171 @@
+---
+phase: 86-skill-and-command-frontmatter-compliance
+plan: 02
+subsystem: bridges
+tags: [frontmatter, parseFrontmatter, skills, degrade, install-orchestrator, notify]
+
+# Dependency graph
+requires:
+  - phase: 86-01
+    provides: "parseFrontmatter re-export through platform/pi-api.ts, malformed skill/command reason tokens, synthesizeUnparseableSkill degrade helper"
+provides:
+  - "Two read-only parseFrontmatter gates in bridges/skills/stage.ts (gate 1 on SOURCE before rewrite/substitution, gate 2 on STAGED bytes after write)"
+  - "Unparseable-source skills synthesize a disable-model-invocation block (body verbatim) and install without hard-failing (SKILL-01)"
+  - "Per-component degrade record threaded bridge -> install orchestrator -> standalone (installed) {malformed skill} row at warning severity (WARN-01)"
+  - "degraded field on StageSkillsCommitResult + StageCommandsCommitResult (commands inert until neutralize arm lands)"
+  - "InstallPluginOutcome.degradedKinds inert seam for the orchestrated reconcile row"
+affects:
+  - "86-03 (skills augment arm builds on the gate-1 RETURN branch)"
+  - "86-04 (commands neutralize populates StageCommandsCommitResult.degraded)"
+  - "86-05 (orchestrated reconcile row consumes InstallPluginOutcome.degradedKinds)"
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - "Two read-only parse gates around a staging seam: gate 1 = attribution ground truth + degrade trigger; gate 2 = Pi-acceptability backstop (self-defect throws loudly, never author-attributed)"
+    - "One-token-per-plugin reason on the (installed) row (mirrors orphan rewake), with per-component free-text detail on the orchestrated postCommitWarnings channel"
+
+key-files:
+  created:
+    - tests/bridges/_fixtures/unparseable-skill-plugin/skills/bad-skill/SKILL.md
+  modified:
+    - extensions/pi-claude-marketplace/bridges/skills/stage.ts
+    - extensions/pi-claude-marketplace/bridges/skills/types.ts
+    - extensions/pi-claude-marketplace/bridges/commands/stage.ts
+    - extensions/pi-claude-marketplace/bridges/commands/types.ts
+    - extensions/pi-claude-marketplace/orchestrators/plugin/install.ts
+    - extensions/pi-claude-marketplace/bridges/skills/frontmatter-degrade.ts
+    - tests/bridges/skills/stage.test.ts
+    - tests/bridges/skills/frontmatter-degrade.test.ts
+    - tests/orchestrators/plugin/install.test.ts
+
+key-decisions:
+  - "Gate-1 throw arm skips rewriteFrontmatterName (synthesize already emits the generated name); RETURN arm is byte-identical passthrough today (NREG-01)"
+  - "extractBodyAfterFrontmatter reproduces parseFrontmatter's CRLF->LF + trim body normalization on the throw path so the synthesized body matches the return-path body byte-for-byte"
+  - "A degraded-but-installed component keeps the (installed) row (NOT partially-installed) at warning severity (D-86-03)"
+  - "degradedKinds set derived from frontmatterDegradations (skill before command by collection order), omitted when empty"
+
+patterns-established:
+  - "parse gate 1 (source) / gate 2 (staged) discipline around a bridge write seam"
+  - "degrade-record collection -> installCtx.frontmatterDegradations -> reasons[] (standalone) + postCommitWarnings (orchestrated detail) + InstallPluginOutcome.degradedKinds (orchestrated seam)"
+
+requirements-completed: [PARSE-01, PARSE-02, SKILL-01, WARN-01, NREG-01]
+
+coverage:
+  - id: D1
+    description: "Gate 1 parses SOURCE before rewrite/substitution; a throw synthesizes a disable-model-invocation block with body verbatim and records a degrade entry; install does not hard-fail"
+    requirement: "SKILL-01"
+    verification:
+      - kind: unit
+        ref: "tests/bridges/skills/stage.test.ts#SKILL-01 / PARSE-01 unparseable source frontmatter -> synthesized disable-model-invocation block, body verbatim, degrade record"
+        status: pass
+    human_judgment: false
+  - id: D2
+    description: "Gate 2 re-parses staged bytes as a Pi-acceptability backstop; the synthesized output re-parses (does not throw); a happy-arm throw is our defect and rides the cleanup catch"
+    requirement: "PARSE-02"
+    verification:
+      - kind: unit
+        ref: "tests/bridges/skills/stage.test.ts#SKILL-01 / PARSE-01 unparseable source frontmatter -> synthesized disable-model-invocation block, body verbatim, degrade record"
+        status: pass
+    human_judgment: false
+  - id: D3
+    description: "Standalone install of a one-bad-skill plugin renders (installed) {malformed skill} at warning severity, returns an installed outcome (no hard-fail), and carries degradedKinds=[skill]"
+    requirement: "WARN-01"
+    verification:
+      - kind: unit
+        ref: "tests/orchestrators/plugin/install.test.ts#SKILL-01 / WARN-01: standalone install of a plugin with one unparseable skill -> (installed) {malformed skill} at warning severity, no hard-fail"
+        status: pass
+    human_judgment: false
+  - id: D4
+    description: "A valid skill is staged byte-for-byte identical to a name-rewrite + var-substitution of the source; the read-only gates mutate nothing on the happy path and the degrade list is empty"
+    requirement: "NREG-01"
+    verification:
+      - kind: unit
+        ref: "tests/bridges/skills/stage.test.ts#NREG-01 valid skill is staged byte-for-byte identical to a name-rewrite + var-substitution of the source (gates mutate nothing)"
+        status: pass
+    human_judgment: false
+  - id: D5
+    description: "After /reload, a degraded skill's /skill:<generated-name> resolves and the model never auto-invokes it (disable-model-invocation)"
+    requirement: "SKILL-01"
+    verification: []
+    human_judgment: true
+    rationale: "Runtime Pi-loader + /reload behavior is a backstop truth in the plan; not exercisable in unit tests (needs a live Pi session)."
+
+# Metrics
+duration: 36min
+completed: 2026-07-26
+status: complete
+---
+
+# Phase 86 Plan 02: Unparseable-skill degrade tracer Summary
+
+**Two read-only parseFrontmatter gates now wrap the skills staging seam end-to-end: an unparseable SOURCE frontmatter synthesizes a `disable-model-invocation` block (body verbatim) and still installs, surfacing `(installed) {malformed skill}` at warning severity, while a valid skill is proven byte-for-byte unchanged.**
+
+## Performance
+
+- **Duration:** ~36 min
+- **Started:** 2026-07-26
+- **Completed:** 2026-07-26
+- **Tasks:** 2
+- **Files modified:** 10 (9 modified, 1 fixture created)
+
+## Accomplishments
+- Gate 1 parses the SOURCE `SKILL.md` before `rewriteFrontmatterName`/`substituteClaudeVars`. A throw (closed `---` block, malformed inner YAML) routes to `synthesizeUnparseableSkill`; a return (including absent/empty frontmatter) keeps today's byte-identical passthrough. A new `extractBodyAfterFrontmatter` reproduces `parseFrontmatter`'s CRLF->LF + trim body normalization so the synthesized body matches the return-path body exactly.
+- Gate 2 re-parses the STAGED bytes after write as a Pi-acceptability backstop. A throw here (our own rewrite/substitution producing bytes Pi rejects) propagates to the existing `appendLeakToError`/`cleanupStaging` catch — never masked as author degradation (PARSE-02 / D-86-04).
+- The skills bridge returns a `degraded: { generatedName, parseError }[]` list; the install orchestrator collects it into `installCtx.frontmatterDegradations` (mapping skill/command kinds), pushes one `{malformed skill}` / `{malformed command}` token per plugin onto the standalone `(installed)` row, raises that row to `warning` severity, and emits per-component `<plugin>/<component>: <parseError>` detail on the orchestrated `postCommitWarnings` channel. `InstallPluginOutcome.degradedKinds` is the inert seam the orchestrated reconcile row will consume.
+- The commands bridge/type carry an inert `degraded` field (empty) so the command neutralize arm can populate it without a later type change.
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: End-to-end unparseable-skill degrade (source gate to standalone row)** - `47353c3f` (feat)
+2. **Task 2: NREG-01 byte-equality regression for the valid-skill happy path** - `4cd11d2c` (test)
+
+## Files Created/Modified
+- `extensions/pi-claude-marketplace/bridges/skills/stage.ts` - two parse gates + `extractBodyAfterFrontmatter` + degrade collection/return
+- `extensions/pi-claude-marketplace/bridges/skills/types.ts` - `degraded` field on `StageSkillsCommitResult`
+- `extensions/pi-claude-marketplace/bridges/commands/types.ts` - `degraded` field on `StageCommandsCommitResult` (inert)
+- `extensions/pi-claude-marketplace/bridges/commands/stage.ts` - empty `degraded` at both result sites (inert)
+- `extensions/pi-claude-marketplace/orchestrators/plugin/install.ts` - `frontmatterDegradations` installCtx list, standalone reason tokens, warning severity, per-component detail, `degradedKinds` outcome seam
+- `extensions/pi-claude-marketplace/bridges/skills/frontmatter-degrade.ts` - eslint remediation (see Deviations)
+- `tests/bridges/skills/stage.test.ts` - unparseable-skill degrade case + NREG-01 byte-equality case
+- `tests/bridges/skills/frontmatter-degrade.test.ts` - drop redundant explicit type argument (eslint)
+- `tests/orchestrators/plugin/install.test.ts` - standalone `(installed) {malformed skill}` warning-row case
+- `tests/bridges/_fixtures/unparseable-skill-plugin/skills/bad-skill/SKILL.md` - NEW malformed-frontmatter fixture (`name: [unterminated`)
+
+## Decisions Made
+None beyond the locked decisions (D-86-01..07) the plan already fixed. Body extraction on the throw path was implemented as a small local helper (`extractBodyAfterFrontmatter`) rather than an exported degrade-module function, keeping the change localized to the staging seam.
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+**1. [Rule 3 - Blocking issue] Remediated pre-existing eslint debt in `frontmatter-degrade.ts` (and its test)**
+- **Found during:** Task 1 pre-commit (the `npm-lint` hook runs `eslint .` over the whole repo).
+- **Issue:** `bridges/skills/frontmatter-degrade.ts` and `tests/bridges/skills/frontmatter-degrade.test.ts` (both from Plan 01, unchanged at HEAD) failed `eslint .` — `no-non-null-assertion`, `sonarjs/cognitive-complexity` (17 > 15) on `firstBodyParagraph`/`setDescriptionScalar`, `prefer-string-starts-ends-with`, and an unnecessary type argument. Plan 01's code was committed via a `--no-verify` path and never run through `eslint .`, leaving the repo lint-red at HEAD. This blocked any hook-respecting commit (CLAUDE.md forbids `--no-verify`).
+- **Fix:** Extracted `skipFencedBlock` / `collectParagraph` from `firstBodyParagraph` and `frontmatterBlockEnd` / `descriptionValueEnd` from `setDescriptionScalar` to drop cognitive complexity under 15; replaced `arr[i]!` non-null assertions with `arr[i] ?? ""` guarded reads; replaced `/^description:/.test(...)` with `startsWith`; dropped the redundant `parseFrontmatter<Record<string, unknown>>` type argument in the test. Behavior is identical — verified by the 14 pre-existing `frontmatter-degrade.test.ts` unit cases (all pass).
+- **Files modified:** `extensions/pi-claude-marketplace/bridges/skills/frontmatter-degrade.ts`, `tests/bridges/skills/frontmatter-degrade.test.ts`
+- **Commit:** `47353c3f` (bundled into Task 1, as it blocked that commit)
+
+## Issues Encountered
+- The `npm-lint` pre-commit hook lints the whole repo (`eslint .`), so Plan 01's un-linted debt surfaced as a hard commit blocker; resolved via the Rule 3 fix above. Prettier reformatted one multi-line signature in `frontmatter-degrade.ts` during the hook run; re-staged and re-ran clean.
+
+## User Setup Required
+None.
+
+## Next Phase Readiness
+- The gate-1 RETURN branch is a byte-identical passthrough today; Plan 03 (skills augment) hangs the description/`when_to_use` fill on that branch.
+- `StageCommandsCommitResult.degraded` and the `kind: "command"` collection in the commands phase are wired but inert; Plan 04 (command neutralize) populates them with no further orchestrator change.
+- `InstallPluginOutcome.degradedKinds` is the seam Plan 05 (orchestrated reconcile row) reads to push the token onto the reconcile `plugin-installed` arm.
+
+## Self-Check: PASSED
+
+- Fixture `tests/bridges/_fixtures/unparseable-skill-plugin/skills/bad-skill/SKILL.md` exists on disk.
+- Both task commits present in git history (`47353c3f`, `4cd11d2c`).
+- `npm run typecheck` green; `eslint` clean on all touched files; `node --test` across the skills degrade + stage + commands stage + install suites: 150 pass / 0 fail; full `npm test`: 3036 pass / 0 fail / 1 pre-existing platform skip.
+
+---
+*Phase: 86-skill-and-command-frontmatter-compliance*
+*Completed: 2026-07-26*

--- a/.planning/phases/86-skill-and-command-frontmatter-compliance/86-03-PLAN.md
+++ b/.planning/phases/86-skill-and-command-frontmatter-compliance/86-03-PLAN.md
@@ -1,0 +1,171 @@
+---
+phase: 86-skill-and-command-frontmatter-compliance
+plan: 03
+type: execute
+wave: 3
+depends_on: ["86-02"]
+files_modified:
+  - extensions/pi-claude-marketplace/bridges/skills/stage.ts
+  - extensions/pi-claude-marketplace/bridges/skills/rewrite-frontmatter.ts
+  - tests/bridges/skills/stage.test.ts
+  - tests/bridges/skills/rewrite-frontmatter.test.ts
+autonomous: true
+requirements: [SKILL-02, SKILL-03, WTU-01, WTU-02]
+
+must_haves:
+  truths:
+    - "A skill with an absent or empty `description` (well-formed frontmatter) gets a first-paragraph-of-body fallback via `firstBodyParagraph` and remains model-invocable (SKILL-02 · unclassified probe / D-86-06)."
+    - "`firstBodyParagraph` on an empty/whitespace-only body yields an empty candidate; the augment arm still produces a non-empty `description` sufficient to clear Pi's non-empty gate (SKILL-02 · empty probe)."
+    - "Description equality is exact-string on the parsed value (no normalization beyond parseFrontmatter's own CRLF/trim), and length is JS `.length` UTF-16 code units (SKILL-02 · encoding probe)."
+    - "A skill's `when_to_use` text is appended to the Pi `description` with a single `\\n` separator; empty `when_to_use` appends nothing (WTU-01 · empty probe; A1)."
+    - "The combined `description` + `when_to_use` is truncated at 1,536 UTF-16 code units, hard cut with no ellipsis, dropping the appended tail (WTU-02 · boundary/empty/encoding/precision probes; A2)."
+    - "The `description` set uses `setDescriptionScalar` (full node span replace + safe double-quoted scalar), so a source `>-`/`|` block-scalar `description` cannot be corrupted (the SKILL-03 class)."
+    - "The written skill `name` always equals the generated name; a folded or multi-line source `name:` scalar cannot silently corrupt it — the rewrite is verified against the parsed value, not a blind `^name:` line regex (SKILL-03)."
+    - "SKILL-03 name equality is checked on the re-parsed staged value (exact string), covering empty/absent source `name` (rewrite still lands the generated name) (SKILL-03 · empty/encoding probes)."
+    - "Gate 2 re-parse of the augmented bytes returns (does not throw); an augment-arm gate-2 throw is our defect (PARSE-02)."
+  prohibitions:
+    - "MUST NOT silently truncate the combined description to Pi's 1024-char cap — that would drop trigger keywords and diverge from Claude Code's 1,536 listing cap (D-86-05)."
+    - "MUST NOT re-emit the whole frontmatter block to set `description` — whole-block re-emit flattens nested maps / block scalars and damages ~13% of real skills (NREG-01)."
+    - "MUST NOT replace the `description` or `name` via a single `^description:`/`^name:` line regex on a multi-line block scalar (the SKILL-03 corruption class)."
+  artifacts:
+    - "extensions/pi-claude-marketplace/bridges/skills/stage.ts — augment arm on the gate-1 RETURN branch (first-paragraph fill, when_to_use fold, truncate, surgical description set)"
+    - "extensions/pi-claude-marketplace/bridges/skills/rewrite-frontmatter.ts — SKILL-03 name-equals-generated verification (full node span / parsed-value check)"
+    - "tests/bridges/skills/stage.test.ts — description-less / when_to_use / block-scalar / >1024 cases"
+    - "tests/bridges/skills/rewrite-frontmatter.test.ts — folded / multi-line `name` cases"
+  key_links:
+    - "gate-1 RETURN branch -> inspect `frontmatter.description` / `frontmatter.when_to_use` -> `setDescriptionScalar` -> gate-2 backstop"
+    - "`rewriteFrontmatterName` output -> re-parse -> assert `name === generatedName` (SKILL-03 oracle)"
+---
+
+<assumption_delta_decision>
+no-change — The deterministic detector fired on the term "fallback" in "first-paragraph fallback" (SKILL-02). This is a FALSE POSITIVE: "fallback" names the description-fallback degrade path, NOT a singular->plural identity/abstraction generalization; no core noun loses its monopoly. No assumption change recorded.
+</assumption_delta_decision>
+
+<objective>
+Expand the proven degrade slice (Plan 02) into the gate-1 RETURN (well-formed-source) branch: fill an absent/empty `description` from the first body paragraph (SKILL-02), fold `when_to_use` into the `description` Pi reads and hard-cut the combined text at 1,536 chars (WTU-01/WTU-02), applying both through the surgical single-key `setDescriptionScalar` so a block-scalar source `description` cannot be corrupted; and verify the rewritten skill `name` equals the generated name so a folded source `name:` scalar cannot silently corrupt it (SKILL-03).
+
+Purpose: This is the phase's central technical risk (NREG-safe multi-line `description` set) and the genuine Claude-Code parity for description-less and trigger-carrying skills. It reuses the helper (Plan 01) and the gate seam (Plan 02) — a horizontal expansion, no new architecture.
+Output: The augment arm and the SKILL-03 name verification, with block-scalar/folded fixtures.
+</objective>
+
+<execution_context>
+@/home/acolomba/pi-claude-marketplace/.claude/gsd-core/workflows/execute-plan.md
+@/home/acolomba/pi-claude-marketplace/.claude/gsd-core/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/86-skill-and-command-frontmatter-compliance/86-CONTEXT.md
+@.planning/phases/86-skill-and-command-frontmatter-compliance/86-RESEARCH.md
+@.planning/phases/86-skill-and-command-frontmatter-compliance/86-PATTERNS.md
+@.claude/rules/typescript-comments.md
+
+# Prior plan output consumed here
+@.planning/phases/86-skill-and-command-frontmatter-compliance/86-02-SUMMARY.md
+
+# Files touched (read before editing)
+@extensions/pi-claude-marketplace/bridges/skills/stage.ts
+@extensions/pi-claude-marketplace/bridges/skills/rewrite-frontmatter.ts
+@extensions/pi-claude-marketplace/bridges/skills/frontmatter-degrade.ts
+</context>
+
+<artifacts_this_phase>
+New symbols/behavior introduced by this plan:
+- The gate-1 RETURN augment arm in `skills/stage.ts` (SKILL-02 fill + WTU-01 fold + WTU-02 truncate via `setDescriptionScalar`).
+- SKILL-03 name-equals-generated verification in `rewrite-frontmatter.ts` (parsed-value oracle over the multi-line-scalar-corruption class).
+</artifacts_this_phase>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Augment arm — first-paragraph fill, when_to_use fold, 1,536 truncation</name>
+  <read_first>
+    - extensions/pi-claude-marketplace/bridges/skills/stage.ts §159-176 (the seam and the gate-1 RETURN branch established in Plan 02)
+    - extensions/pi-claude-marketplace/bridges/skills/frontmatter-degrade.ts (Plan 01 helpers: `firstBodyParagraph`, `foldWhenToUse`, `truncate1536`, `setDescriptionScalar`)
+    - 86-RESEARCH.md §"Pattern 2", §"Common Pitfalls" (1024-vs-1536 divergence; multi-line description corruption), §"State of the Art" (upstream field contract)
+    - 86-CONTEXT.md D-86-05 (1,536 stays; >1024 still loads), D-86-06 (first-body-line), A1/A2
+    - tests/bridges/skills/stage.test.ts (harness; the fixtures added in Plan 01/02)
+  </read_first>
+  <files>extensions/pi-claude-marketplace/bridges/skills/stage.ts, tests/bridges/skills/stage.test.ts</files>
+  <behavior>
+    - Description-less well-formed skill: staged `description` equals `firstBodyParagraph(body)`; the skill stays model-invocable (no `disable-model-invocation`).
+    - Skill with `when_to_use`: staged `description` equals `truncate1536(foldWhenToUse(effectiveDescription, whenToUse))`.
+    - Combined text 1025..1536 chars: staged unchanged (no cut) and gate 2 returns; a >1024 combined value still parses to a non-empty `description`.
+    - Combined text 1537 chars: staged `description` is exactly 1536 UTF-16 code units.
+    - `>-` block-scalar source `description`: the augment set replaces the full node span; sibling keys stay byte-identical; gate 2 returns.
+  </behavior>
+  <action>
+    On the gate-1 RETURN branch in `skills/stage.ts`, after `rewriteFrontmatterName` (name) but as a distinct `description` computation: read `frontmatter.description` and `frontmatter.when_to_use` from the gate-1 parse result. Compute the effective description: if `description` is absent or empty, use `firstBodyParagraph(body)`; else use `description`. If `when_to_use` is non-empty, set `effective = foldWhenToUse(effective, whenToUse)`. Apply `truncate1536(effective)`. If the effective value differs from the source `description`, write it back with `setDescriptionScalar` (full node span, safe double-quoted scalar); if it is identical AND there was no `when_to_use` to fold, leave the frontmatter untouched (NREG-01). Run `substituteClaudeVars` and write, then GATE 2 re-parse (a throw here on this augment arm is our defect — rethrow per PARSE-02). Honor D-86-05: cut at 1,536, never at 1024. Anchor comments to SKILL-02 / WTU-01 / WTU-02 / D-86-05 / D-86-06 only.
+  </action>
+  <verify>
+    <automated>node --test "tests/bridges/skills/stage.test.ts" && npm --prefix . run typecheck</automated>
+  </verify>
+  <acceptance_criteria>
+    - A case asserts a description-less skill stages a non-empty `description` equal to the first body paragraph and carries no `disable-model-invocation`.
+    - A case asserts a `when_to_use` skill stages `description` ending with the folded `when_to_use` text (single `\n` separator) and, for a source combined length 1537, a staged `description` of `.length === 1536`.
+    - A case stages a combined description in the 1025..1536 range and asserts `parseFrontmatter` on the staged bytes returns a non-empty `description` (does not throw, not empty) — the >1024 path.
+    - A `>-` block-scalar source description case asserts sibling keys are byte-identical and gate 2 returns.
+    - `npm run typecheck` is green.
+  </acceptance_criteria>
+  <done>Description-less and trigger-carrying skills are augmented at Claude-Code parity, block-scalar-safe, capped at 1,536.</done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: SKILL-03 — verify the written name equals the generated name</name>
+  <read_first>
+    - extensions/pi-claude-marketplace/bridges/skills/rewrite-frontmatter.ts §21-43 (the `^name:.*$` line replace that corrupts a folded/block-scalar `name:`)
+    - extensions/pi-claude-marketplace/platform/pi-api.ts (`parseFrontmatter` — the verification oracle)
+    - tests/bridges/skills/rewrite-frontmatter.test.ts (existing cases to extend)
+    - 86-RESEARCH.md §"Anti-Patterns" (blind line replace), diagnosis doc §"Blast radius" (folded name -> `acme-skill my skill` corruption)
+  </read_first>
+  <files>extensions/pi-claude-marketplace/bridges/skills/rewrite-frontmatter.ts, tests/bridges/skills/rewrite-frontmatter.test.ts</files>
+  <action>
+    Make `rewriteFrontmatterName` (or a thin verification alongside it) guarantee the written `name` equals `newName` when re-parsed: replace the FULL `name` node span (not just the first `^name:` line) so a folded (`name: >\n  a\n  b`) or block source scalar cannot leave orphaned continuation lines, and/or re-parse the rewritten frontmatter and assert `frontmatter.name === newName`, throwing a clear error if not (a self-inflicted defect, PARSE-02 family). Keep the pure-string / READ-ONLY posture (T-03-17): parse to VALIDATE, never eval. Extend `rewrite-frontmatter.test.ts` with a folded multi-line `name:` fixture and an absent-`name` fixture, asserting the re-parsed staged `name` equals the generated name in both.
+  </action>
+  <verify>
+    <automated>node --test "tests/bridges/skills/rewrite-frontmatter.test.ts" && npm --prefix . run typecheck</automated>
+  </verify>
+  <acceptance_criteria>
+    - A case with a folded multi-line source `name:` asserts the re-parsed staged `name` exactly equals the generated name (no orphaned continuation lines, no `<gen> a b` corruption).
+    - A case with no source `name:` asserts the staged `name` equals the generated name.
+    - `node --test "tests/bridges/skills/rewrite-frontmatter.test.ts"` passes.
+  </acceptance_criteria>
+  <done>A folded or absent source `name:` can no longer silently produce a skill under the wrong name.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| plugin author -> skills bridge augment arm | Untrusted `description` / `when_to_use` / body values are read and re-emitted as a `description` scalar Pi will parse. |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Severity | Disposition | Mitigation Plan |
+|-----------|----------|-----------|----------|-------------|-----------------|
+| T-86-02 | Tampering (Injection) | `setDescriptionScalar` safe scalar emit | high | mitigate | Escape `\`/`"`, collapse newlines; full node-span replace + gate-2 re-parse backstop prevents an author scalar re-forming a new YAML key (AG-8 class) |
+| T-86-04 | DoS (context) | combined description length | low | mitigate | `truncate1536` hard cut bounds listing size (WTU-02) |
+| T-86-01 | Tampering | gate-2 re-parse | high | mitigate | Read-only `parseFrontmatter`; an augment-arm throw fails loudly (PARSE-02), never ships bytes Pi rejects |
+| T-86-SC | Tampering | npm/pip/cargo installs | low | accept | No package installs this phase |
+
+Block threshold: `high`. T-86-01 and T-86-02 are mitigated by the safe emitter + gate-2 backstop; no `high` threat is unmitigated.
+</threat_model>
+
+<verification>
+- `node --test "tests/bridges/skills/stage.test.ts" "tests/bridges/skills/rewrite-frontmatter.test.ts"` pass.
+- `npm run typecheck` green.
+- Per-wave merge: `npm test` + `npm run test:integration`.
+</verification>
+
+<success_criteria>
+- Description-less skills gain a first-paragraph description; `when_to_use` is folded and capped at 1,536; block-scalar and folded-`name` sources are corruption-proof; the >1024 combined value still loads in Pi.
+</success_criteria>
+
+<output>
+Create `.planning/phases/86-skill-and-command-frontmatter-compliance/86-03-SUMMARY.md` when done.
+</output>

--- a/.planning/phases/86-skill-and-command-frontmatter-compliance/86-03-SUMMARY.md
+++ b/.planning/phases/86-skill-and-command-frontmatter-compliance/86-03-SUMMARY.md
@@ -1,0 +1,191 @@
+---
+phase: 86-skill-and-command-frontmatter-compliance
+plan: 03
+subsystem: bridges
+tags: [frontmatter, skills, when_to_use, description, yaml, block-scalar, degrade]
+
+# Dependency graph
+requires:
+  - phase: 86-01
+    provides: "frontmatter-degrade helpers (firstBodyParagraph, foldWhenToUse, truncate1536, setDescriptionScalar) + parseFrontmatter re-export"
+  - phase: 86-02
+    provides: "two read-only parse gates in skills/stage.ts; the gate-1 RETURN branch (byte-identical passthrough) the augment arm hangs on"
+provides:
+  - "Gate-1 RETURN augment arm in skills/stage.ts: absent/empty description filled from first body paragraph (SKILL-02/D-86-06), when_to_use folded in (WTU-01/A1), combined text hard-cut at 1,536 (WTU-02/D-86-05/A2), applied via setDescriptionScalar (block-scalar-safe)"
+  - "setDescriptionScalar now INSERTS a description key when the source has none (description-less fill), in addition to full-node-span replacement"
+  - "SKILL-03 name verification in rewrite-frontmatter.ts: full name-node-span replacement (folded/block scalars) + re-parse assertion that the written name equals the generated name"
+affects:
+  - "86-04 (commands neutralize — sibling staging seam)"
+  - "86-05 (orchestrated reconcile row — consumes degrade signal, unaffected by augment)"
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - "Compute the description value from the PARSED frontmatter/body, then surgically set a single node span (never re-emit the block) — extends the Plan 01 pattern to the fill/fold/truncate augment arm"
+    - "Re-parse-to-verify backstop: a name/description rewrite is validated against Pi's own parseFrontmatter output, never a blind line regex (SKILL-03)"
+
+key-files:
+  created: []
+  modified:
+    - extensions/pi-claude-marketplace/bridges/skills/stage.ts
+    - extensions/pi-claude-marketplace/bridges/skills/frontmatter-degrade.ts
+    - extensions/pi-claude-marketplace/bridges/skills/rewrite-frontmatter.ts
+    - tests/bridges/skills/stage.test.ts
+    - tests/bridges/skills/rewrite-frontmatter.test.ts
+
+key-decisions:
+  - "The augment arm runs only on the gate-1 RETURN (well-formed) branch, after rewriteFrontmatterName; the synthesize (unparseable) arm already emits a name + placeholder description and skips it"
+  - "NREG-01 guard: a present, in-cap description with no when_to_use is left byte-identical (setDescriptionScalar is NOT called), preserving the ~99% happy path"
+  - "A description-less skill with no prose body (empty first-paragraph candidate) falls back to a fixed non-empty placeholder ('No description provided.') so Pi does not drop it (skill:null on empty description)"
+  - "setDescriptionScalar extended to INSERT a description key when absent (the description-less source has no line to replace) rather than returning unchanged"
+  - "SKILL-03 corruption is prevented by full name-node-span replacement AND a re-parse equality assertion; a residual mismatch throws loudly as a self-defect (PARSE-02 family)"
+
+patterns-established:
+  - "Parsed-value-in, single-node-span-out augment: read description/when_to_use/body from parseFrontmatter, compute the effective value, write exactly one YAML node"
+  - "Re-parse verification of a surgical frontmatter rewrite as a self-defect backstop"
+
+requirements-completed: [SKILL-02, SKILL-03, WTU-01, WTU-02]
+
+coverage:
+  - id: D1
+    description: "A description-less well-formed skill stages a first-body-paragraph description (skipping heading) and stays model-invocable (no disable-model-invocation)"
+    requirement: "SKILL-02"
+    verification:
+      - kind: unit
+        ref: "tests/bridges/skills/stage.test.ts#SKILL-02 description-less skill stages a first-body-paragraph description and stays model-invocable"
+        status: pass
+    human_judgment: false
+  - id: D2
+    description: "A description-less skill with no prose body still stages a non-empty description (Pi loads it, does not drop as skill:null)"
+    requirement: "SKILL-02"
+    verification:
+      - kind: unit
+        ref: "tests/bridges/skills/stage.test.ts#SKILL-02 empty probe: a description-less skill with no prose body still stages a non-empty description"
+        status: pass
+    human_judgment: false
+  - id: D3
+    description: "when_to_use is folded into the description and the combined text is hard-cut at exactly 1,536 UTF-16 code units (no ellipsis)"
+    requirement: "WTU-01"
+    verification:
+      - kind: unit
+        ref: "tests/bridges/skills/stage.test.ts#WTU-01 / WTU-02 when_to_use is folded into the description and hard-cut at 1,536"
+        status: pass
+    human_judgment: false
+  - id: D4
+    description: "A >1024 combined description still re-parses to a non-empty description (Pi loads it) — not secretly truncated to Pi's 1,024 warning threshold (D-86-05)"
+    requirement: "WTU-02"
+    verification:
+      - kind: unit
+        ref: "tests/bridges/skills/stage.test.ts#WTU-02 / D-86-05 a >1024 combined description still parses to a non-empty description (Pi loads it)"
+        status: pass
+    human_judgment: false
+  - id: D5
+    description: "A >- block-scalar source description folded with when_to_use is replaced as a full node span; sibling keys stay byte-identical; gate 2 re-parses"
+    requirement: "WTU-01"
+    verification:
+      - kind: unit
+        ref: "tests/bridges/skills/stage.test.ts#SKILL-03 / WTU-01 a `>-` block-scalar description is replaced as a full node span, siblings byte-identical"
+        status: pass
+    human_judgment: false
+  - id: D6
+    description: "A folded multi-line source name: scalar is rewritten to exactly the generated name (no orphaned continuation lines, no `<gen> a b` corruption); siblings preserved"
+    requirement: "SKILL-03"
+    verification:
+      - kind: unit
+        ref: "tests/bridges/skills/rewrite-frontmatter.test.ts#SKILL-03 folded multi-line source name is rewritten to the generated name (no orphaned continuation lines)"
+        status: pass
+    human_judgment: false
+  - id: D7
+    description: "An absent source name: is inserted as the generated name; the re-parsed staged name equals the generated name"
+    requirement: "SKILL-03"
+    verification:
+      - kind: unit
+        ref: "tests/bridges/skills/rewrite-frontmatter.test.ts#SKILL-03 absent source name is inserted as the generated name"
+        status: pass
+    human_judgment: false
+  - id: D8
+    description: "A valid skill with a present description and no when_to_use is still staged byte-for-byte identical (augment arm leaves it untouched)"
+    requirement: "NREG-01"
+    verification:
+      - kind: unit
+        ref: "tests/bridges/skills/stage.test.ts#NREG-01 valid skill is staged byte-for-byte identical to a name-rewrite + var-substitution of the source (gates mutate nothing)"
+        status: pass
+    human_judgment: false
+
+# Metrics
+duration: 45min
+completed: 2026-07-26
+status: complete
+---
+
+# Phase 86 Plan 03: Skill description augment + SKILL-03 name verification Summary
+
+**The gate-1 RETURN arm now fills a description-less skill from its first body paragraph, folds `when_to_use` in and hard-cuts the combined text at 1,536 — all through the block-scalar-safe `setDescriptionScalar` — and the name rewrite is verified against Pi's own parser so a folded source `name:` can never silently produce a wrong-named skill.**
+
+## Performance
+
+- **Duration:** ~45 min
+- **Started:** 2026-07-26
+- **Completed:** 2026-07-26
+- **Tasks:** 2
+- **Files modified:** 5 (5 modified, 0 created)
+
+## Accomplishments
+- On the well-formed (gate-1 RETURN) branch, `skills/stage.ts` now augments the `description` Pi reads: an absent/empty `description` is filled from the first body paragraph (`firstBodyParagraph`, skipping headings/code fences per D-86-06), a non-empty `when_to_use` is folded in after a single `\n` (WTU-01/A1), and the combined text is hard-cut at 1,536 UTF-16 code units with no ellipsis (WTU-02/D-86-05/A2). The value is written through `setDescriptionScalar`, so a `>-`/`|` block-scalar source `description` collapses into one safe double-quoted scalar with every sibling key left byte-identical.
+- `setDescriptionScalar` gained an INSERT arm: a description-less source (no `description:` line to replace) gets the scalar inserted as the last frontmatter line. An empty first-paragraph candidate on a bodyless skill falls back to a fixed non-empty placeholder so Pi does not drop the skill (`skill: null` on empty description).
+- `rewrite-frontmatter.ts` now replaces the FULL `name` node span (folded/block scalars included) and re-parses the result with Pi's own `parseFrontmatter`, asserting the written `name` equals the generated name — a folded or absent source `name:` can no longer corrupt the generated name, and a residual mismatch throws loudly as our own defect.
+- NREG-01 preserved: a valid skill with a present, in-cap `description` and no `when_to_use` is left byte-for-byte identical (the augment arm short-circuits before `setDescriptionScalar`), proven by the unchanged byte-equality regression.
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Augment arm — first-paragraph fill, when_to_use fold, 1,536 truncation** - `2c75676d` (feat)
+2. **Task 2: SKILL-03 — verify the written name equals the generated name** - `a81e7def` (feat)
+
+_TDD note: each task's tests were written and confirmed failing before the implementation, then confirmed passing. Because the whole-project `tsc`/`eslint .` pre-commit hooks reject a repo that is not lint-clean, each task's test + implementation landed in one atomic commit rather than separate RED/GREEN commits._
+
+## Files Created/Modified
+- `extensions/pi-claude-marketplace/bridges/skills/stage.ts` - gate-1 RETURN augment arm (`augmentSkillDescription`) + captured parse result; empty-body placeholder constant
+- `extensions/pi-claude-marketplace/bridges/skills/frontmatter-degrade.ts` - `setDescriptionScalar` now inserts a `description:` key when absent (doc comment updated)
+- `extensions/pi-claude-marketplace/bridges/skills/rewrite-frontmatter.ts` - full name-node-span replacement + re-parse name-equals-generated backstop
+- `tests/bridges/skills/stage.test.ts` - 5 augment-arm cases (description-less, empty-body, when_to_use fold + 1537→1536, >1024 loads, block-scalar+when_to_use node span)
+- `tests/bridges/skills/rewrite-frontmatter.test.ts` - folded multi-line `name:` and absent-`name:` cases
+
+## Decisions Made
+None beyond the locked decisions (D-86-05/D-86-06, A1/A2) the plan fixed. Two implementation choices within discretion: (1) the empty-first-paragraph fallback placeholder string is `No description provided.` (a short YAML-safe non-empty constant, kept local to the augment arm since the frontmatter parsed cleanly — distinct from D-86-02's unparseable-source placeholder); (2) `setDescriptionScalar`'s insert position is the last frontmatter line (before the closing `---`), preserving sibling key order.
+
+## Assumption Delta
+`no-change` — The plan's deterministic detector flagged the word "fallback" (in "first-paragraph fallback") as a possible singular→plural generalization. Confirmed FALSE POSITIVE: "fallback" names the description-fallback degrade path, not an identity/abstraction change. No assumption recorded.
+
+## Deviations from Plan
+
+None - plan executed exactly as written. (The `prefer-includes` lint fix and one prettier reflow on this plan's own new code are normal in-task cleanup, not deviations.)
+
+## Issues Encountered
+- The safe double-quoted scalar emitter collapses a multi-line first-body paragraph's internal `\n` into a space; the SKILL-02 test expectation was written to the collapsed (single-line) form, which is the correct emitted shape.
+- Two `tests/integration/*` cases fail on this branch (`provenance-invisibility`, `skill-path-resolution`). They are PRE-EXISTING and unrelated to this plan: reverting the three bridge sources to `HEAD~2` and re-running only those two tests reproduces the identical 2 failures (they exercise the pi-subagents runtime resolution surface, write their own `SKILL.md` inline, and never call `prepareStageSkills`). Recorded in `deferred-items.md`.
+
+## Test Results
+- `node --test tests/bridges/skills/*.test.ts tests/orchestrators/plugin/install.test.ts tests/platform/pi-api.test.ts`: 168 pass / 0 fail.
+- Full unit suite (`npm test`): 3043 pass / 0 fail / 1 pre-existing skip.
+- `npm run typecheck`, whole-repo `eslint .`, and `prettier --check` on changed files: clean.
+- `npm run test:integration`: 16 pass / 2 fail — both failures pre-existing (see above).
+
+## User Setup Required
+None - no external service configuration required.
+
+## Next Phase Readiness
+- Skill description + name compliance is complete: description-less, trigger-carrying (`when_to_use`), block-scalar, folded-`name`, and >1024-combined skills are all handled at Claude-Code parity, corruption-proof, and NREG-safe.
+- Plan 04 (command neutralize) and Plan 05 (orchestrated reconcile row) are unaffected — they consume the degrade seam wired in Plan 02, which this plan did not touch.
+
+## Self-Check: PASSED
+
+- All modified files exist on disk; both task commits present in git history (`2c75676d`, `a81e7def`).
+- `npm run typecheck` green; targeted skills/orchestrator/platform suites 168/168 pass; full unit suite 3043 pass / 1 pre-existing skip.
+- Working tree clean and byte-identical to HEAD after the pre-existing-failure isolation check.
+
+---
+*Phase: 86-skill-and-command-frontmatter-compliance*
+*Completed: 2026-07-26*

--- a/.planning/phases/86-skill-and-command-frontmatter-compliance/86-04-PLAN.md
+++ b/.planning/phases/86-skill-and-command-frontmatter-compliance/86-04-PLAN.md
@@ -1,0 +1,132 @@
+---
+phase: 86-skill-and-command-frontmatter-compliance
+plan: 04
+type: execute
+wave: 3
+depends_on: ["86-02"]
+files_modified:
+  - extensions/pi-claude-marketplace/bridges/commands/stage.ts
+  - tests/bridges/commands/stage.test.ts
+autonomous: true
+requirements: [CMD-01, PARSE-01, PARSE-02, NREG-01]
+
+must_haves:
+  truths:
+    - "Gate 1 parses the SOURCE command `.md` with `parseFrontmatter` BEFORE `substituteClaudeVars` at the commands seam (PARSE-01)."
+    - "A THROW at gate 1 neutralizes the command by STRIPPING the entire malformed frontmatter block (opening `---` through the closing `---`), leaving the real body, so a re-parse RETURNS empty and Pi takes name-from-filename + description-from-first-body-line (CMD-01 / D-86-07)."
+    - "An empty / no-delimiter command source does NOT throw and needs no neutralize (parseFrontmatter returns empty already) (CMD-01 · empty probe)."
+    - "The neutralized output has no synthesized placeholder `description` and no `disable-model-invocation` flag — Pi's command loader has no non-empty-description gate (CMD-01)."
+    - "Gate 2 re-parses the STAGED bytes; the neutralized output is designed to RETURN, so a gate-2 THROW here is always our defect and throws loudly (PARSE-02 / D-86-04)."
+    - "Each neutralized command pushes a `{ generatedName, parseError }` degrade record onto `StageCommandsCommitResult.degraded`; the install orchestrator (Plan 02) already collects it as kind `command` and emits `malformed command`."
+    - "Command parse errors are measured/sliced on the source string as-is (no re-encoding); the neutralize strips by delimiter index, not by byte offset assumptions (CMD-01 · encoding probe)."
+    - "A valid command (parseable frontmatter) is written byte-for-byte identical after the read-only gates — only `${CLAUDE_PLUGIN_ROOT}`/`${CLAUDE_PLUGIN_DATA}` substitution changes bytes (NREG-01)."
+  prohibitions:
+    - "MUST NOT strip only the `---` delimiter lines and leave the ex-frontmatter text as body — that would become a poor first-body-line description (D-86-07 rejects delimiter-only stripping)."
+    - "MUST NOT synthesize a placeholder `description` or a disable flag for commands (that is the skills degrade shape, not the command one) (CMD-01)."
+    - "MUST NOT rewrite or reformat a valid command's frontmatter (NREG-01 byte-identity)."
+  artifacts:
+    - "extensions/pi-claude-marketplace/bridges/commands/stage.ts — gate 1 + gate 2 + neutralize arm + degrade-record population"
+    - "tests/bridges/commands/stage.test.ts — throwing-command neutralize + NREG byte-equality cases"
+  key_links:
+    - "commands/stage.ts seam (readFile -> gate1 -> substitute -> writeFile -> gate2) parallels the skills seam"
+    - "`StageCommandsCommitResult.degraded` (field added in Plan 02) -> installCtx command-kind records -> `malformed command` token"
+---
+
+<objective>
+Bring the commands bridge to the same parse-gate parity as the skills bridge: insert the two read-only `parseFrontmatter` gates into `bridges/commands/stage.ts`, and on a gate-1 throw NEUTRALIZE the command by stripping the entire malformed frontmatter block so Pi loads it with name-from-filename and description-from-first-body-line — the literal Claude-Code malformed-command behavior (no synthesized placeholder, no disable flag). Populate the `degraded` record the install orchestrator (Plan 02) already collects and classifies as `malformed command`.
+
+Purpose: The commands bridge has the identical silent-failure gap as skills (diagnosis §"Blast radius": `loadTemplateFromFile` swallows the parse throw). This closes CMD-01 and completes PARSE-01/02 on the second seam, reusing the degrade-signal wire the tracer proved.
+Output: Two live gates + a neutralize arm in the commands bridge, plus byte-equality proof for valid commands.
+</objective>
+
+<execution_context>
+@/home/acolomba/pi-claude-marketplace/.claude/gsd-core/workflows/execute-plan.md
+@/home/acolomba/pi-claude-marketplace/.claude/gsd-core/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/86-skill-and-command-frontmatter-compliance/86-CONTEXT.md
+@.planning/phases/86-skill-and-command-frontmatter-compliance/86-RESEARCH.md
+@.planning/phases/86-skill-and-command-frontmatter-compliance/86-PATTERNS.md
+@.claude/rules/typescript-comments.md
+
+# Prior plan output consumed here
+@.planning/phases/86-skill-and-command-frontmatter-compliance/86-02-SUMMARY.md
+
+# Files touched (read before editing)
+@extensions/pi-claude-marketplace/bridges/commands/stage.ts
+@extensions/pi-claude-marketplace/bridges/commands/types.ts
+</context>
+
+<artifacts_this_phase>
+New symbols/behavior introduced by this plan:
+- Gate 1 + gate 2 + neutralize arm in `commands/stage.ts`, populating `StageCommandsCommitResult.degraded` (the field itself is added in Plan 02).
+- A neutralize transform that strips the full `---`...`---` block (D-86-07).
+</artifacts_this_phase>
+
+<tasks>
+
+<task type="tracer">
+  <name>Task 1: Commands parse gates + neutralize arm, end-to-end to the degrade record</name>
+  <read_first>
+    - extensions/pi-claude-marketplace/bridges/commands/stage.ts §148-167 (the `readFile -> substituteClaudeVars -> writeFile` seam and the `appendLeakToError`/`cleanupStaging` catch)
+    - extensions/pi-claude-marketplace/bridges/commands/types.ts §54-58 (`StageCommandsCommitResult` — the `degraded` field added in Plan 02)
+    - extensions/pi-claude-marketplace/bridges/skills/stage.ts (the gate-1/gate-2 shape landed in Plan 02 — mirror it)
+    - extensions/pi-claude-marketplace/platform/pi-api.ts (`parseFrontmatter` re-export)
+    - 86-RESEARCH.md §"Pi command loader" (name = basename, desc = first non-empty body line 60-cap), §"Common Pitfalls" (gate 1 does not throw on missing delimiters)
+    - 86-CONTEXT.md D-86-07 (strip the entire block), diagnosis doc §"Blast radius" (commands are fully silent today)
+  </read_first>
+  <files>extensions/pi-claude-marketplace/bridges/commands/stage.ts, tests/bridges/commands/stage.test.ts</files>
+  <action>
+    Wrap the per-command seam in `commands/stage.ts`. GATE 1: call `parseFrontmatter(content)` on the source inside a try BEFORE `substituteClaudeVars`. On THROW, neutralize: locate the opening `---` and its matching closing `\n---` and remove that entire block (D-86-07 — strip the whole block, NOT just the delimiter lines), leaving the real body; record `{ generatedName, parseError }` onto a local degrade list. On RETURN, keep today's path unchanged (NREG-01 passthrough). Run `substituteClaudeVars` and write. GATE 2: re-`parseFrontmatter` the staged bytes; the neutralized output is designed to RETURN, so a THROW here is our defect — rethrow so it rides the existing `appendLeakToError`/`cleanupStaging` catch (PARSE-02 / D-86-04). Return the collected `degraded` records from `prepareStageCommands` on `StageCommandsCommitResult`. The install orchestrator (Plan 02) already maps these to kind `command` and emits `malformed command` — no install.ts change here. Anchor comments to CMD-01 / PARSE-01 / PARSE-02 / D-86-07 only; no phase/plan/wave references.
+  </action>
+  <verify>
+    <automated>node --test "tests/bridges/commands/stage.test.ts" && npm --prefix . run typecheck</automated>
+  </verify>
+  <acceptance_criteria>
+    - A case stages a command whose frontmatter throws (unquoted `: ` mid-scalar) and asserts the staged `.md` has NO `---` frontmatter block, the real body is intact as the leading content, and `parseFrontmatter` on the staged bytes RETURNS empty (does not throw).
+    - The same case asserts `prepareStageCommands` result `degraded` carries one record with the generated name and a non-empty `parseError`, and that the staged output contains no synthesized `description` and no `disable-model-invocation`.
+    - An NREG case asserts a valid command is written byte-for-byte identical except for `${CLAUDE_PLUGIN_ROOT}`/`${CLAUDE_PLUGIN_DATA}` substitution, with `result.degraded.length === 0`.
+    - `npm run typecheck` is green.
+  </acceptance_criteria>
+  <done>An unparseable command installs neutralized (name-from-filename + first-body-line) with a `malformed command` degrade record, and valid commands are byte-for-byte unchanged.</done>
+  <reversibility rating="reversible">Additive gate + neutralize on an existing seam; revertible by removing the wrapper.</reversibility>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| plugin author -> commands bridge | Untrusted command `.md` bytes are parsed (read-only) at both gates; a malformed source has its frontmatter block stripped. |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Severity | Disposition | Mitigation Plan |
+|-----------|----------|-----------|----------|-------------|-----------------|
+| T-86-01 | Tampering/Elevation | gate 1 / gate 2 `parseFrontmatter` | high | mitigate | Data-only parse via the `platform/pi-api.ts` re-export; READ-ONLY (validate, never eval) — preserves T-03-17 |
+| T-86-06 | Tampering | frontmatter-block strip | medium | mitigate | Strip by matched `---`...`\n---` delimiter span only; gate-2 re-parse backstop proves the stripped output is Pi-parseable (RETURNS empty), never ships bytes Pi rejects |
+| T-86-05 | Tampering | path escape via crafted command dir | low | accept | UNCHANGED — existing `assertPathInside` guards; this task touches file content, not path selection |
+| T-86-SC | Tampering | npm/pip/cargo installs | low | accept | No package installs this phase |
+
+Block threshold: `high`. T-86-01 is mitigated by construction; no `high` threat is unmitigated.
+</threat_model>
+
+<verification>
+- `node --test "tests/bridges/commands/stage.test.ts"` passes.
+- `npm run typecheck` green.
+- Per-wave merge: `npm test` + `npm run test:integration`.
+</verification>
+
+<success_criteria>
+- An unparseable command loads after `/reload` with name-from-filename + first-body-line description (no placeholder, no disable flag), surfaces `malformed command`, and valid commands stay byte-for-byte unchanged.
+</success_criteria>
+
+<output>
+Create `.planning/phases/86-skill-and-command-frontmatter-compliance/86-04-SUMMARY.md` when done.
+</output>

--- a/.planning/phases/86-skill-and-command-frontmatter-compliance/86-04-SUMMARY.md
+++ b/.planning/phases/86-skill-and-command-frontmatter-compliance/86-04-SUMMARY.md
@@ -1,0 +1,150 @@
+---
+phase: 86-skill-and-command-frontmatter-compliance
+plan: 04
+subsystem: bridges
+tags: [frontmatter, parseFrontmatter, commands, neutralize, degrade]
+
+# Dependency graph
+requires:
+  - phase: 86-01
+    provides: "parseFrontmatter re-export through platform/pi-api.ts; malformed command reason token"
+  - phase: 86-02
+    provides: "degraded field on StageCommandsCommitResult (inert); install orchestrator maps command-kind degrade records to the {malformed command} token + per-component detail"
+provides:
+  - "Two read-only parseFrontmatter gates in bridges/commands/stage.ts (gate 1 on SOURCE before substitution, gate 2 on STAGED bytes after write)"
+  - "Unparseable-source commands neutralized by stripping the entire malformed frontmatter block, so Pi loads name-from-filename + description-from-first-body-line (CMD-01 / D-86-07)"
+  - "StageCommandsCommitResult.degraded now populated on the neutralize arm (was inert)"
+affects:
+  - "86-05 (orchestrated reconcile row consumes InstallPluginOutcome.degradedKinds, which now includes command)"
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - "Two read-only parse gates around the commands staging seam, mirroring the skills bridge: gate 1 = attribution ground truth + degrade trigger; gate 2 = Pi-acceptability backstop (self-defect throws loudly)"
+    - "Neutralize = strip the whole `---`...`---` block by delimiter index (line-ending agnostic, no re-encoding), leaving body bytes untouched -- distinct from the skills synthesize path"
+
+key-files:
+  created:
+    - tests/bridges/_fixtures/unparseable-command-plugin/commands/bad-command.md
+  modified:
+    - extensions/pi-claude-marketplace/bridges/commands/stage.ts
+    - tests/bridges/commands/stage.test.ts
+
+key-decisions:
+  - "Neutralize strips by the same `\\n---` delimiter search parseFrontmatter uses (indexOf on the source as-is), never a fixed byte offset -- surviving body bytes are byte-preserved (no CRLF normalization on the command path)"
+  - "Commands get NO synthesized description and NO disable-model-invocation flag (that is the skills degrade shape); Pi's command loader has no non-empty-description gate, so the stripped body is sufficient"
+  - "Gate-1 RETURN arm (including absent/empty frontmatter) is a byte-identical passthrough -- only ${CLAUDE_PLUGIN_ROOT}/${CLAUDE_PLUGIN_DATA} substitution changes bytes (NREG-01)"
+
+patterns-established:
+  - "parse gate 1 (source) / gate 2 (staged) discipline reused verbatim on the second bridge seam"
+
+requirements-completed: [CMD-01, PARSE-01, PARSE-02, NREG-01]
+
+coverage:
+  - id: D1
+    description: "Gate 1 parses the SOURCE command before substitution; a throw neutralizes by stripping the entire malformed frontmatter block, leaving the real body, and records a degrade entry"
+    requirement: "CMD-01"
+    verification:
+      - kind: unit
+        ref: "tests/bridges/commands/stage.test.ts#CMD-01 / PARSE-01 unparseable command source -> neutralized (whole frontmatter block stripped), degrade record"
+        status: pass
+    human_judgment: false
+  - id: D2
+    description: "Gate 2 re-parses the staged bytes as a Pi-acceptability backstop; the neutralized output re-parses (does not throw) and returns empty frontmatter"
+    requirement: "PARSE-02"
+    verification:
+      - kind: unit
+        ref: "tests/bridges/commands/stage.test.ts#CMD-01 / PARSE-01 unparseable command source -> neutralized (whole frontmatter block stripped), degrade record"
+        status: pass
+    human_judgment: false
+  - id: D3
+    description: "The neutralized output carries no synthesized description and no disable-model-invocation flag; the degrade record carries the generated name + a non-empty parse error"
+    requirement: "CMD-01"
+    verification:
+      - kind: unit
+        ref: "tests/bridges/commands/stage.test.ts#CMD-01 / PARSE-01 unparseable command source -> neutralized (whole frontmatter block stripped), degrade record"
+        status: pass
+    human_judgment: false
+  - id: D4
+    description: "A valid command is staged byte-for-byte identical except variable substitution; the read-only gates mutate nothing on the happy path and the degrade list is empty"
+    requirement: "NREG-01"
+    verification:
+      - kind: unit
+        ref: "tests/bridges/commands/stage.test.ts#NREG-01 valid command is staged byte-for-byte identical except variable substitution (gates mutate nothing)"
+        status: pass
+    human_judgment: false
+  - id: D5
+    description: "After /reload, an unparseable command's /<generated-name> resolves with name-from-filename and a first-body-line description"
+    requirement: "CMD-01"
+    verification: []
+    human_judgment: true
+    rationale: "Runtime Pi command-loader + /reload behavior is a backstop truth; not exercisable in unit tests (needs a live Pi session)."
+
+# Metrics
+duration: 22min
+completed: 2026-07-26
+status: complete
+---
+
+# Phase 86 Plan 04: Command neutralize Summary
+
+**The commands bridge now has the same two read-only parseFrontmatter gates as the skills bridge: an unparseable SOURCE command has its entire malformed `---`...`---` block stripped so Pi loads it with name-from-filename + description-from-first-body-line, surfacing a `malformed command` degrade record, while valid commands are proven byte-for-byte unchanged.**
+
+## Performance
+
+- **Duration:** ~22 min
+- **Started:** 2026-07-26
+- **Completed:** 2026-07-26
+- **Tasks:** 1 (tracer)
+- **Files modified:** 3 (2 modified, 1 fixture created)
+
+## Accomplishments
+
+- Gate 1 parses the SOURCE `.md` frontmatter before `substituteClaudeVars`. A throw routes to `neutralizeCommandFrontmatter`, which strips the entire malformed block; a return (including absent/empty frontmatter) keeps today's byte-identical passthrough.
+- `neutralizeCommandFrontmatter` locates the closing delimiter via the same `\n---` search `parseFrontmatter` itself uses (from index 3), then slices everything after the closing delimiter line on the source as-is -- no fixed byte offset, no CRLF re-encoding, so the surviving body bytes are untouched (D-86-07 encoding-probe truth).
+- Gate 2 re-parses the STAGED bytes after write as a Pi-acceptability backstop. The neutralized output is designed to RETURN empty; a throw there is our own substitution defect and propagates to the existing `appendLeakToError`/`cleanupStaging` catch, never masked as author degradation (PARSE-02 / D-86-04).
+- `prepareStageCommands` now returns a populated `degraded: { generatedName, parseError }[]` list on the staged result (the field was added inert by the tracer). No install-orchestrator change was needed -- it already collects command-kind degrade records and emits `malformed command`.
+- Commands get NO synthesized placeholder description and NO `disable-model-invocation` flag: that is the skills degrade shape. Pi's command loader has no non-empty-description gate, so the stripped body alone reproduces Claude Code's "body loads, metadata empty" behavior.
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Commands parse gates + neutralize arm, end-to-end to the degrade record** - `b3a39784` (feat)
+
+## Files Created/Modified
+
+- `extensions/pi-claude-marketplace/bridges/commands/stage.ts` - `parseFrontmatter` import, `neutralizeCommandFrontmatter` helper, gate 1 + gate 2 + degrade collection, populated `degraded` on the staged result
+- `tests/bridges/commands/stage.test.ts` - unparseable-command neutralize case (CMD-01 / PARSE-01 / PARSE-02) + NREG-01 byte-equality case
+- `tests/bridges/_fixtures/unparseable-command-plugin/commands/bad-command.md` - NEW malformed-frontmatter fixture (`title: Deploy: the whole thing` -- an unquoted `: ` mid-scalar that the `yaml` parser rejects)
+
+## Decisions Made
+
+None beyond the locked decisions (D-86-01..07) the plan already fixed. The neutralize transform was implemented as a small local helper (`neutralizeCommandFrontmatter`), symmetric with the skills bridge's local `extractBodyAfterFrontmatter`, keeping the change localized to the staging seam.
+
+## Deviations from Plan
+
+None - plan executed exactly as written.
+
+## Issues Encountered
+
+- The first `pre-commit run --files` invocation timed out at the 2-minute harness ceiling because the `npm-lint` / `npm-typecheck` hooks run repo-wide; re-running with a longer timeout completed clean (all hooks Passed). No code change was involved.
+
+## User Setup Required
+
+None.
+
+## Next Phase Readiness
+
+- Both bridge seams (skills, commands) now populate `degraded`; `InstallPluginOutcome.degradedKinds` includes `command` when a command neutralizes. Plan 05 (orchestrated reconcile row) reads that seam to push the token onto the reconcile `plugin-installed` arm.
+
+## Self-Check: PASSED
+
+- Fixture `tests/bridges/_fixtures/unparseable-command-plugin/commands/bad-command.md` exists on disk.
+- Task commit `b3a39784` present in git history.
+- `npm run typecheck` green; `eslint` + `prettier` clean on both touched source files; `node --test` across the commands stage + skills stage + install suites: 143 pass / 0 fail.
+
+---
+*Phase: 86-skill-and-command-frontmatter-compliance*
+*Completed: 2026-07-26*

--- a/.planning/phases/86-skill-and-command-frontmatter-compliance/86-05-PLAN.md
+++ b/.planning/phases/86-skill-and-command-frontmatter-compliance/86-05-PLAN.md
@@ -1,0 +1,138 @@
+---
+phase: 86-skill-and-command-frontmatter-compliance
+plan: 05
+type: execute
+wave: 3
+depends_on: ["86-02"]
+files_modified:
+  - extensions/pi-claude-marketplace/orchestrators/reconcile/apply-outcomes.ts
+  - extensions/pi-claude-marketplace/orchestrators/reconcile/apply.ts
+  - extensions/pi-claude-marketplace/orchestrators/reconcile/notify.ts
+  - tests/orchestrators/reconcile/notify.test.ts
+  - tests/orchestrators/reconcile/apply.test.ts
+autonomous: true
+requirements: [WARN-01, CLASS-01]
+
+must_haves:
+  truths:
+    - "`PluginInstalledOutcome` carries a `degradedKinds` field propagated from `InstallPluginOutcome.degradedKinds` (added in Plan 02) through the reconcile outcome builder (apply.ts §588-602)."
+    - "The reconcile `plugin-installed` arm (notify.ts §497-509) pushes `malformed skill` and/or `malformed command` onto the installed row's `reasons` and raises `severity` from `info` to `warning` when `degradedKinds` is non-empty — the genuinely new orchestrated wire (the arm carries no reasons today)."
+    - "ONE token per kind per plugin regardless of how many components degraded (WARN-01 · adjacency probe); the row stays `(installed)` NOT `(partially-installed)` (a degraded-but-installed component is not a dropped supported component — D-86-03)."
+    - "Zero degraded components => the installed row is unchanged: `info` severity, no `reasons` (WARN-01 · empty probe)."
+    - "The per-component free-text detail `<plugin>/<component>: <parse error>` surfaces via the existing `postCommitWarnings -> surfacePostCommitWarnings -> notifyDiagnostic` channel (orchestrated only, D-19-01); no new notify variant is added."
+    - "Detail lines are routed through `redactAbsolutePaths` before `notifyDiagnostic`, so an absolute source path in a parse error is collapsed to its basename (WARN-01 · encoding probe)."
+    - "When multiple components degrade, the detail lines preserve the stable collection order of `frontmatterDegradations` (WARN-01 · ordering probe)."
+  prohibitions:
+    - "MUST NOT render the degraded install as `(partially-installed)` — that token is for DROPPED supported components; a degraded-but-installed component stays `(installed)` (D-86-03)."
+    - "MUST NOT add a new post-cascade notify variant for the detail — reuse the sanctioned `notifyDiagnostic` seam (D-19-01)."
+    - "MUST NOT emit a per-component token on the row — the token is one-per-kind-per-plugin; per-component text rides the detail channel only."
+  artifacts:
+    - "extensions/pi-claude-marketplace/orchestrators/reconcile/apply-outcomes.ts — `PluginInstalledOutcome.degradedKinds` field"
+    - "extensions/pi-claude-marketplace/orchestrators/reconcile/apply.ts — propagate `degradedKinds` into the `plugin-installed` outcome"
+    - "extensions/pi-claude-marketplace/orchestrators/reconcile/notify.ts — push token + raise severity on the orchestrated installed row"
+    - "tests/orchestrators/reconcile/notify.test.ts + apply.test.ts — orchestrated degraded-install row + propagation cases"
+  key_links:
+    - "`InstallPluginOutcome.degradedKinds` -> `dependenciesFromInstall`-adjacent propagation (apply.ts) -> `PluginInstalledOutcome.degradedKinds` -> reconcile notify composer"
+    - "`postCommitWarnings` (already propagated onto `PluginInstalledOutcome`) -> `surfacePostCommitWarnings` -> `notifyDiagnostic` (the WARN-01 detail surface)"
+---
+
+<objective>
+Complete WARN-01 on the primary install surface: thread the degrade signal into the orchestrated (reconcile) notification composer. The standalone row already carries the reason token (Plan 02); the reconcile `plugin-installed` arm carries no reasons today — that is the confirmed new wire. Add a `degradedKinds` field to `PluginInstalledOutcome`, propagate it from `InstallPluginOutcome.degradedKinds`, and push `malformed skill` / `malformed command` onto the orchestrated installed row at `warning` severity. The per-component free-text detail already flows through the existing `postCommitWarnings -> notifyDiagnostic` channel — verify it, including absolute-path redaction and stable ordering.
+
+Purpose: Reconcile-driven installs and imports are where most installs run (RESEARCH Open Q2); the reason token must reach that composer for the failure to stop being silent there. This is a pure orchestrator wire reusing the outcome flag the tracer laid.
+Output: The orchestrated `(installed) {malformed skill|command}` warning row and verified detail surfacing.
+</objective>
+
+<execution_context>
+@/home/acolomba/pi-claude-marketplace/.claude/gsd-core/workflows/execute-plan.md
+@/home/acolomba/pi-claude-marketplace/.claude/gsd-core/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/86-skill-and-command-frontmatter-compliance/86-CONTEXT.md
+@.planning/phases/86-skill-and-command-frontmatter-compliance/86-RESEARCH.md
+@.planning/phases/86-skill-and-command-frontmatter-compliance/86-PATTERNS.md
+@.claude/rules/typescript-comments.md
+
+# Prior plan output consumed here
+@.planning/phases/86-skill-and-command-frontmatter-compliance/86-02-SUMMARY.md
+
+# Files touched (read before editing)
+@extensions/pi-claude-marketplace/orchestrators/reconcile/apply-outcomes.ts
+@extensions/pi-claude-marketplace/orchestrators/reconcile/apply.ts
+@extensions/pi-claude-marketplace/orchestrators/reconcile/notify.ts
+</context>
+
+<artifacts_this_phase>
+New symbols/behavior introduced by this plan:
+- `PluginInstalledOutcome.degradedKinds?: readonly ("skill" | "command")[]` (apply-outcomes.ts).
+- Propagation in apply.ts (§588-602) from `InstallPluginOutcome.degradedKinds`.
+- Token push + severity raise in reconcile/notify.ts `plugin-installed` arm (§497-509).
+</artifacts_this_phase>
+
+<tasks>
+
+<task type="tracer">
+  <name>Task 1: Orchestrated reason-token wire on the reconcile installed row</name>
+  <read_first>
+    - extensions/pi-claude-marketplace/orchestrators/reconcile/apply-outcomes.ts §80-95 (`PluginInstalledOutcome` incl. `postCommitWarnings?` — the sibling field to add `degradedKinds` beside)
+    - extensions/pi-claude-marketplace/orchestrators/reconcile/apply.ts §314-322 (`dependenciesFromInstall` — the same seam that derives from install flags), §588-602 (the `plugin-installed` outcome construction that already spreads `postCommitWarnings`)
+    - extensions/pi-claude-marketplace/orchestrators/reconcile/notify.ts §497-509 (the `plugin-installed` arm that pushes the row with `severity: "info"` and NO reasons — the new wire), §510-535 (the `plugin-backfilled` arm for the `partially-installed` contrast)
+    - extensions/pi-claude-marketplace/orchestrators/reconcile/apply.ts §1371-1394 (`surfacePostCommitWarnings` -> `notifyDiagnostic`; confirm `redactAbsolutePaths` routing)
+    - extensions/pi-claude-marketplace/orchestrators/plugin/install.ts (the `InstallPluginOutcome.degradedKinds` returned in Plan 02)
+    - 86-PATTERNS.md §"orchestrators/reconcile/*" (the confirmed new-wire), 86-RESEARCH.md §"Common Pitfalls" (orchestrated reason-token has no existing wire; detail dropped in standalone)
+  </read_first>
+  <files>extensions/pi-claude-marketplace/orchestrators/reconcile/apply-outcomes.ts, extensions/pi-claude-marketplace/orchestrators/reconcile/apply.ts, extensions/pi-claude-marketplace/orchestrators/reconcile/notify.ts, tests/orchestrators/reconcile/notify.test.ts, tests/orchestrators/reconcile/apply.test.ts</files>
+  <action>
+    Add `degradedKinds?: readonly ("skill" | "command")[]` to `PluginInstalledOutcome` (apply-outcomes.ts), beside `postCommitWarnings?`. In apply.ts (§588-602), when building the `plugin-installed` outcome, spread `degradedKinds` from `result.degradedKinds` when non-empty (mirror the conditional `postCommitWarnings` spread). In reconcile/notify.ts (§497-509 `plugin-installed` arm): if `outcome.degradedKinds` is non-empty, build a `reasons` array pushing `"malformed skill"` when it includes `"skill"` and `"malformed command"` when it includes `"command"` (one token per kind), spread it onto the pushed row, and set `severity: "warning"` instead of `"info"`; otherwise leave the row exactly as today (`info`, no reasons). Keep the row `status: "installed"` — NOT `partially-installed` (D-86-03). Do NOT touch `surfacePostCommitWarnings` beyond confirming the detail already routes through `redactAbsolutePaths` (the detail lines were pushed into `postCommitWarnings` in Plan 02). Anchor comments to WARN-01 / CLASS-01 / D-86-03 only. Extend `notify.test.ts` with an orchestrated degraded-install row case and `apply.test.ts` with a `degradedKinds` propagation case.
+  </action>
+  <verify>
+    <automated>node --test "tests/orchestrators/reconcile/notify.test.ts" "tests/orchestrators/reconcile/apply.test.ts" && npm --prefix . run typecheck</automated>
+  </verify>
+  <acceptance_criteria>
+    - A `notify.test.ts` case asserts a `plugin-installed` outcome with `degradedKinds: ["skill"]` renders an `(installed)` row carrying `malformed skill` at `warning` severity (NOT `partially-installed`).
+    - A case with `degradedKinds: ["skill","command"]` asserts BOTH tokens ride the single row (one per kind).
+    - A case with no `degradedKinds` asserts the row is unchanged (`info`, no `reasons`).
+    - An `apply.test.ts` case asserts `degradedKinds` propagates from an `InstallPluginOutcome` into the `plugin-installed` outcome, and a degraded install's detail line reaches `notifyDiagnostic` with any absolute path redacted to its basename.
+    - `npm run typecheck` is green.
+  </acceptance_criteria>
+  <done>The orchestrated reconcile install row surfaces the failure-class token at warning severity with per-component detail, closing WARN-01 on the primary surface.</done>
+  <reversibility rating="reversible">Additive outcome field + composer branch; revertible by removing the field and the branch.</reversibility>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| bridge degrade signal -> reconcile notify composer | The parse-error detail (may embed a source path) crosses into user-visible orchestrated notification text. |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Severity | Disposition | Mitigation Plan |
+|-----------|----------|-----------|----------|-------------|-----------------|
+| T-86-03 | Info Disclosure | `notifyDiagnostic` detail line | medium | mitigate | Detail routed through `redactAbsolutePaths` before emission — an absolute source path collapses to its basename (NFR-9: message text only, never `.stack`) |
+| T-86-07 | Repudiation | truthful attribution on the row | low | mitigate | The row carries a per-kind failure-class token (`malformed skill` / `malformed command`), never mis-attributing a self-inflicted defect (those throw in Plan 02/04) |
+| T-86-SC | Tampering | npm/pip/cargo installs | low | accept | No package installs this phase |
+
+Block threshold: `high`. No `high`-severity threat is introduced by this pure-orchestrator wire.
+</threat_model>
+
+<verification>
+- `node --test "tests/orchestrators/reconcile/notify.test.ts" "tests/orchestrators/reconcile/apply.test.ts"` pass.
+- `npm run typecheck` green.
+- Phase gate: `npm run check` green before `/gsd-verify-work`.
+</verification>
+
+<success_criteria>
+- The orchestrated (reconcile) install path renders `(installed) {malformed skill|command}` at warning severity, one token per kind per plugin, with per-component redacted detail via `notifyDiagnostic`.
+</success_criteria>
+
+<output>
+Create `.planning/phases/86-skill-and-command-frontmatter-compliance/86-05-SUMMARY.md` when done.
+</output>

--- a/.planning/phases/86-skill-and-command-frontmatter-compliance/86-05-SUMMARY.md
+++ b/.planning/phases/86-skill-and-command-frontmatter-compliance/86-05-SUMMARY.md
@@ -1,0 +1,163 @@
+---
+phase: 86-skill-and-command-frontmatter-compliance
+plan: 05
+subsystem: orchestrators
+tags: [frontmatter, degrade, reconcile, notify, warning-severity, redaction]
+
+# Dependency graph
+requires:
+  - phase: 86-02
+    provides: "InstallPluginOutcome.degradedKinds seam + per-component postCommitWarnings detail on the orchestrated channel"
+provides:
+  - "PluginInstalledOutcome.degradedKinds field (reconcile outcome union)"
+  - "Propagation of InstallPluginOutcome.degradedKinds -> PluginInstalledOutcome in apply.ts install arm"
+  - "Reconcile (installed) row raised to warning severity with one malformed skill/command token per kind (WARN-01 on the orchestrated surface)"
+  - "redactAbsolutePaths applied to post-commit warnings before notifyDiagnostic (T-86-03 / NFR-9)"
+affects: []
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - "Outcome-flag propagation through the reconcile install arm mirrors the existing conditional postCommitWarnings spread (omit-when-empty for NREG-01 byte-identity)"
+    - "One-token-per-kind-per-plugin reason on the (installed) row (mirrors orphan rewake), with per-component free-text detail on the notifyDiagnostic channel redacted at the emission seam"
+
+key-files:
+  created: []
+  modified:
+    - extensions/pi-claude-marketplace/orchestrators/reconcile/apply-outcomes.ts
+    - extensions/pi-claude-marketplace/orchestrators/reconcile/apply.ts
+    - extensions/pi-claude-marketplace/orchestrators/reconcile/notify.ts
+    - tests/orchestrators/reconcile/notify.test.ts
+    - tests/orchestrators/reconcile/apply.test.ts
+
+key-decisions:
+  - "A degraded-but-installed component keeps the (installed) row at warning severity, NOT (partially-installed) (D-86-03)"
+  - "Row-token construction extracted into installedRowFromOutcome helper to keep applyOutcomeToBlock cognitive complexity under the eslint ceiling"
+  - "redactAbsolutePaths applied inside surfacePostCommitWarnings (the emission seam) rather than at the install.ts source, so all post-commit warnings are redacted before notifyDiagnostic and the redaction is directly observable in apply.test.ts"
+
+patterns-established:
+  - "installedRowFromOutcome: outcome -> PluginInstalledMessage row builder consolidating the degradedKinds -> reason token + severity mapping"
+
+requirements-completed: [WARN-01, CLASS-01]
+
+coverage:
+  - id: D1
+    description: "A plugin-installed outcome with degradedKinds=[skill] renders an (installed) row carrying malformed skill at warning severity (NOT partially-installed)"
+    requirement: "WARN-01"
+    verification:
+      - kind: unit
+        ref: "tests/orchestrators/reconcile/notify.test.ts#WARN-01 / D-86-03: a plugin-installed outcome with degradedKinds=[skill] renders an (installed) row carrying {malformed skill} at warning severity (NOT partially-installed)"
+        status: pass
+    human_judgment: false
+  - id: D2
+    description: "degradedKinds=[skill,command] rides ONE row with BOTH tokens (one per kind)"
+    requirement: "CLASS-01"
+    verification:
+      - kind: unit
+        ref: "tests/orchestrators/reconcile/notify.test.ts#WARN-01 / D-86-03: degradedKinds=[skill,command] rides ONE row with BOTH tokens (one per kind)"
+        status: pass
+    human_judgment: false
+  - id: D3
+    description: "A plugin-installed outcome with no degradedKinds is unchanged -- info severity, no reasons brace (byte-identity)"
+    requirement: "WARN-01"
+    verification:
+      - kind: unit
+        ref: "tests/orchestrators/reconcile/notify.test.ts#WARN-01 / NREG-01: a plugin-installed outcome with no degradedKinds is unchanged -- info severity, no reasons brace"
+        status: pass
+    human_judgment: false
+  - id: D4
+    description: "A degraded outcome carries degradedKinds onto the rendered cascade row AND surfaces its per-component detail through notifyDiagnostic with the absolute source path redacted to its basename"
+    requirement: "WARN-01"
+    verification:
+      - kind: unit
+        ref: "tests/orchestrators/reconcile/apply.test.ts#WARN-01 / D-86-03 / T-86-03: a degraded plugin-installed outcome carries degradedKinds onto the rendered cascade row AND surfaces its per-component detail through notifyDiagnostic with the absolute source path redacted to its basename"
+        status: pass
+    human_judgment: false
+
+# Metrics
+duration: 30min
+completed: 2026-07-26
+status: complete
+---
+
+# Phase 86 Plan 05: Orchestrated reason-token wire Summary
+
+**The reconcile `plugin-installed` arm now consumes `InstallPluginOutcome.degradedKinds` (via a new `PluginInstalledOutcome.degradedKinds` field): a skill/command whose source frontmatter could not be parsed renders `(installed) {malformed skill|command}` at warning severity on the orchestrated cascade, with its per-component parse detail surfaced through `notifyDiagnostic` and any absolute source path redacted to its basename — closing WARN-01 on the primary install surface.**
+
+## Performance
+
+- **Duration:** ~30 min
+- **Started:** 2026-07-26
+- **Completed:** 2026-07-26
+- **Tasks:** 1 (tracer)
+- **Files modified:** 5
+
+## Accomplishments
+
+- Added `degradedKinds?: readonly ("skill" | "command")[]` to `PluginInstalledOutcome` (apply-outcomes.ts), beside `postCommitWarnings?`, with the D-86-03 contract documented (degraded-but-installed keeps the `(installed)` row, one token per kind, omitted when empty for NREG-01 byte-identity).
+- Propagated `result.degradedKinds` from the install orchestrator into the `plugin-installed` outcome in `applyPluginInstalls` (apply.ts), mirroring the adjacent conditional `postCommitWarnings` spread (omit-when-empty).
+- Wired the reconcile `plugin-installed` notify arm: the previously reasons-less, `info`-only row now reads `outcome.degradedKinds` and pushes `malformed skill` and/or `malformed command` (one per kind) at `warning` severity. A clean install (no degradedKinds) is byte-identical to today — `info`, no reasons brace. The row stays `status: "installed"`, never `partially-installed` (D-86-03).
+- Confirmed and hardened the per-component detail surface: `surfacePostCommitWarnings` now routes every post-commit warning through `redactAbsolutePaths` before `notifyDiagnostic`, so an absolute source path embedded in a parse-error detail collapses to its basename (T-86-03 / NFR-9). This closed a gap — the detail was NOT previously redacted at any point in the chain (see Deviations).
+- Added three notify.test.ts cases (skill-only row; skill+command one-per-kind; clean-install byte-identity) and one apply.test.ts case (degradedKinds propagation onto the rendered cascade row + redacted detail via notifyDiagnostic at warning severity).
+
+## Task Commits
+
+1. **Task 1 (tracer): Orchestrated reason-token wire on the reconcile installed row** - `b91ba2ca` (feat)
+
+## Files Created/Modified
+
+- `extensions/pi-claude-marketplace/orchestrators/reconcile/apply-outcomes.ts` - `degradedKinds` field on `PluginInstalledOutcome`
+- `extensions/pi-claude-marketplace/orchestrators/reconcile/apply.ts` - propagate `degradedKinds` into the `plugin-installed` outcome; redact post-commit warnings before `notifyDiagnostic`; export `surfacePostCommitWarnings` for direct unit testing
+- `extensions/pi-claude-marketplace/orchestrators/reconcile/notify.ts` - `degradedKindReasons` + `installedRowFromOutcome` helpers; the `plugin-installed` arm now pushes the built row (token + severity)
+- `tests/orchestrators/reconcile/notify.test.ts` - three orchestrated-row cases (WARN-01 / CLASS-01 / NREG-01)
+- `tests/orchestrators/reconcile/apply.test.ts` - degradedKinds propagation + redacted-detail case (WARN-01 / D-86-03 / T-86-03)
+
+## Decisions Made
+
+- **Redaction seam location.** The plan's `<action>` assumed the detail already routed through `redactAbsolutePaths` ("confirm" only). Investigation showed it did NOT — the detail is built raw in `install.ts` (`errorMessage(parseErr)`), passed through `postCommitWarnings` raw, and `surfacePostCommitWarnings`/`notifyDiagnostic` emitted it raw. The plan's `must_haves` and `acceptance_criteria` both REQUIRE redaction (T-86-03 threat-register `mitigate` disposition, NFR-9). I applied `redactAbsolutePaths` inside `surfacePostCommitWarnings` at the emission seam (the file the plan lists as modifiable) rather than at the `install.ts` source, because (a) it is the single point every post-commit warning crosses before the operator-facing surface, and (b) it makes the redaction directly observable in an apply.test.ts unit test as the acceptance criterion demands. See Deviations (Rule 2).
+- **Helper extraction.** Adding the token/severity branch inline pushed `applyOutcomeToBlock` cognitive complexity to 18 (> 15 eslint ceiling). Extracted `installedRowFromOutcome` (returns a `PluginInstalledMessage`) so the case arm is a single push and complexity stays under the ceiling.
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+**1. [Rule 2 - Missing critical functionality] Added the missing `redactAbsolutePaths` mitigation on the post-commit-warning detail surface**
+- **Found during:** Task 1 (verifying the plan's "detail already routes through redactAbsolutePaths" claim).
+- **Issue:** The threat register assigns T-86-03 (Info Disclosure, medium) a `mitigate` disposition: the per-component parse-error detail (which may embed an absolute source path) must be redacted before emission (NFR-9). No redaction existed anywhere in the chain — `install.ts` builds the detail from raw `errorMessage(parseErr)`, and `surfacePostCommitWarnings` -> `notifyDiagnostic` emitted it verbatim. A malformed skill whose parse error embedded an absolute path would have leaked that path to the operator.
+- **Fix:** Applied `redactAbsolutePaths(w)` to each line inside `surfacePostCommitWarnings` before pushing to `notifyDiagnostic`. Redaction is idempotent and desirable for all post-commit warnings (consistent with the established T-53-02-02 / T-55-02-01 diagnostic-redaction norm). Added an apply.test.ts assertion proving an absolute path collapses to its basename.
+- **Files modified:** `extensions/pi-claude-marketplace/orchestrators/reconcile/apply.ts`
+- **Commit:** `b91ba2ca`
+
+**2. [Rule 3 - Blocking issue] Exported `surfacePostCommitWarnings`; extracted `installedRowFromOutcome` to clear the eslint cognitive-complexity ceiling**
+- **Found during:** Task 1 pre-commit lint.
+- **Issue:** (a) `surfacePostCommitWarnings` was module-private, so the acceptance-criteria redaction assertion could not observe it directly. (b) The inline token/severity branch raised `applyOutcomeToBlock` cognitive complexity to 18 (> 15), failing `eslint .` (the whole-repo `npm-lint` hook) and blocking any hook-respecting commit.
+- **Fix:** Exported `surfacePostCommitWarnings` (read-only helper, no behavior change); extracted `installedRowFromOutcome`/`degradedKindReasons` so the case arm is a single push.
+- **Files modified:** `extensions/pi-claude-marketplace/orchestrators/reconcile/apply.ts`, `extensions/pi-claude-marketplace/orchestrators/reconcile/notify.ts`
+- **Commit:** `b91ba2ca`
+
+## Issues Encountered
+
+- The `pre-commit run --files` invocation exceeded a 2-minute tool timeout on the first attempt (whole-repo `eslint .` + TruffleHog + typecheck). Re-ran with an extended timeout; all hooks passed.
+
+## User Setup Required
+
+None.
+
+## Threat Flags
+
+None — no new security surface beyond the T-86-03 mitigation this plan closes.
+
+## Next Phase Readiness
+
+- WARN-01 is now closed on both the standalone (Plan 02) and the orchestrated/reconcile (this plan) install surfaces. The full phase gate (`npm run check`) should be run before `/gsd-verify-work`.
+
+## Self-Check: PASSED
+
+- Commit `b91ba2ca` present in git history.
+- `node --test` on both reconcile test files: notify 31 pass / 0 fail, apply 25 pass / 0 fail (includes the 4 new WARN-01/CLASS-01/NREG-01/T-86-03 cases).
+- `npm run typecheck` green; `eslint` + `prettier --check` clean on all touched files; full pre-commit hook suite passed.
+
+---
+*Phase: 86-skill-and-command-frontmatter-compliance*
+*Completed: 2026-07-26*

--- a/.planning/phases/86-skill-and-command-frontmatter-compliance/86-CONTEXT.md
+++ b/.planning/phases/86-skill-and-command-frontmatter-compliance/86-CONTEXT.md
@@ -94,23 +94,65 @@ WARN-01, CLASS-01, NREG-01.
   synthesize/neutralize degrade path (D-86-01..03), which fires only on an
   unparseable **source**.
 
-### Claude's Discretion
+### Research-confirmed decisions (post-RESEARCH.md, operator-confirmed 2026-07-26)
 
-- **Upstream-parity mechanics — research MUST verify before planning, do not
-  invent** (operator norm: verify upstream first; upstream absence/answer is
-  decisive):
-  - `when_to_use` fold separator and exact combination format (WTU-01).
-  - The 1,536-char truncation style (hard cut vs ellipsis) and which side
-    truncates when `description` + `when_to_use` overflow (WTU-02).
-  - Claude Code's precise "first paragraph of markdown content" extraction for
-    the description-less fallback (SKILL-02) — heading handling, blank-line
-    boundary.
-  - Source of truth to fetch: `code.claude.com/docs/en/skills.md` (field
-    contract + failure policy), cross-checked against the diagnosis doc.
-- Exact placeholder-description string (within D-86-02's "short fixed constant").
-- Whether `parseFrontmatter` needs re-export plumbing in `platform/pi-api.ts` or
-  is already surfaced there — **verify it was exported at the declared peer floor
-  `>=0.74.0`** (dev dep is 0.79.10); the diagnosis flags this as a must-verify.
+Research (`86-RESEARCH.md`) resolved the upstream-parity unknowns and surfaced a
+Pi divergence; the operator confirmed the following:
+
+- **D-86-05:** Truncation cap stays **1,536** (WTU-02 / Claude Code parity), even
+  though Pi's skill loader emits a **non-fatal** startup warning when
+  `description` exceeds 1,024 chars. A combined `description`+`when_to_use` of
+  1025–1536 loads in Pi and stays model-invocable — do NOT secretly truncate to
+  1,024 (that would silently drop trigger keywords and diverge from Claude Code).
+  Treat the Pi >1024 warning as a documented, known divergence; add a test that a
+  >1024-combined skill still loads (Pi returns a `Skill`, not `null`). — **Reversibility:** reversible.
+- **D-86-06:** First-paragraph fallback (SKILL-02) = derive the description from
+  the **first genuine body line** — skip blank lines, ATX `#` headings, and fenced
+  code blocks (` ``` ` / `~~~` and their contents) and similar non-prose
+  constructs; land on the first plain body line. (Operator's words: "the first
+  line that's a body — not header, not code block, … just a body.") Take the
+  paragraph starting at that first body line (contiguous body text to the next
+  blank line), consistent with Claude Code's "first paragraph of markdown
+  content." Lead the implementation with a robust body-line detector, not a naive
+  "skip one heading." — **Reversibility:** reversible.
+- **D-86-07:** CMD-01 neutralize = **strip the entire malformed frontmatter block**
+  (opening `---` through the closing `---`), leaving the real body, so
+  `parseFrontmatter` returns empty and Pi takes name-from-filename + the real
+  body's first non-empty line — matching Claude Code's "loads the body with empty
+  metadata." NOT "strip only the delimiter lines" (that would leave ex-frontmatter
+  junk as the first body line and produce a poor description). — **Reversibility:** reversible.
+
+**Scope confirmations (research Open Questions Q2/Q3 — sensible defaults, no real
+tradeoff):**
+- The **orchestrated** (reconcile) install path is the primary/required wiring
+  surface for the reason token AND the free-text `notifyDiagnostic` detail — that
+  is where reconcile-driven installs and imports run. The reconcile
+  `plugin-installed` arm carries no `reasons` today, so wiring the token there is
+  new work (add a degrade flag to `InstallPluginOutcome` → `PluginInstalledOutcome`
+  and push the token in the reconcile notify composer). Standalone reason-token
+  parity is a smaller add (rides `PluginInstalledMessage.reasons?` like `orphan
+  rewake`); standalone drops the free-text detail per D-19-01.
+- Scope is **write-path-only** (aligns with NREG-01): fix the staging write path;
+  do NOT re-materialize or migrate already-installed malformed components. They
+  are corrected on next re-install.
+
+**`parseFrontmatter` (VERIFIED by research):** public root export of
+`@earendil-works/pi-coding-agent` at the peer floor `>=0.74.0` (confirmed in the
+0.74.0 tarball, `dist/index.d.ts`). It **throws** on malformed YAML inside `---`
+delimiters but **returns empty (no throw)** when delimiters are absent — this
+split is the SKILL-01 (throw → synthesize) vs SKILL-02 (empty → first-paragraph)
+branch trigger. Not yet surfaced in `platform/pi-api.ts` → new re-export plumbing.
+
+### Claude's Discretion (low-stakes planner defaults — research A1/A2/A4)
+
+- **A1 — `when_to_use` fold separator:** append with a single `\n` separator
+  (Claude Code documents only that it is "appended"; it pins no separator, so this
+  is a source-side detail).
+- **A2 — truncation style:** a **hard cut** at 1,536 (no ellipsis); since
+  `when_to_use` is appended after `description`, the tail overflows and is dropped.
+- **A4 — placeholder-description string** (within D-86-02's "short fixed
+  constant"): a short YAML-safe constant, e.g. `Source frontmatter could not be
+  parsed.`
 
 </decisions>
 

--- a/.planning/phases/86-skill-and-command-frontmatter-compliance/86-CONTEXT.md
+++ b/.planning/phases/86-skill-and-command-frontmatter-compliance/86-CONTEXT.md
@@ -1,0 +1,249 @@
+# Phase 86: Skill and command frontmatter compliance - Context
+
+**Gathered:** 2026-07-26
+**Status:** Ready for planning
+
+<domain>
+## Phase Boundary
+
+The skills and commands bridges reach **observable parity** with Claude Code's
+frontmatter-loading behavior. Source frontmatter is parsed with Pi's own
+`parseFrontmatter` (re-exported through `platform/pi-api.ts`) **before**
+name-rewrite and variable substitution — establishing attribution ground truth
+and the degrade trigger — and the staged bytes are re-parsed afterward as a
+Pi-acceptability backstop. Unparseable skill → synthesized
+`disable-model-invocation` block (body verbatim); unparseable command →
+neutralized (name-from-filename, description-from-first-body-line);
+description-less skill → first-paragraph fallback; `when_to_use` folded into the
+Pi `description`. Every degraded/neutralized component surfaces an install-time
+warning classified under a new failure-class reason token. The ~99% of
+already-valid components are written byte-for-byte unchanged.
+
+Delivers all 11 requirements: PARSE-01/02, SKILL-01/02/03, WTU-01/02, CMD-01,
+WARN-01, CLASS-01, NREG-01.
+
+</domain>
+
+<decisions>
+## Implementation Decisions
+
+### Reason-token catalog (CLASS-01)
+
+- **D-86-01:** Add **two dedicated per-kind tokens** — `malformed skill` and
+  `malformed command` — paralleling the `malformed mcp` truthful-attribution
+  precedent (`notify.ts:143-151`, `notify-reasons.ts:110-115`). NOT a single
+  shared token and NOT a reuse of the existing generic `unparseable`. Rationale:
+  this codebase consistently adds a dedicated token when truthful attribution
+  demands it (`dangling reference` over `source mismatch`, `authentication
+  required` over `network unreachable`, `malformed mcp` over a generic bucket).
+  The reason row should tell the operator *which component kind* malformed.
+  - Mechanics: append both tokens to the `REASONS` tuple in `notify.ts` **after**
+    the existing 35 entries (order of the existing 35 stays byte-identical —
+    OUT-08), and file both under `FAILURE_REASONS` in `notify-reasons.ts` (NOT
+    `UNSUPPORTED_REASONS` — this is a malformation of a *supported* component,
+    exactly the `malformed mcp` rationale). The `_ReasonsCoverageProof`
+    completeness proof in `notify-reasons.ts` must be updated in lockstep or it
+    fails to compile — that compile error is the guardrail.
+  - Closed set grows 35 → 37.
+  — **Reversibility:** costly — the `REASONS` tuple is a published catalog
+    contract with a compile-time completeness proof and byte-stability tests;
+    renaming/removing a token later touches the tuple, the topic-group view, the
+    proof, and every test that asserts the rendered row bytes.
+
+### Unparseable-skill placeholder description (SKILL-01)
+
+- **D-86-02:** The synthesized `description` on an unparseable skill is a **short
+  fixed constant** (e.g. `Source frontmatter could not be parsed.`) — not
+  interpolated with plugin/source names. The skill carries
+  `disable-model-invocation: true`, so it is excluded from the model's skill
+  listing and the description costs zero context; it exists only to clear Pi's
+  non-empty-`description` gate. The actionable detail (plugin, source skill,
+  parse error) rides the install-time warning instead (see D-86-03). Body is
+  preserved verbatim; install does not hard-fail.
+  - Exact string wording is Claude's discretion within "short fixed constant."
+
+### Warning surface (WARN-01)
+
+- **D-86-03:** A degraded skill / neutralized command still installs; the failure
+  stops being silent via a **two-part surface**:
+  1. The closed-set reason token (`{malformed skill}` / `{malformed command}`)
+     rides the plugin's `(installed)` row at **`warning`** severity — parallel to
+     the `(installed) {orphan rewake}` component-defect precedent. **One token
+     per plugin** regardless of how many of its components degraded (mirrors
+     orphan-rewake's "one row per plugin regardless of N handlers").
+  2. The per-component free-text detail (`<plugin>/<component>: <parse error>`)
+     rides the existing **post-cascade `notifyDiagnostic`** warning channel
+     (`notify.ts:339-349`) — the sanctioned seam for warnings that have no
+     representation in the cascade body. This is where WARN-01's "name the source
+     component and the parse error" requirement is satisfied (the closed-set
+     token cannot carry free text).
+  - Planner to confirm: the row is `(installed)` (component installed in degraded
+    form), NOT `(partially-installed)` (which is for *dropped* supported
+    components). Severity is a per-row stamp (SEV-01/SEV-02); a degraded-but-
+    installed component is "carried out but short of ideal" → `warning`.
+
+### Self-inflicted staged-parse failure (PARSE-02)
+
+- **D-86-04:** If a source parses cleanly but the **staged** output (after
+  name-rewrite + `${CLAUDE_PLUGIN_ROOT}`/`${CLAUDE_PLUGIN_DATA}` substitution)
+  fails to parse, that is **our** bug — **throw** and fail that plugin's install
+  loudly (test-guarded), never mask it as author degradation. Truthful
+  attribution: we do not knowingly ship bytes Pi rejects, and we do not
+  mis-attribute our defect to the plugin author. This is the "loud failure /
+  test-guarded" arm PARSE-02 calls for — distinct from the author-facing
+  synthesize/neutralize degrade path (D-86-01..03), which fires only on an
+  unparseable **source**.
+
+### Claude's Discretion
+
+- **Upstream-parity mechanics — research MUST verify before planning, do not
+  invent** (operator norm: verify upstream first; upstream absence/answer is
+  decisive):
+  - `when_to_use` fold separator and exact combination format (WTU-01).
+  - The 1,536-char truncation style (hard cut vs ellipsis) and which side
+    truncates when `description` + `when_to_use` overflow (WTU-02).
+  - Claude Code's precise "first paragraph of markdown content" extraction for
+    the description-less fallback (SKILL-02) — heading handling, blank-line
+    boundary.
+  - Source of truth to fetch: `code.claude.com/docs/en/skills.md` (field
+    contract + failure policy), cross-checked against the diagnosis doc.
+- Exact placeholder-description string (within D-86-02's "short fixed constant").
+- Whether `parseFrontmatter` needs re-export plumbing in `platform/pi-api.ts` or
+  is already surfaced there — **verify it was exported at the declared peer floor
+  `>=0.74.0`** (dev dep is 0.79.10); the diagnosis flags this as a must-verify.
+
+</decisions>
+
+<canonical_refs>
+## Canonical References
+
+**Downstream agents MUST read these before planning or implementing.**
+
+### Authoritative design + requirements
+- `docs/research/issue-101-skill-frontmatter-diagnosis.md` — the authoritative
+  design: root cause, rejected approaches (quote-repair; whole-block re-emit),
+  the chosen "mirror Claude Code via Pi's own machinery" approach, work-items
+  table, classification rationale, and the two open questions (both now resolved:
+  placeholder = fixed short via D-86-02; `when_to_use` fold = WTU-01/02).
+- `.planning/REQUIREMENTS.md` — the 11 requirements + Out-of-Scope table (which
+  non-`description` fields are intentionally dropped, why quote-repair and
+  whole-block re-emit are rejected).
+
+### Notification surface (the catalog + warning channels)
+- `extensions/pi-claude-marketplace/shared/notify.ts` — `REASONS` closed-set
+  source of truth (currently 35 entries; §89-152), the `malformed mcp` token +
+  its truthful-attribution comment (§143-151), the `orphan rewake` reason-on-
+  `(installed)`-row precedent (§121-129 and `PluginInstalledMessage.reasons?`
+  §621-629), the `Severity`/`computeSeverity` model (SEV-01/02), and the
+  `notifyDiagnostic` post-cascade warning channel (§339-349).
+- `extensions/pi-claude-marketplace/shared/notify-reasons.ts` — the topic-group
+  views; `FAILURE_REASONS` (§99-128, where the two new tokens go) and the
+  `_ReasonsCoverageProof` completeness proof (§166-169, must update in lockstep).
+
+### Staging seams (where the parse gates + degrade logic land)
+- `extensions/pi-claude-marketplace/bridges/skills/stage.ts` §159-164 — the
+  `readFile → rewriteFrontmatterName → substituteClaudeVars → writeFile` seam;
+  gate 1 (source) before rewrite, gate 2 (staged) after write.
+- `extensions/pi-claude-marketplace/bridges/skills/rewrite-frontmatter.ts` — the
+  pure-string `name:` rewrite (T-03-17 injection-safety note). Today it
+  *manufactures* a name-only frontmatter block when the source has none (the
+  missing-`description` bug), and only replaces the first line of a folded
+  `name:` (the SKILL-03 corruption). SKILL-03: verify the written `name` equals
+  the parsed generated name.
+- `extensions/pi-claude-marketplace/bridges/commands/stage.ts` §158-160 — the
+  command `readFile → substituteClaudeVars → writeFile` seam; CMD-01 neutralize
+  lands here.
+- `extensions/pi-claude-marketplace/platform/pi-api.ts` — the Pi-API boundary;
+  re-export `parseFrontmatter` here for byte-identical accept/reject semantics
+  (verify it was exported at peer floor `>=0.74.0`).
+
+### Precedent (reference, not a copy target)
+- `extensions/pi-claude-marketplace/bridges/agents/frontmatter.ts` — the bridge
+  that already parses source frontmatter and re-emits scalars correctly. It is
+  the *conceptual* precedent (parse-your-own-output-before-shipping), NOT a
+  template: it flattens to pi-subagents' flat target format; skills' target is
+  real structured YAML, so whole-block re-emit is explicitly rejected.
+
+### Upstream (research fetches to verify parity)
+- `code.claude.com/docs/en/skills.md` — failure policy ("malformed → body loads,
+  metadata empty, `/name` works, no auto-invoke; error only under `--debug`") and
+  field contract (`description` Recommended, first-paragraph fallback,
+  `when_to_use` appended, 1,536-char listing cap).
+
+</canonical_refs>
+
+<code_context>
+## Existing Code Insights
+
+### Reusable Assets
+- `notifyDiagnostic(ctx, header, lines)` (`notify.ts:339-349`) — the post-cascade
+  `warning`-severity channel for the per-component parse-error detail lines
+  (D-86-03 part 2). Already used for post-commit hygiene warnings.
+- `orphan rewake` reason-on-`(installed)`-row pattern — the shape D-86-03 part 1
+  copies: a component-level config/format defect surfacing as a `{token}` brace on
+  an otherwise-successful plugin install row.
+- The closed-set `as const` tuple + `(typeof X)[number]` literal-union machinery
+  and its topic-group completeness proof — the two new tokens plug into it.
+
+### Established Patterns
+- **`REASONS` is the single byte-stable source of truth** (OUT-08): membership +
+  order of the existing entries must not change; new tokens append at the end.
+  The topic groups in `notify-reasons.ts` are typed *views* with a compile-time
+  proof — adding a token to `REASONS` without giving it a home in a group (or a
+  typo) is a compile error. Update both files together.
+- **Failure-class vs unsupported vs soft-degrade are distinct axes.** A malformed
+  supported component is failure-class (`FAILURE_REASONS`), never
+  `UNSUPPORTED_REASONS` (that family is for unsupported *kinds* — hooks/lsp/soft
+  deps). This is the exact `malformed mcp` classification precedent.
+- **Pure-string rewrite for injection-safety (T-03-17) is preserved.** The new
+  parse is READ-ONLY — parse to validate + extract field values, never `eval`.
+  Reading input to check output-validity does not reintroduce the injection
+  surface the "no YAML parsing" comment guards against.
+
+### Integration Points
+- Two parse gates inserted into both `bridges/skills/stage.ts` and
+  `bridges/commands/stage.ts` (source-before-rewrite, staged-after-write).
+- `parseFrontmatter` sourced through `platform/pi-api.ts`.
+- Two new tokens in `notify.ts::REASONS` + `notify-reasons.ts::FAILURE_REASONS`.
+- Warning rows: reason token on the install-cascade `(installed)` row + detail
+  lines through `notifyDiagnostic`.
+
+</code_context>
+
+<specifics>
+## Specific Ideas
+
+- The `malformed mcp` member (MCPR-03 / D-02) is the explicit model to mirror —
+  both for classification (failure-class, not unsupported) and for the
+  truthful-per-feature-attribution rationale that drove D-86-01 to two dedicated
+  tokens.
+- The chosen degrade primitive for unparseable skills is Pi's
+  `disable-model-invocation: true` (Pi `core/skills.js`) — it reproduces Claude
+  Code's observable "invocable by `/name`, never auto-invoked" pair, which literal
+  empty-metadata parity cannot (Pi returns `skill: null` on empty description).
+
+</specifics>
+
+<deferred>
+## Deferred Ideas
+
+- **REASON-01** (v1.14 backlog): unify all parse-error reasons under a single
+  `{malformed <feature>}` family. This phase adds two more failure-class members
+  paralleling `malformed mcp`; the broad unification stays deferred.
+- `when_to_use` folding for **commands** is out of scope — WTU is skills-only
+  (Pi's command loader reads name + first-body-line, has no description-listing
+  surface for triggers).
+
+### Reviewed Todos (not folded)
+- `2026-06-12-coverage-sweep-test-rare-failure-arms-in-update-reinstall-in`
+  (testing, match score 0.6) — a broad pre-existing coverage sweep over
+  *existing* update/reinstall/install failure arms. Tangential to this focused
+  compliance phase; this phase adds its own parse-failure-arm tests as required
+  by PARSE/SKILL/CMD/WARN/CLASS. Left deferred to keep the phase scoped.
+
+</deferred>
+
+---
+
+*Phase: 86-skill-and-command-frontmatter-compliance*
+*Context gathered: 2026-07-26*

--- a/.planning/phases/86-skill-and-command-frontmatter-compliance/86-DISCUSSION-LOG.md
+++ b/.planning/phases/86-skill-and-command-frontmatter-compliance/86-DISCUSSION-LOG.md
@@ -1,0 +1,71 @@
+# Phase 86: Skill and command frontmatter compliance - Discussion Log
+
+> **Audit trail only.** Do not use as input to planning, research, or execution agents.
+> Decisions are captured in CONTEXT.md — this log preserves the alternatives considered.
+
+**Date:** 2026-07-26
+**Phase:** 86-skill-and-command-frontmatter-compliance
+**Areas discussed:** Reason token, Placeholder description, Warning detail, Self-inflicted staged-parse failure
+
+---
+
+## Reason token (CLASS-01)
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Per-kind: skill + command | Two dedicated tokens (`malformed skill`, `malformed command`) paralleling `malformed mcp`'s per-feature attribution; catalog grows by 2 (OUT-08 amendment, existing 35 keep order). | ✓ |
+| Single: malformed frontmatter | One token shared by both bridges; matches CLASS-01's singular wording; catalog grows by 1; doesn't name the component kind. | |
+| Reuse existing unparseable | No catalog growth, but drops the per-feature attribution the codebase insists on. | |
+
+**User's choice:** Per-kind: `malformed skill` + `malformed command`
+**Notes:** Matches the established pattern of adding dedicated tokens for truthful attribution (`dangling reference`, `authentication required`, `malformed mcp`).
+
+---
+
+## Placeholder description (SKILL-01)
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Short fixed constant | e.g. `Source frontmatter could not be parsed.` Zero model context (skill is `disable-model-invocation`); actionable detail rides the warning row. | ✓ |
+| Name plugin + source skill | More informative to a human opening the file, but duplicates the warning row. | |
+
+**User's choice:** Short fixed constant
+**Notes:** The skill is hidden from the model's listing, so the description exists only to clear Pi's non-empty gate.
+
+---
+
+## Warning detail (WARN-01)
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Post-cascade notifyDiagnostic | Token `{malformed skill}` rides the `(installed)` row at warning severity; per-component `<plugin>/<component>: <error>` detail rides the existing `notifyDiagnostic` channel. | ✓ |
+| Cause-chain trailer on row | Attach parse errors as a `cause` chain under the row, but `(installed)` rows carry no `cause` — needs a new field, more invasive. | |
+
+**User's choice:** Post-cascade notifyDiagnostic
+**Notes:** One token per plugin regardless of N degraded components (mirrors orphan-rewake). The closed-set token can't carry free text, so the detail needs the diagnostic channel.
+
+---
+
+## Self-inflicted staged-parse failure (PARSE-02)
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Throw — fail plugin loudly | A staged-parse failure is our bug; throw (test-guarded), never mask as author degradation. | ✓ |
+| Degrade like author failure | Install never blocks, but mis-attributes our bug as the author's malformation. | |
+
+**User's choice:** Throw — fail plugin loudly
+**Notes:** Truthful attribution — the author-facing synthesize/neutralize degrade path fires only on an unparseable *source*, not on our own broken staged output.
+
+---
+
+## Claude's Discretion
+
+- Upstream-parity mechanics (research verifies via `code.claude.com/docs`, does not invent): `when_to_use` fold separator/format (WTU-01), 1,536-char truncation style (WTU-02), first-paragraph extraction for the description-less fallback (SKILL-02).
+- Exact placeholder-description string (within "short fixed constant").
+- Whether `parseFrontmatter` needs new re-export plumbing in `platform/pi-api.ts` (verify it was exported at peer floor `>=0.74.0`).
+
+## Deferred Ideas
+
+- REASON-01 (v1.14 backlog): unify all parse-error reasons under a single `{malformed <feature>}` family — this phase adds two members; broad unification stays deferred.
+- `when_to_use` folding for commands — out of scope (WTU is skills-only).
+- Reviewed-not-folded todo: `2026-06-12-coverage-sweep-test-rare-failure-arms-in-update-reinstall-in` — broad pre-existing coverage sweep, tangential to this focused compliance phase.

--- a/.planning/phases/86-skill-and-command-frontmatter-compliance/86-PATTERNS.md
+++ b/.planning/phases/86-skill-and-command-frontmatter-compliance/86-PATTERNS.md
@@ -1,0 +1,338 @@
+# Phase 86: Skill and command frontmatter compliance - Pattern Map
+
+**Mapped:** 2026-07-26
+**Files analyzed:** 9 (7 modified, 2 new)
+**Analogs found:** 9 / 9
+
+All analogs are in-repo under `extensions/pi-claude-marketplace/`. Paths below are
+repo-relative to that root unless otherwise noted.
+
+## File Classification
+
+| New/Modified File | Role | Data Flow | Closest Analog | Match Quality |
+|-------------------|------|-----------|----------------|---------------|
+| `platform/pi-api.ts` (MODIFY: re-export `parseFrontmatter`) | config / API boundary | transform | its own existing `export { getAgentDir }` (`pi-api.ts:15`) | exact |
+| `bridges/skills/stage.ts` (MODIFY: gate 1 + gate 2 + degrade arm) | bridge / staging | file-I/O + transform | itself (`stage.ts:159-164` read→rewrite→substitute→write seam) | exact |
+| `bridges/commands/stage.ts` (MODIFY: gate 1 + gate 2 + neutralize arm) | bridge / staging | file-I/O + transform | itself (`stage.ts:158-160` read→substitute→write seam) | exact |
+| `bridges/skills/rewrite-frontmatter.ts` (MODIFY: SKILL-03 verify) | utility | transform | itself (line-regex `name:` rewrite) | exact |
+| NEW `bridges/skills/frontmatter-degrade.ts` (or similar: synth/fold/first-paragraph/truncate + safe dq-scalar emit) | utility | transform | `bridges/agents/frontmatter.ts::emitYamlScalar` (conceptual precedent, NOT copy) | role-match |
+| `shared/notify.ts` (MODIFY: append 2 REASONS + `PluginInstalledMessage.reasons?`) | config / catalog | transform | `malformed mcp` addition (`notify.ts:143-152`); `orphan rewake` reason field (`notify.ts:120-129`, `:621-629`) | exact |
+| `shared/notify-reasons.ts` (MODIFY: add 2 FAILURE_REASONS) | config / catalog | transform | `malformed mcp` in `FAILURE_REASONS` (`notify-reasons.ts:111-115`) + `_ReasonsCoverageProof` (`:166-169`) | exact |
+| `orchestrators/plugin/install.ts` (MODIFY: carry degrade flag → reasons[] standalone + outcome) | orchestrator | event-driven | `orphan rewake` push (`install.ts:1708-1711`, `:1760`); `agentForeignFailures` detail (`:374`, `:967`, `:1637-1646`) | exact |
+| `orchestrators/reconcile/{apply-outcomes.ts, apply.ts, notify.ts}` (MODIFY: degrade flag on `PluginInstalledOutcome` + push token on orchestrated row) | orchestrator | event-driven | `PluginInstalledOutcome` (`apply-outcomes.ts:80-95`); reconcile `plugin-installed` arm (`notify.ts:497-509`) | role-match (new wire) |
+
+## Pattern Assignments
+
+### `platform/pi-api.ts` (API boundary, transform)
+
+**Analog:** its own existing named re-export at line 15.
+
+**Re-export pattern** (`pi-api.ts:15`):
+```typescript
+export { getAgentDir } from "@earendil-works/pi-coding-agent";
+```
+Add a sibling line for `parseFrontmatter`. Signature (VERIFIED, RESEARCH §Code Examples):
+`<T extends Record<string, unknown>>(content: string) => { frontmatter: T; body: string }`.
+This is the ONLY production file allowed to import from `@earendil-works/pi-coding-agent`
+(file header, `pi-api.ts:3-5`); every gate must import `parseFrontmatter` from here, not the peer.
+
+**Semantics to encode in a doc comment** (RESEARCH Pattern 1, VERIFIED):
+- content NOT starting with `---` → `{ frontmatter: {}, body }` (NO throw)
+- opening `---` but no closing `\n---` → `{ frontmatter: {}, body }` (NO throw)
+- closed `---` block, malformed YAML inside → THROWS (the degrade trigger)
+- returned `body` is CRLF→LF normalized and `.trim()`ed
+
+---
+
+### `bridges/skills/stage.ts` (bridge, file-I/O + transform)
+
+**Analog:** the existing per-skill mutation seam, `stage.ts:159-164`.
+
+**The seam to wrap** (`stage.ts:160-164`):
+```typescript
+const skillMdPath = path.join(stagedDir, "SKILL.md");
+let content = await readFile(skillMdPath, "utf8");
+content = rewriteFrontmatterName(content, skill.generatedName);
+content = substituteClaudeVars(content, { pluginRoot, pluginData: pluginDataDir });
+await writeFile(skillMdPath, content, "utf8");
+```
+- **Gate 1 (source, before rewrite):** call `parseFrontmatter(content)` inside a try.
+  THROW → unparseable source → synthesize `disable-model-invocation` block (SKILL-01, body
+  verbatim, fixed-const description). RETURN → inspect `frontmatter.description` /
+  `frontmatter.when_to_use`: empty desc → first-paragraph fill (SKILL-02); `when_to_use`
+  present → fold + truncate 1536 (WTU-01/02); do the surgical single-key `description:` set.
+- **Gate 2 (staged, after `writeFile`):** re-`parseFrontmatter(content)`. THROW on the
+  augment/happy arm → OUR bug → **throw** (D-86-04 / PARSE-02), do not mask as author degradation.
+
+**Import + error idioms already in this file to match:**
+- Imports of `readFile`/`writeFile` from `node:fs/promises` (`stage.ts:20`); add
+  `parseFrontmatter` import from `../../platform/pi-api.ts`.
+- Partial-staging cleanup on throw: `throw appendLeakToError(err, await cleanupStaging(...))`
+  (`stage.ts:174-176`) — a gate-2 throw rides this same catch.
+
+**Degrade-signal collection:** this loop is where a per-component degrade record
+(`{ generatedName, reason }`, mirroring `agentForeignFailures`) is pushed for the
+orchestrator to consume. The bridge returns it up through its result/warnings channel.
+
+---
+
+### `bridges/commands/stage.ts` (bridge, file-I/O + transform)
+
+**Analog:** the existing per-command mutation seam, `stage.ts:158-160`.
+
+**The seam to wrap** (`commands/stage.ts:158-160`):
+```typescript
+let content = await readFile(command.commandFile, "utf8");
+content = substituteClaudeVars(content, { pluginRoot, pluginData: pluginDataDir });
+await writeFile(stagedFile, content, "utf8");
+```
+- **Gate 1 (source):** `parseFrontmatter(content)`. THROW → CMD-01 neutralize = **strip the
+  entire malformed frontmatter block** (opening `---` through closing `---`) so a re-parse
+  RETURNS empty (D-86-07); Pi then takes name-from-filename + first-body-line (60-char cap,
+  RESEARCH §Pi command loader). RETURN → no augment work for commands (WTU is skills-only).
+- **Gate 2 (staged):** re-parse; THROW → OUR bug → **throw** (D-86-04). Note the neutralized
+  output is designed to RETURN, so a gate-2 throw here is always a defect.
+
+**Error idiom to match:** same `appendLeakToError` cleanup catch (`commands/stage.ts:165-167`).
+
+---
+
+### `bridges/skills/rewrite-frontmatter.ts` (utility, transform)
+
+**Analog:** itself — the pure-string `name:` rewrite.
+
+**Current corruption-prone core** (`rewrite-frontmatter.ts:33-40`):
+```typescript
+const nameRegex = /^name:.*$/m;
+let newFrontmatter: string;
+if (nameRegex.test(frontmatter)) {
+  newFrontmatter = frontmatter.replace(nameRegex, `name: ${newName}`);
+} else {
+  newFrontmatter = `\nname: ${newName}` + frontmatter;
+}
+```
+- SKILL-03: after rewrite, the written `name` must equal `newName` when re-parsed. The
+  `/^name:.*$/m` line replace corrupts a folded/block-scalar `name:` (leaves orphaned
+  continuation lines) — verify against gate-1's parsed value, or replace the full node span.
+- Keep the T-03-17 injection-safety property (file header `rewrite-frontmatter.ts:1-6`): the
+  new parse is READ-ONLY (validate + extract), never `eval`.
+
+---
+
+### NEW helper module (utility, transform) — synth / fold / first-paragraph / truncate / safe scalar
+
+**Analog (conceptual ONLY, do NOT copy):** `bridges/agents/frontmatter.ts::emitYamlScalar`
+(`frontmatter.ts:48-59`).
+
+```typescript
+export function emitYamlScalar(value: string): string {
+  const oneLine = value.replace(/\r?\n/g, " ");
+  if (oneLine.startsWith('"') && oneLine.endsWith('"')) return `'${oneLine}'`;
+  if (oneLine.startsWith("'") && oneLine.endsWith("'")) return `"${oneLine}"`;
+  return oneLine;
+}
+```
+**Why this is the anti-pattern, not the template** (RESEARCH §Anti-Patterns, Map row "Safe YAML
+scalar emit"): the agents emitter targets pi-subagents' **flat, line-based** format
+(`emitGeneratedAgentFile`, `frontmatter.ts:258-340` re-emits the WHOLE block). Skills' target is
+**real structured YAML** — whole-block re-emit flattens nested maps / block scalars and damages
+~13% of real skills (NREG-01 violation). Build a NEW safe **double-quoted** scalar emitter
+(escape `\` and `"`, `\n`-encode/collapse embedded newlines) and do a **surgical single-key
+`description:` set**, then rely on gate 2 to prove correctness. Do NOT re-emit siblings.
+
+Helper responsibilities (all pure string, unit-testable in isolation — RESEARCH Wave 0):
+- first-paragraph extraction (skip blank lines, ATX `#` headings, fenced ` ``` `/`~~~` blocks;
+  take contiguous body text to next blank line — D-86-06 / A3)
+- `when_to_use` fold: `description + "\n" + when_to_use` (A1)
+- hard-cut truncate at 1536, no ellipsis (A2 / WTU-02)
+- synthesized unparseable-skill block: fixed-const description + `disable-model-invocation: true`
+  + verbatim body (D-86-02 / A4)
+
+---
+
+### `shared/notify.ts` (catalog, transform)
+
+**Analog:** the `malformed mcp` member and the `orphan rewake` reason-on-row precedent.
+
+**REASONS append pattern** — add AFTER `"malformed mcp"` at `notify.ts:151` (positions 36, 37;
+existing 35 stay byte-identical, OUT-08). Mirror the `malformed mcp` comment block
+(`notify.ts:143-151`) which documents the failure-class-not-unsupported rationale:
+```typescript
+  "malformed mcp",
+  "malformed skill",     // parallels malformed mcp: malformation of a SUPPORTED component (skill)
+  "malformed command",   // parallels malformed mcp: malformation of a SUPPORTED component (command)
+] as const;
+```
+
+**Reason-on-`(installed)`-row precedent** — `PluginInstalledMessage.reasons?` already exists
+(`notify.ts:627`):
+```typescript
+export interface PluginInstalledMessage extends TransitionMessageBase {
+  readonly status: "installed";
+  readonly name: string;
+  readonly dependencies: readonly Dependency[];
+  readonly version?: string;
+  readonly scope?: Scope;
+  readonly reasons?: readonly ContentReason[];   // ← orphan rewake rides this; malformed skill/command joins
+  readonly description?: string;
+}
+```
+No structural change to this interface needed — the new tokens are `ContentReason` members and
+ride the existing field. One token per plugin (mirrors `orphan rewake`, `notify.ts:121-129`).
+
+**Free-text detail channel** — `notifyDiagnostic` (`notify.ts:339-349`), unchanged, reused:
+```typescript
+export function notifyDiagnostic(ctx: ExtensionContext, header: string, lines: readonly string[]): void {
+  if (lines.length === 0) return;
+  ctx.ui.notify(`${header}\n\n${lines.join("\n")}`, "warning");
+}
+```
+Orchestrated-mode only (D-19-01); carries `<plugin>/<component>: <parse error>` lines (WARN-01).
+
+---
+
+### `shared/notify-reasons.ts` (catalog, transform)
+
+**Analog:** `malformed mcp` in `FAILURE_REASONS`.
+
+**FAILURE_REASONS add** (`notify-reasons.ts:111-115`) — add both here, NOT `UNSUPPORTED_REASONS`
+(malformation of a *supported* component). Mirror the existing comment:
+```typescript
+  "malformed mcp",
+  "malformed skill",
+  "malformed command",
+```
+
+**Completeness proof self-guard** (`notify-reasons.ts:166-169`) — no manual edit; adding to
+`REASONS` without a home here makes `_UncoveredReason ≠ never` → TS2344 compile error:
+```typescript
+type _UncoveredReason = Exclude<Reason, SharedTopicReason | CommandPrivateReason>;
+type _ExtraReason = Exclude<SharedTopicReason | CommandPrivateReason, Reason>;
+export type _ReasonsCoverageProof = [_AssertNever<_UncoveredReason>, _AssertNever<_ExtraReason>];
+```
+Update `notify.ts::REASONS` and `notify-reasons.ts::FAILURE_REASONS` in lockstep — the compile
+error is the guardrail (D-86-01).
+
+---
+
+### `orchestrators/plugin/install.ts` (orchestrator, event-driven)
+
+**Analog A — reason-on-row (standalone):** the `orphan rewake` push (`install.ts:1708-1711`):
+```typescript
+const reasons: ContentReason[] = [];
+if (installCtx.resolved.orphanRewake === true) {
+  reasons.push("orphan rewake");
+}
+```
+…then spread onto the row (`install.ts:1760`): `...(reasons.length > 0 && { reasons })`.
+Add a `pushIf` for the bridge-reported degrade flag here (`reasons.push("malformed skill")` /
+`"malformed command"`), one token per plugin regardless of N degraded components.
+
+**Analog B — per-component structured detail carrier:** `agentForeignFailures`
+(`install.ts:374`, collected `:967`, surfaced `:1637-1646`):
+```typescript
+agentForeignFailures: { generatedName: string; reason: string }[];   // install.ts:374
+// ...
+if (installCtx.agentForeignFailures.length > 0) {                    // install.ts:1637
+  const detail = installCtx.agentForeignFailures
+    .map((f) => `${f.generatedName}: ${f.reason}`).join("; ");
+  const msg = `Plugin "${plugin}" installed; ... preserved on disk: ${detail}`;
+  if (orchestrated) { postCommitWarnings.push(msg); }
+  // else: D-19-01 -- dropped in standalone mode.
+}
+```
+Copy this shape for a new `installCtx` list of `{ component, parseError }` degrade records fed by
+the two bridges; format `<plugin>/<component>: <parse error>` into `postCommitWarnings`
+(orchestrated only) → `notifyDiagnostic` (WARN-01 part 2).
+
+**Outcome plumbing:** `InstallPluginOutcome` installed arm (`install.ts:219-227`) already carries
+`postCommitWarnings?`; add a `degraded`/reason flag alongside so the reconcile composer can push
+the row token.
+
+---
+
+### `orchestrators/reconcile/{apply-outcomes.ts, apply.ts, notify.ts}` (orchestrator — NEW wire)
+
+**Analog:** `PluginInstalledOutcome` (`apply-outcomes.ts:80-95`) and the reconcile
+`plugin-installed` arm (`notify.ts:497-509`).
+
+**The gap (VERIFIED, RESEARCH Pitfall "orchestrated reason-token has no existing wire"):** the
+reconcile installed row carries NO `reasons` today:
+```typescript
+case "plugin-installed":                     // reconcile/notify.ts:497
+  block.plugins.push({
+    status: "installed",
+    name: outcome.plugin,
+    ...(outcome.version !== undefined && { version: outcome.version }),
+    dependencies: outcome.dependencies,
+    severity: "info",
+    needsReload: true,
+  });
+  return;
+```
+New work:
+1. Add a degrade flag (e.g. `readonly malformed?: "skill" | "command"` or a `reasons` field) to
+   `PluginInstalledOutcome` (`apply-outcomes.ts:80-95`), alongside the existing
+   `postCommitWarnings?` (`:94`).
+2. Propagate it from `InstallPluginOutcome` through `apply.ts` (the outcome-builder;
+   `apply.ts:314` derives `dependencies` from install flags — same seam).
+3. Push the `{malformed skill|command}` token + raise `severity` to `"warning"` in the
+   `plugin-installed` arm (`notify.ts:497-509`). Row stays `(installed)` NOT
+   `(partially-installed)` (D-86-03: degraded-but-installed, not dropped-supported-component).
+
+---
+
+## Shared Patterns
+
+### Two read-only parse gates (applies to both stage.ts files)
+**Source:** RESEARCH Pattern 1; seams `skills/stage.ts:159-164`, `commands/stage.ts:158-160`.
+Gate 1 = attribution ground truth + degrade trigger (branch on THROW vs RETURN, before any
+mutation). Gate 2 = Pi-acceptability backstop (after `writeFile`; a throw on the non-degrade arm
+is OUR bug → PARSE-02 loud throw). Import `parseFrontmatter` from `platform/pi-api.ts` only.
+
+### Failure-class catalog amendment (applies to both notify files)
+**Source:** `malformed mcp` (`notify.ts:143-152`, `notify-reasons.ts:111-115`). Append to
+`REASONS` after position 35; file under `FAILURE_REASONS` (never `UNSUPPORTED_REASONS`); the
+`_ReasonsCoverageProof` (`notify-reasons.ts:166-169`) compile-fails if either file is out of sync.
+
+### One-token-per-plugin reason on the `(installed)` row (applies to both orchestrators)
+**Source:** `orphan rewake` (`install.ts:1708-1711`, `notify.ts:121-129`,
+`PluginInstalledMessage.reasons?` `:627`). Standalone rides `PluginInstalledMessage.reasons?`
+directly; orchestrated needs the new `PluginInstalledOutcome` flag + reconcile-composer push.
+
+### Structured per-component detail → notifyDiagnostic (applies to install.ts + bridges)
+**Source:** `agentForeignFailures` (`install.ts:374`, `:1637-1646`) → `postCommitWarnings` →
+`notifyDiagnostic` (`notify.ts:339-349`). Orchestrated-only (D-19-01); the reason token is the
+standalone surface.
+
+## No Analog Found
+
+None. Every touched file has an in-repo precedent. The single genuinely new artifact is the skills
+degrade helper module, whose *shape* has a conceptual precedent (`agents/frontmatter.ts`) but whose
+YAML-emit strategy must diverge (surgical single-key set vs whole-block re-emit) — flagged above and
+in RESEARCH Open Question 1 as the phase's central technical risk.
+
+## Test Analogs
+
+| New/extended test | Analog file | Covers |
+|-------------------|-------------|--------|
+| skills gate + degrade arms | `tests/bridges/skills/stage.test.ts` (extend) | PARSE-01/02, SKILL-01, NREG-01 |
+| SKILL-03 name verify | `tests/bridges/skills/rewrite-frontmatter.test.ts` (extend) | SKILL-03 |
+| helper: first-paragraph / fold / truncate / safe scalar | NEW (Wave 0) | SKILL-02, WTU-01, WTU-02 |
+| commands neutralize | `tests/bridges/commands/stage.test.ts` (extend) | CMD-01 |
+| catalog + row token | `tests/shared/notify-v2.test.ts` (extend) | CLASS-01, WARN-01 |
+
+Fixtures needed (RESEARCH Wave 0 gaps): unquoted-`: `-mid-scalar skill (throws), description-less
+skill, `>-`/`|` block-scalar description skill, folded multi-line `name` skill, throwing command.
+
+## Metadata
+
+**Analog search scope:** `extensions/pi-claude-marketplace/{platform,bridges,shared,orchestrators}`
+**Files read this session:** `bridges/skills/stage.ts`, `bridges/commands/stage.ts`,
+`bridges/skills/rewrite-frontmatter.ts`, `bridges/agents/frontmatter.ts`, `platform/pi-api.ts`,
+`shared/notify.ts` (89-254, 330-349, 615-644), `shared/notify-reasons.ts` (95-169),
+`orchestrators/plugin/install.ts` (219-240, 1630-1764), `orchestrators/reconcile/notify.ts`
+(485-524), `orchestrators/reconcile/apply-outcomes.ts` (70-109)
+**Pattern extraction date:** 2026-07-26
+</content>
+</invoke>

--- a/.planning/phases/86-skill-and-command-frontmatter-compliance/86-RESEARCH.md
+++ b/.planning/phases/86-skill-and-command-frontmatter-compliance/86-RESEARCH.md
@@ -1,0 +1,538 @@
+# Phase 86: Skill and command frontmatter compliance - Research
+
+**Researched:** 2026-07-26
+**Domain:** Frontmatter parse/degrade parity between Claude Code and Pi's skill/command loaders; a closed-set notification-catalog amendment
+**Confidence:** HIGH (all load-bearing claims verified against installed Pi package source, the 0.74.0 npm tarball, the extension source, and upstream docs)
+
+## Summary
+
+This is a codebase-and-upstream-verification phase, not a package-selection one. No new runtime
+dependency is required. The entire delivery lands in the extension's existing skills/commands
+staging seams plus the closed `REASONS` catalog. The five critical unknowns are now resolved with
+direct evidence:
+
+1. **`parseFrontmatter` is a public root export at the peer floor.** Verified in the `0.74.0` npm
+   tarball (`dist/index.d.ts:26`) and the installed `0.79.10` (`dist/index.d.ts:29`). Signature:
+   `<T extends Record<string, unknown>>(content: string) => { frontmatter: T; body: string }`. It
+   **throws** (via `yaml.parse`) on malformed YAML *inside* `---` delimiters, and **returns empty
+   frontmatter without throwing** when the content lacks an opening `---` or a closing `\n---`.
+   `platform/pi-api.ts` does **not** surface it yet — new re-export plumbing is needed there.
+
+2. **Upstream parity mechanics are documented, but three sub-behaviors are NOT** — those absences
+   are themselves decisive (they become Claude's discretion, not invented fact). `when_to_use` is
+   "Appended to `description`" with **no documented separator**; the 1,536-char cap is a plain
+   "truncated at 1,536 characters" with **no documented ellipsis** (so a hard cut); "first paragraph
+   of markdown content" has **no documented heading/blank-line rule**.
+
+3. **A hard cross-loader discrepancy exists that the plan must confront:** Pi caps a skill
+   `description` at **1024** chars (`MAX_DESCRIPTION_LENGTH`, a non-fatal warning diagnostic), while
+   the locked WTU-02 truncates the combined text at **1,536** to match Claude Code's listing. A
+   combined description in the 1025–1536 range loads fine in Pi but emits a Pi startup length-warning.
+
+4. **Both surfacing channels already exist; one is fully wired, one needs new plumbing for
+   orchestrated mode.** The free-text detail (D-86-03 part 2) rides the existing
+   `bridgeWarnings → postCommitWarnings → notifyDiagnostic` channel (orchestrated mode only, per
+   D-19-01). The `{malformed skill}`/`{malformed command}` reason token (D-86-03 part 1) rides the
+   existing `PluginInstalledMessage.reasons?` field — but the `orphan rewake` precedent only wires
+   the **standalone** row; the **orchestrated** reconcile `plugin-installed` arm carries no reasons
+   today, so cross-mode reason-token plumbing is genuinely new work.
+
+5. **The catalog amendment is mechanical and compile-guarded.** Append `malformed skill` +
+   `malformed command` to `REASONS` (35 → 37) and to `FAILURE_REASONS`; the `_ReasonsCoverageProof`
+   fails to compile if either is added to `REASONS` without a home in a topic group.
+
+**Primary recommendation:** Insert two read-only `parseFrontmatter` gates (source-before-rewrite,
+staged-after-write) at both staging seams via a new `platform/pi-api.ts` re-export. For the
+augment cases (SKILL-02 first-paragraph fill, WTU-01 fold) do a **surgical single-key set** of
+`description:` using a **safe double-quoted YAML scalar emitter** (never whole-block re-emit, never
+add the `yaml` package as a direct dep); backstop every write with gate 2. Keep the existing
+pure-string `name:` rewrite but verify the written name equals the parsed generated name (SKILL-03).
+Do not touch the 99% happy path — the gates are read-only and only the degrade/augment arms mutate.
+
+## User Constraints (from CONTEXT.md)
+
+### Locked Decisions
+
+- **D-86-01 (CLASS-01):** Add **two dedicated per-kind tokens** — `malformed skill` and
+  `malformed command` — paralleling `malformed mcp`. NOT a single shared token, NOT a reuse of the
+  generic `unparseable`. Append both to `REASONS` in `notify.ts` **after** the existing 35 entries
+  (existing order stays byte-identical, OUT-08); file both under `FAILURE_REASONS` in
+  `notify-reasons.ts` (NOT `UNSUPPORTED_REASONS`). Update `_ReasonsCoverageProof` in lockstep (the
+  compile error is the guardrail). Closed set grows 35 → 37. Reversibility: costly (published catalog
+  contract + completeness proof + byte-stability tests).
+
+- **D-86-02 (SKILL-01):** The synthesized `description` on an unparseable skill is a **short fixed
+  constant** (e.g. `Source frontmatter could not be parsed.`) — not interpolated with plugin/source
+  names. The skill carries `disable-model-invocation: true`, so it is excluded from the model's
+  listing and costs zero context; it exists only to clear Pi's non-empty-`description` gate. Body is
+  preserved verbatim; install does not hard-fail. Exact wording is Claude's discretion within "short
+  fixed constant."
+
+- **D-86-03 (WARN-01):** A degraded skill / neutralized command still installs; the failure stops
+  being silent via a **two-part surface**: (1) the closed-set reason token rides the plugin's
+  `(installed)` row at **`warning`** severity — **one token per plugin** regardless of how many
+  components degraded (mirrors `orphan rewake`); (2) the per-component free-text detail
+  (`<plugin>/<component>: <parse error>`) rides the existing post-cascade `notifyDiagnostic` warning
+  channel. Planner to confirm the row is `(installed)` (installed in degraded form), NOT
+  `(partially-installed)` (which is for *dropped* supported components). Severity is a per-row stamp;
+  degraded-but-installed → `warning`.
+
+- **D-86-04 (PARSE-02):** If a source parses cleanly but the **staged** output (post-rewrite +
+  post-substitution) fails to parse, that is **our** bug — **throw** and fail that plugin's install
+  loudly (test-guarded), never mask it as author degradation.
+
+### Claude's Discretion
+
+- **Upstream-parity mechanics — research MUST verify before planning, do not invent:** `when_to_use`
+  fold separator/format (WTU-01); the 1,536-char truncation style and which side truncates (WTU-02);
+  the precise "first paragraph of markdown content" extraction (SKILL-02). Source of truth:
+  `code.claude.com/docs/en/skills.md`. *(All three fetched and reported verbatim below; three
+  sub-behaviors are undocumented upstream — see State of the Art + Assumptions Log.)*
+- Exact placeholder-description string (within D-86-02's "short fixed constant").
+- Whether `parseFrontmatter` needs re-export plumbing in `platform/pi-api.ts` or is already surfaced
+  there — **verify it was exported at the declared peer floor `>=0.74.0`**. *(Resolved: exported at
+  0.74.0; NOT yet surfaced in `platform/pi-api.ts` — plumbing needed.)*
+
+### Deferred Ideas (OUT OF SCOPE)
+
+- **REASON-01** (v1.14 backlog): unify all parse-error reasons under a single `{malformed <feature>}`
+  family. This phase adds two more failure-class members; the broad unification stays deferred.
+- `when_to_use` folding for **commands** is out of scope — WTU is skills-only (Pi's command loader
+  reads name + first-body-line, has no description-listing surface for triggers).
+- The `2026-06-12-coverage-sweep-...` todo (broad pre-existing update/reinstall coverage sweep) stays
+  deferred; this phase adds only its own parse-failure-arm tests.
+
+## Phase Requirements
+
+| ID | Description | Research Support |
+|----|-------------|------------------|
+| PARSE-01 | Source frontmatter parsed with Pi's `parseFrontmatter` before rewrite/substitution, at both seams | `parseFrontmatter` re-export path + signature/throw semantics verified; seams located (`skills/stage.ts:161-164`, `commands/stage.ts:158-160`) |
+| PARSE-02 | Staged bytes re-parsed as Pi-acceptability backstop; self-inflicted defect → loud throw | Gate-2 insertion points identified; `parseFrontmatter` throw-on-malformed confirmed as the trigger |
+| SKILL-01 | Unparseable skill → synthesized `disable-model-invocation` block, body verbatim, no hard-fail | Pi `disableModelInvocation` key + `formatSkillsForPrompt` filter + `!description → skill:null` guard verified in `core/skills.js` |
+| SKILL-02 | Absent/empty `description` → first-paragraph-of-body fallback | Upstream "first paragraph" wording cited; Pi `body` (trimmed) available from `parseFrontmatter`; exact extraction rule is undocumented upstream (discretion) |
+| SKILL-03 | Written `name` always equals generated name; folded scalar cannot corrupt | Current `rewrite-frontmatter.ts` line-regex corruption confirmed; gate-1 parsed value is the check oracle |
+| WTU-01 | `when_to_use` folded (appended) into Pi `description` | Upstream "Appended to `description`" cited; **no separator documented** (discretion) |
+| WTU-02 | Combined `description`+`when_to_use` truncated at 1,536 chars | Upstream cap cited; **hard cut vs ellipsis undocumented** (hard cut assumed); Pi's 1024 warning discrepancy flagged |
+| CMD-01 | Unparseable command → neutralized (name-from-filename, description-from-first-body-line) | Pi `prompt-templates.js` loader path verified (name = basename−`.md`; desc = first non-empty body line, 60-char cap) |
+| WARN-01 | Each degraded/neutralized component → install-time warning naming component + parse error | `notifyDiagnostic` + `postCommitWarnings`/`bridgeWarnings` channel fully traced; `agentForeignFailures` is the structured precedent |
+| CLASS-01 | Failure-class token paralleling `malformed mcp` under `FAILURE_REASONS`; byte-stable amendment | `REASONS` (35) + `FAILURE_REASONS` + `_ReasonsCoverageProof` machinery read; amendment mechanics confirmed |
+| NREG-01 | Already-valid components written byte-for-byte unchanged | Gates are read-only; only degrade/augment arms mutate — happy path untouched by construction |
+
+## Architectural Responsibility Map
+
+| Capability | Primary Tier | Secondary Tier | Rationale |
+|------------|-------------|----------------|-----------|
+| Source-frontmatter validity check (gate 1) | Bridge staging (`skills/stage.ts`, `commands/stage.ts`) | Pi API boundary (`platform/pi-api.ts`) | Attribution ground truth is established where the bytes are first read, before any mutation |
+| Staged-byte backstop (gate 2) | Bridge staging | Pi API boundary | We must not ship bytes Pi rejects; the check belongs immediately after the write |
+| Degrade/neutralize synthesis | Bridge (skills: synthesize block; commands: neutralize) | — | The bridge owns the byte transformation; it alone knows the generated name and the substitution result |
+| Safe YAML scalar emit (description set) | Bridge (new helper alongside `rewrite-frontmatter.ts`) | — | Output-validity concern local to the skills bridge; agents' flat emitter is not reusable (real-YAML target) |
+| Reason-token classification | Notification catalog (`shared/notify.ts`, `shared/notify-reasons.ts`) | — | Closed-set contract owned centrally; per-kind attribution is a catalog concern |
+| Reason token on the install row | Install orchestrator (standalone) + reconcile notify composer (orchestrated) | Install-outcome types | Row composition is a two-mode concern; the degrade signal must reach both composers |
+| Free-text parse-error detail | `notifyDiagnostic` via `postCommitWarnings` | Reconcile/import cascade appliers | The detail has no cascade-body representation; the sanctioned out-of-band warning seam owns it |
+
+## Standard Stack
+
+No new dependencies. Everything is built on already-present modules.
+
+### Core (already present — carry forward, no version change)
+| Module | Source | Purpose | Why Standard |
+|--------|--------|---------|--------------|
+| `parseFrontmatter` | `@earendil-works/pi-coding-agent` (peer `>=0.74.0`) | Read-only parse for gate 1 + gate 2; extract `description`/`name`/`when_to_use`/body | Byte-identical accept/reject semantics with Pi's own loaders — the whole point of "observable parity" [VERIFIED: dist/index.d.ts:26 in 0.74.0 tarball, :29 in installed 0.79.10] |
+| `node:fs/promises` (`readFile`/`writeFile`) | built-in | Existing staging read/write | Already the seam [VERIFIED: skills/stage.ts:161-164, commands/stage.ts:158-160] |
+
+### Supporting (already present)
+| Module | Source | Purpose | When to Use |
+|--------|--------|---------|-------------|
+| `substituteClaudeVars` | `shared/vars.ts` | `${CLAUDE_PLUGIN_ROOT}`/`${CLAUDE_PLUGIN_DATA}` expansion | Unchanged; gate 2 runs *after* it so a substitution that breaks YAML is caught (D-86-04) [VERIFIED: stage.ts] |
+| `rewriteFrontmatterName` | `bridges/skills/rewrite-frontmatter.ts` | Existing pure-string `name:` rewrite | Keep; add a parsed-value verification (SKILL-03) [VERIFIED: source read] |
+| `notifyDiagnostic` | `shared/notify.ts:339-349` | Post-cascade `warning` channel for free-text detail | D-86-03 part 2 [VERIFIED: source read] |
+| `emitYamlScalar` (reference only, do NOT reuse) | `bridges/agents/frontmatter.ts` | Agents' line-based scalar emit | Conceptual precedent ONLY — targets pi-subagents' flat format, wrong for skills' real YAML [VERIFIED: source read] |
+
+### Do NOT add
+| Candidate | Verdict | Why |
+|-----------|---------|-----|
+| `yaml` (2.9.0) as a **direct** dependency | Avoid | Present only transitively via the Pi peer; the extension imports it nowhere. Adding it as a direct dep to get the `Document`/CST round-trip API reintroduces the whole-block-re-emit risk the diagnosis rejected and is unnecessary — a small safe double-quoted-scalar emitter + gate 2 backstop covers the need [VERIFIED: `node_modules/yaml@2.9.0` present; `grep` shows zero `from "yaml"` in `extensions/`] |
+
+## Package Legitimacy Audit
+
+**Not applicable.** This phase installs no external packages. `parseFrontmatter` is a root export of
+the already-declared peer dependency `@earendil-works/pi-coding-agent`; `yaml` is already resolved
+transitively and is explicitly *not* being adopted as a direct dependency. No registry additions.
+
+## Architecture Patterns
+
+### System Architecture Diagram
+
+```
+                         SOURCE SKILL.md / COMMAND.md bytes (untrusted plugin author)
+                                              │
+                                              ▼
+   ┌──────────────────────── GATE 1: parseFrontmatter(source)  [read-only] ────────────────────────┐
+   │                                          │                                                     │
+   │             throws (malformed YAML in ---)│              returns {frontmatter, body}            │
+   │                     ▼                     │                          ▼                          │
+   │   ┌── SKILL: synthesize block ──┐         │        extract name / description / when_to_use     │
+   │   │  name=<generated>           │         │                          │                          │
+   │   │  description=<fixed const>  │         │      ┌───────────────────┴───────────────────┐      │
+   │   │  disable-model-invocation   │         │      │ desc empty? → first-paragraph(body)    │      │
+   │   │  body verbatim              │         │      │ when_to_use present? → append to desc  │      │
+   │   └── COMMAND: neutralize ──────┘         │      │ combined desc → truncate 1536          │      │
+   │   │  strip/defuse frontmatter,  │         │      │ SURGICAL single-key SET description:   │      │
+   │   │  Pi reads name-from-file +  │         │      │   (safe dq-scalar emit)                │      │
+   │   │  first-body-line (60-cap)   │         │      │ rewrite name: (verify == generated)    │      │
+   │   └─── degrade token + detail ──┘         │      └───────────────────┬───────────────────┘      │
+   │              │                            │                          │                          │
+   └──────────────┼────────────────────────────────────substituteClaudeVars()──────────────────────┘
+                  │                                                       │
+                  ▼                                                       ▼
+   ┌──────────────────────── GATE 2: parseFrontmatter(staged bytes)  [read-only] ───────────────────┐
+   │   degraded path: staged must parse (else our bug → THROW)   augmented path: must parse → THROW  │
+   └────────────────────────────────────────────┬───────────────────────────────────────────────────┘
+                                                 ▼   writeFile(staged)
+                        ┌────────────────────────┴────────────────────────┐
+             degrade signal (per component)                     staged bytes on disk
+                        │                                                  │
+           ┌────────────┴───────────┐                                      ▼
+           ▼                        ▼                              atomic rename → target
+   reasons[] token            postCommitWarnings                          │
+   {malformed skill|command}  "<plugin>/<comp>: <err>"                     ▼
+   on (installed) row         → notifyDiagnostic (orchestrated)      Pi loads at /reload
+   (one per plugin)                                                  (byte-identical to Pi's own parse)
+```
+
+### Recommended Structure (files touched)
+```
+extensions/pi-claude-marketplace/
+├── platform/pi-api.ts                      # ADD: re-export parseFrontmatter (+ type)
+├── bridges/skills/
+│   ├── stage.ts                            # insert gate 1 (pre-rewrite) + gate 2 (post-write); degrade arm
+│   ├── rewrite-frontmatter.ts              # keep name rewrite; ADD safe description-set + SKILL-03 verify
+│   └── (new helper module for synth/fold/first-paragraph/truncate + safe scalar emit)
+├── bridges/commands/stage.ts               # insert gate 1 + gate 2; neutralize arm
+├── orchestrators/plugin/install.ts         # carry degrade signal → reasons[] (standalone) + outcome
+├── orchestrators/reconcile/apply.ts,       # propagate degrade signal into PluginInstalledOutcome
+│   apply-outcomes.ts, notify.ts            # push {malformed *} token on the orchestrated installed row
+├── shared/notify.ts                        # append 2 tokens to REASONS (36,37)
+└── shared/notify-reasons.ts                # add 2 to FAILURE_REASONS; proof self-updates
+```
+
+### Pattern 1: Two read-only parse gates
+**What:** `parseFrontmatter(source)` before any mutation (gate 1 = attribution + degrade trigger);
+`parseFrontmatter(stagedBytes)` after write (gate 2 = Pi-acceptability backstop).
+**When:** Both seams, every component.
+**Key semantics** (drive the branch logic):
+```
+// core behavior of parseFrontmatter (utils/frontmatter.js, VERIFIED)
+// - content NOT starting with "---"        → { frontmatter: {}, body }   (NO throw)
+// - opening "---" but no closing "\n---"    → { frontmatter: {}, body }   (NO throw)
+// - closed --- block, malformed YAML inside → THROWS (yaml.parse)         (the degrade trigger)
+// - body is normalized (CRLF→LF) and .trim()'ed on return
+```
+Gate 1 branches on **throw** (→ synthesize/neutralize) vs **return** (→ inspect `frontmatter.description`
+/ `when_to_use`). Gate 2 branches on **throw** → for the degrade arm the throw is impossible if we
+synthesized a known-good block; for the augment/happy arm a throw is **our** defect → PARSE-02 loud throw.
+
+### Pattern 2: Surgical single-key `description:` set (augment cases only)
+**What:** For SKILL-02 (fill from first paragraph) and WTU-01 (append `when_to_use`), set exactly the
+`description` node without whole-block re-emit, emitting the value as a **safe double-quoted YAML
+scalar** (escape `\` and `"`, collapse/`\n`-encode embedded newlines). Gate 2 backstops correctness.
+**Why not whole-block re-emit:** the diagnosis measured that flattening damages ~13% of real skills
+(nested maps, block scalars, flow collections). NREG-01 requires byte-for-byte for the untouched 99%.
+**Caution (surfaced as open question):** if a source `description` is itself a multi-line block scalar
+(`>-`/`|`), a naive line regex replacing only the first line corrupts it — the exact SKILL-03 class of
+bug. The planner must locate the full node span, not just the `description:` line. See Open Questions.
+
+### Pattern 3: Reason token rides the existing `reasons?` field, one per plugin
+**What:** Push `"malformed skill"` / `"malformed command"` into `PluginInstalledMessage.reasons`
+(already `readonly ContentReason[]`, already rendered via `composeReasons`). One token per plugin
+regardless of N degraded components — mirrors `orphan rewake`.
+
+### Anti-Patterns to Avoid
+- **Re-emitting the whole frontmatter block** (agents-bridge style) — rejected in the diagnosis.
+- **Quote-repair of author scalars** — rejected (rewrites third-party content, unbounded heuristic).
+- **Blind `/^name:.*$/m` / `/^description:.*$/m` line replace on multi-line scalars** — the SKILL-03
+  corruption; verify against the parsed value.
+- **Treating a staged-parse failure as author degradation** — D-86-04: that is our bug; throw.
+- **Adding the reason token per-component** — one per plugin (MSG-GR-4 brace share).
+
+## Don't Hand-Roll
+
+| Problem | Don't Build | Use Instead | Why |
+|---------|-------------|-------------|-----|
+| Deciding if bytes are Pi-parseable | A bespoke YAML validator | `parseFrontmatter` (re-exported) | Only byte-identical semantics guarantee parity; a second parser drifts |
+| Full YAML round-trip to set one key | Import `yaml` `Document` API | Surgical single-key set + safe dq-scalar emit + gate 2 | Round-trip reformats siblings (breaks NREG-01); direct dep is unnecessary |
+| Post-cascade free-text warning surface | A new notify variant | `notifyDiagnostic` + `postCommitWarnings` | Already the sanctioned out-of-band warning seam |
+| Structured per-component failure carrier | Ad-hoc string list | An `installCtx` list like `agentForeignFailures` (`{generatedName, reason}`) | Established precedent already threaded to `postCommitWarnings` |
+| Catalog completeness enforcement | Manual review | `_ReasonsCoverageProof` (compile error) | Adding to `REASONS` without a topic-group home already fails `tsc` |
+
+**Key insight:** the hard part of this phase is *not* new machinery — it is threading a stage-time
+degrade signal into two different row composers (standalone + orchestrated) and doing a NREG-safe
+single-key YAML set. Both existing precedents (`orphan rewake` reason, `agentForeignFailures` detail)
+solve *half* the propagation each; neither covers the orchestrated reason-row.
+
+## Runtime State Inventory
+
+This is a code/behavior change to the staging pipeline, not a rename/migration. No stored data, live
+service config, OS-registered state, secrets, or build artifacts embed a renamed identifier.
+
+| Category | Items Found | Action Required |
+|----------|-------------|------------------|
+| Stored data | None — no datastore keys change. Already-installed skills/commands on disk are re-materialized only on the next install/update; this phase does not migrate existing target bytes. | None |
+| Live service config | None | None |
+| OS-registered state | None | None |
+| Secrets/env vars | None | None |
+| Build artifacts | None — no package rename; `parseFrontmatter` is a peer-provided export | None |
+
+**Note (not a runtime-state item but a behavioral one):** already-installed malformed skills/commands
+stay broken until the plugin is re-installed/updated; this phase fixes the *write path*, not existing
+on-disk output. Confirm this matches the intended scope (it aligns with NREG-01 and the diagnosis).
+
+## Common Pitfalls
+
+### Pitfall: Pi's 1024-char description cap vs the locked 1,536-char truncation
+**What goes wrong:** WTU-02 truncates the combined `description`+`when_to_use` at 1,536 to match
+Claude Code's listing. But Pi's skill loader validates `description.length > 1024` and pushes a
+`warning` diagnostic ("description exceeds 1024 characters"). A combined value in the 1025–1536 range
+therefore loads and stays model-invocable in Pi **but emits a Pi startup warning**.
+**Why it happens:** the two hosts use different listing budgets; the requirement pins the Claude Code
+number (1,536), which is the correct parity target for the *source-of-truth* combined text.
+**How to avoid:** honor the locked 1,536 (the requirement), and treat the Pi 1024 warning as a
+known, non-fatal divergence — do NOT secretly truncate to 1024 (that would diverge from Claude Code
+and silently drop trigger keywords). Document the divergence; consider a test asserting the >1024
+skill still loads (Pi returns a Skill, not `null`, when description is non-empty).
+**Warning signs:** a Pi `--debug`/startup warning on a long-triggered skill. [VERIFIED: `core/skills.js`
+`MAX_DESCRIPTION_LENGTH = 1024`, `validateDescription` pushes a warning; the `skill:null` guard fires
+only on **empty**, not on over-length]
+
+### Pitfall: gate 1 does NOT throw on missing delimiters
+**What goes wrong:** treating "no frontmatter" as an unparseable-source degrade. `parseFrontmatter`
+returns `{ frontmatter: {}, body }` (no throw) for content with no `---` block.
+**How to avoid:** the unparseable-source degrade (SKILL-01/CMD-01) triggers on a **throw**, not on an
+empty result. An empty-frontmatter skill is the SKILL-02 case (fill description from first paragraph),
+not the SKILL-01 case. [VERIFIED: `utils/frontmatter.js` `extractFrontmatter`]
+
+### Pitfall: multi-line source `description` node corruption
+**What goes wrong:** appending `when_to_use` (WTU-01) or replacing an empty description (SKILL-02) by
+replacing only the `description:` line, when the source used a `>-`/`|` block scalar spanning several
+lines — leaving orphaned continuation lines, exactly the SKILL-03 folded-`name` corruption class.
+**How to avoid:** compute the value from the parsed object, then replace the full node span; verify
+with gate 2. Add fixtures with block-scalar and folded descriptions.
+
+### Pitfall: orchestrated reason-token has no existing wire
+**What goes wrong:** copying only the `orphan rewake` precedent (`install.ts:1709`) surfaces the token
+in **standalone** install but not in the **orchestrated** reconcile cascade — where most installs run.
+The reconcile `plugin-installed` arm (`reconcile/notify.ts:497-509`) carries no `reasons` today.
+**How to avoid:** add a degrade flag to `InstallPluginOutcome` → `PluginInstalledOutcome`, and push
+the token in the reconcile notify composer. [VERIFIED: `reconcile/notify.ts` plugin-installed arm has
+no reasons; `grep orphanRewake` shows it only in `resolver.ts`, `install.ts:1709`, comments]
+
+### Pitfall: free-text detail is dropped in standalone mode (D-19-01)
+**What goes wrong:** expecting the `<plugin>/<component>: <parse error>` line to appear on a bare
+`/claude:plugin install foo@mp`. `postCommitWarnings`/`bridgeWarnings` are collected only when
+`orchestrated`; standalone drops them per D-19-01.
+**How to avoid:** confirm the target install path is orchestrated (reconcile), or accept that the
+reason token (on the row, both modes) is the standalone surface and the detail line is orchestrated-only.
+[VERIFIED: `install.ts:1604/1624/1643/1654` all guard on `if (orchestrated)`]
+
+## Code Examples
+
+### `parseFrontmatter` re-export (new plumbing in `platform/pi-api.ts`)
+```typescript
+// Source: dist/index.d.ts:29 (installed 0.79.10) / :26 (0.74.0 tarball) — VERIFIED
+export { parseFrontmatter } from "@earendil-works/pi-coding-agent";
+// signature: <T extends Record<string, unknown> = Record<string, unknown>>
+//   (content: string) => { frontmatter: T; body: string }
+```
+
+### Pi skills loader — the degrade targets (VERIFIED, `core/skills.js`)
+```javascript
+// loadSkillFromFile (dist/core/skills.js:208-247), abridged
+const { frontmatter } = parseFrontmatter(rawContent);          // THROWS on malformed → catch below
+const name = frontmatter.name || parentDirName;
+if (!frontmatter.description || frontmatter.description.trim() === "") {
+    return { skill: null, diagnostics };                        // empty desc ⇒ skill GONE
+}
+return { skill: { name, description: frontmatter.description,
+    disableModelInvocation: frontmatter["disable-model-invocation"] === true, ... } };
+// catch (parse throw) → diagnostics.push({type:"warning",...}); return { skill: null }
+// MAX_DESCRIPTION_LENGTH = 1024; validateDescription pushes a NON-FATAL warning when exceeded
+// formatSkillsForPrompt filters s.disableModelInvocation (excluded from model listing)
+```
+
+### Pi command loader — the neutralize target (VERIFIED, `core/prompt-templates.js`)
+```javascript
+// loadTemplateFromFile (dist/core/prompt-templates.js:81-108), abridged
+try {
+  const { frontmatter, body } = parseFrontmatter(rawContent);  // THROWS → catch → return null (SILENT)
+  const name = basename(filePath).replace(/\.md$/, "");        // name-from-filename
+  let description = frontmatter.description || "";
+  if (!description) {
+    const firstLine = body.split("\n").find((line) => line.trim());
+    if (firstLine) { description = firstLine.slice(0, 60);       // first non-empty body line, 60-cap
+      if (firstLine.length > 60) description += "..."; }
+  }
+  return { name, description, ... };
+} catch { return null; }                                        // fully silent today
+```
+CMD-01 neutralize must make `parseFrontmatter` **return** (not throw) so Pi takes the
+name-from-filename + first-body-line path — i.e. defuse the frontmatter so it is no longer a closed,
+malformed `---` block (e.g. drop the delimiters so the block reads as body).
+
+### Catalog amendment (`shared/notify.ts` + `shared/notify-reasons.ts`)
+```typescript
+// notify.ts REASONS — append AFTER "malformed mcp" (positions 36, 37); existing 35 unchanged (OUT-08)
+  "malformed mcp",
+  "malformed skill",     // parallels malformed mcp: malformation of a SUPPORTED component (skill)
+  "malformed command",   // parallels malformed mcp: malformation of a SUPPORTED component (command)
+] as const;
+// notify-reasons.ts FAILURE_REASONS — add both here (NOT UNSUPPORTED_REASONS)
+//   → _ReasonsCoverageProof self-satisfies; omit one and _UncoveredReason ≠ never → TS2344
+```
+
+## State of the Art
+
+### Upstream parity mechanics (fetched verbatim from code.claude.com/docs/en/skills.md, 2026-07-26)
+
+| Behavior | Documented upstream text (verbatim) | Status |
+|----------|-------------------------------------|--------|
+| `description` fallback | "If omitted, uses the first paragraph of markdown content." | **Documented** — SKILL-02 confirmed |
+| Combined truncation | "the combined `description` and `when_to_use` text is truncated at 1,536 characters in the skill listing to reduce context usage." | **Documented** — WTU-02 cap confirmed |
+| `when_to_use` fold | "Additional context for when Claude should invoke the skill... **Appended to `description`** in the skill listing and counts toward the 1,536-character cap." | **Documented that it is appended** — WTU-01 confirmed |
+| Malformed policy | "If the frontmatter YAML is malformed, Claude Code loads the skill body with empty metadata, so `/skill-name` still works but Claude has no `description` to match against. Run with `--debug` to see the parse error." | **Documented** — SKILL-01/CMD-01 parity target confirmed |
+
+### Upstream ABSENCES (decisive findings — these become Claude's discretion, not fact)
+
+| Sub-behavior | What is NOT documented | Consequence for the plan |
+|--------------|------------------------|--------------------------|
+| `when_to_use` separator | The docs say "Appended" but give **no** separator/label/ordering between `description` and `when_to_use`. | Choose a separator (recommend a single `\n` or `. ` / space) as a discretionary decision; mark `[ASSUMED]`. Whatever is chosen, it is a source-side detail Claude Code does not pin. |
+| Truncation style | "truncated at 1,536 characters" — **no** mention of an ellipsis or which end. Since `when_to_use` is *appended*, the tail (i.e. `when_to_use` first, then description tail) is what overflows. | Implement a **hard cut** at 1,536 of `description + <sep> + when_to_use`; no ellipsis. Mark `[ASSUMED]` on "hard cut." |
+| First-paragraph extraction | "first paragraph of markdown content" — **no** rule for skipping a leading `#` heading or the exact blank-line boundary. | Choose a rule (recommend: skip a leading ATX `#` heading line if present, then take text up to the first blank line). Mark `[ASSUMED]`. |
+
+**Deprecated/outdated:** none. The diagnosis's parser fingerprinting (Claude Code = js-yaml strict;
+Pi = `yaml` strict) is still accurate; both reject the same `: `-in-plain-scalar inputs. Exhaustive
+`yaml ≡ js-yaml` equivalence is explicitly out of scope (safe divergence).
+
+## Assumptions Log
+
+| # | Claim | Section | Risk if Wrong |
+|---|-------|---------|---------------|
+| A1 | `when_to_use` is folded with a single-`\n` (or space) separator | WTU-01 | Low — cosmetic; Claude Code itself does not pin a separator. Confirm the chosen char with the operator. |
+| A2 | The 1,536-char truncation is a **hard cut** (no ellipsis), applied to `description + sep + when_to_use` with the tail dropped | WTU-02 | Low — upstream says only "truncated at 1,536"; a hard cut is the literal reading. |
+| A3 | First-paragraph = skip a leading ATX `#` heading, then text to the first blank line | SKILL-02 | Medium — a wrong boundary yields an unhelpful description (still loads; still model-invocable). Confirm the rule with the operator. |
+| A4 | The exact placeholder string for an unparseable skill (D-86-02 leaves wording to discretion) | SKILL-01 | Low — disabled skill, zero context cost; must be a YAML-safe short constant. |
+| A5 | CMD-01 neutralize = defuse the `---` block so `parseFrontmatter` returns empty (Pi then uses name-from-filename + first-body-line) | CMD-01 | Medium — the exact defuse transform (drop delimiters vs comment out) affects the body Pi reads for its first-line description; verify with a fixture. |
+
+**These five need operator confirmation in discuss/plan before they become locked.** All other claims
+in this document are `[VERIFIED]` or `[CITED]`.
+
+## Open Questions
+
+1. **NREG-safe multi-line `description` replacement.**
+   - What we know: happy-path skills stay byte-identical (gates are read-only); only augment arms
+     (SKILL-02, WTU-01) rewrite `description`; whole-block re-emit is rejected.
+   - What's unclear: how to replace a `description` that is a **multi-line block scalar** without a
+     full YAML round-trip and without corrupting sibling fields. A single-line regex is unsafe (the
+     SKILL-03 class). `parseFrontmatter` returns values but not source ranges.
+   - Recommendation: replace the full `description` node span (scan from `^description:` to the next
+     top-level key or the block-scalar dedent boundary), emit the new value as a safe double-quoted
+     single-line scalar, and **rely on gate 2** to prove correctness. Add block-scalar/folded fixtures.
+     Escalate to the planner as the phase's central technical risk.
+
+2. **Which install path is the primary surface — orchestrated or standalone?**
+   - What we know: the reason token can ride both rows; the free-text detail rides orchestrated only.
+   - What's unclear: whether a bare single-plugin install runs orchestrated (reconcile) in practice.
+   - Recommendation: plan the orchestrated wiring as the required path (that is where reconcile-driven
+     installs and imports run) and treat standalone reason-token parity as a smaller add.
+
+3. **Does the plan re-materialize already-installed malformed components?**
+   - What we know: this phase fixes the write path; existing on-disk output is untouched until re-install.
+   - Recommendation: confirm scope is write-path-only (aligns with NREG-01); do not add a migration.
+
+## Environment Availability
+
+Not applicable — this phase makes code and behavior changes only. `parseFrontmatter` is provided by
+the already-declared peer dependency; no external tools, services, runtimes, or CLIs are introduced.
+
+## Validation Architecture
+
+### Test Framework
+| Property | Value |
+|----------|-------|
+| Framework | `node:test` (built-in) + `node:assert/strict` [VERIFIED: existing tests] |
+| Config file | none — glob-driven via `package.json` `test` script |
+| Quick run command | `node --test "tests/bridges/skills/**/*.test.ts" "tests/bridges/commands/**/*.test.ts"` |
+| Full suite command | `npm run check` (typecheck + lint + format:check + `npm test` + `npm run test:integration`) |
+
+### Phase Requirements → Test Map
+| Req ID | Behavior | Test Type | Automated Command | File Exists? |
+|--------|----------|-----------|-------------------|-------------|
+| PARSE-01 | source gate rejects/reads before rewrite | unit | `node --test "tests/bridges/skills/stage.test.ts"` | ✅ (extend) |
+| PARSE-02 | staged self-inflicted breakage throws | unit | `node --test "tests/bridges/skills/stage.test.ts"` | ✅ (extend) |
+| SKILL-01 | unparseable skill → disable-model-invocation block, body verbatim | unit | `node --test "tests/bridges/skills/stage.test.ts"` | ✅ (extend) |
+| SKILL-02 | empty desc → first-paragraph fill | unit | new helper test + `stage.test.ts` | ❌ Wave 0 (new helper module) |
+| SKILL-03 | written name == generated name; folded scalar can't corrupt | unit | `node --test "tests/bridges/skills/rewrite-frontmatter.test.ts"` | ✅ (extend) |
+| WTU-01 | `when_to_use` appended into description | unit | new helper test | ❌ Wave 0 |
+| WTU-02 | combined truncated at 1,536 (hard cut); >1024 still loads in Pi | unit | new helper test | ❌ Wave 0 |
+| CMD-01 | unparseable command → neutralized (name-from-file, first-body-line) | unit | `node --test "tests/bridges/commands/stage.test.ts"` | ✅ (extend) |
+| WARN-01 | degrade → reason token on row + detail via notifyDiagnostic | unit | `tests/shared/notify-v2.test.ts` + orchestrator test | ✅ (extend) |
+| CLASS-01 | REASONS 35→37, byte-stable; FAILURE_REASONS membership; proof compiles | unit + typecheck | `npm run typecheck` + `tests/shared/notify-v2.test.ts` | ✅ (extend) |
+| NREG-01 | valid + non-empty desc + no when_to_use → byte-for-byte identical | unit | `stage.test.ts` byte-equality assertion | ✅ (extend) |
+
+### Sampling Rate
+- **Per task commit:** the quick run command above (skills + commands bridge tests) plus `npm run typecheck`
+- **Per wave merge:** `npm test` (full unit set) + `npm run test:integration`
+- **Phase gate:** `npm run check` green before `/gsd-verify-work`
+
+### Wave 0 Gaps
+- [ ] New skills helper module test (first-paragraph extraction, `when_to_use` fold, 1,536 truncation,
+      safe scalar emit) — covers SKILL-02, WTU-01, WTU-02
+- [ ] Fixtures: a skill whose source frontmatter throws (unquoted `: ` mid-scalar); a description-less
+      skill; a skill with a `>-`/`|` block-scalar description; a folded multi-line `name`; a command
+      whose frontmatter throws — covers PARSE/SKILL/CMD arms
+- [ ] Byte-equality (NREG-01) assertion helper for the happy path
+- [ ] Framework install: none — `node:test` already present
+
+## Security Domain
+
+`security_enforcement` is not set in `.planning/config.json` (treat as enabled).
+
+### Applicable ASVS Categories
+| ASVS Category | Applies | Standard Control |
+|---------------|---------|-----------------|
+| V5 Input Validation | yes | Parse untrusted plugin-author YAML with `parseFrontmatter` in a **read-only** capacity — extract values, never `eval`/execute. Preserves the T-03-17 injection-safety property that the "no YAML parsing" comment guarded, because reading-to-validate is not evaluating (the diagnosis explicitly separates these two concerns). |
+| V6 Cryptography | no | — |
+| V2/V3/V4 (authn/session/access) | no | — |
+
+### Known Threat Patterns for this stack
+| Pattern | STRIDE | Standard Mitigation |
+|---------|--------|---------------------|
+| Malicious frontmatter that executes on parse | Tampering / Elevation | Use `parseFrontmatter` (data-only `yaml.parse`, no tags/`!!` execution surface in the `yaml` package's default schema); never emit author scalars unescaped — the safe dq-scalar emitter + gate 2 prevent an author string from re-forming a new YAML key (the same class as the AG-8 provenance-injection guard in the agents bridge) |
+| Path escape via crafted skill/command dir | Tampering | Unchanged — existing `assertPathInside` + `verbatimSymlinks:true, dereference:false` guards remain; this phase touches only file *content*, not path selection |
+| Description used to smuggle a huge context payload | DoS (context) | The 1,536 truncation (WTU-02) plus Pi's own 1024 cap bound listing size; unparseable skills carry `disable-model-invocation` so a placeholder costs zero model context |
+
+## Sources
+
+### Primary (HIGH confidence)
+- Installed `@earendil-works/pi-coding-agent@0.79.10`: `dist/utils/frontmatter.{d.ts,js}` (signature + throw/return semantics), `dist/core/skills.js` (loader, `MAX_DESCRIPTION_LENGTH=1024`, `!description→null` guard, `disableModelInvocation`, `formatSkillsForPrompt` filter), `dist/core/prompt-templates.js` (command loader), `dist/index.d.ts:29` (root export)
+- `@earendil-works/pi-coding-agent@0.74.0` npm tarball: `dist/index.d.ts:26` (parseFrontmatter exported at peer floor), `dist/core/skills.js:12` (`MAX_DESCRIPTION_LENGTH=1024` at floor)
+- Extension source (this repo): `bridges/skills/stage.ts`, `bridges/skills/rewrite-frontmatter.ts`, `bridges/commands/stage.ts`, `platform/pi-api.ts`, `shared/notify.ts` (REASONS 89-152; notifyDiagnostic 339-349; PluginInstalledMessage 621-629), `shared/notify-reasons.ts` (FAILURE_REASONS 99-128; proof 166-169), `orchestrators/plugin/install.ts` (1590-1786), `orchestrators/reconcile/{apply.ts,apply-outcomes.ts,notify.ts}`, `bridges/agents/frontmatter.ts`
+- `code.claude.com/docs/en/skills.md` (fetched 2026-07-26) — `description`/`when_to_use` field table (lines 253-254), malformed policy (line 897), 1,536-char listing cap (lines 253-254, 914)
+
+### Secondary (MEDIUM confidence)
+- `docs/research/issue-101-skill-frontmatter-diagnosis.md` — cross-checked against upstream and codebase; parser fingerprinting and rejected-approach rationale
+
+### Tertiary (LOW confidence)
+- None — every load-bearing claim was verified against a primary source this session.
+
+## Metadata
+
+**Confidence breakdown:**
+- Stack / no-new-deps: HIGH — verified `parseFrontmatter` export at floor + installed; `yaml` not a direct dep
+- Loader degrade targets (Pi): HIGH — read directly from installed `core/skills.js` and `core/prompt-templates.js`
+- Upstream parity: HIGH for what is documented; the three undocumented sub-behaviors are flagged `[ASSUMED]` with recommendations
+- Catalog amendment: HIGH — machinery and compile-guard read directly
+- Propagation plumbing: HIGH — both channels traced end to end; the orchestrated reason-row gap is a confirmed new-work finding
+- Central technical risk (NREG-safe multi-line description set): MEDIUM — resolved to a recommended approach, escalated as Open Question 1 for the planner
+
+**Research date:** 2026-07-26
+**Valid until:** ~2026-08-25 (stable; re-verify only if the peer dep floor or Claude Code skills docs change)

--- a/.planning/phases/86-skill-and-command-frontmatter-compliance/86-REVIEW.md
+++ b/.planning/phases/86-skill-and-command-frontmatter-compliance/86-REVIEW.md
@@ -1,0 +1,208 @@
+---
+phase: 86-skill-and-command-frontmatter-compliance
+reviewed: 2026-07-26T00:00:00Z
+depth: standard
+files_reviewed: 13
+files_reviewed_list:
+  - extensions/pi-claude-marketplace/bridges/skills/frontmatter-degrade.ts
+  - extensions/pi-claude-marketplace/bridges/skills/stage.ts
+  - extensions/pi-claude-marketplace/bridges/skills/rewrite-frontmatter.ts
+  - extensions/pi-claude-marketplace/bridges/skills/types.ts
+  - extensions/pi-claude-marketplace/bridges/commands/stage.ts
+  - extensions/pi-claude-marketplace/bridges/commands/types.ts
+  - extensions/pi-claude-marketplace/shared/notify.ts
+  - extensions/pi-claude-marketplace/shared/notify-reasons.ts
+  - extensions/pi-claude-marketplace/platform/pi-api.ts
+  - extensions/pi-claude-marketplace/orchestrators/plugin/install.ts
+  - extensions/pi-claude-marketplace/orchestrators/reconcile/apply.ts
+  - extensions/pi-claude-marketplace/orchestrators/reconcile/apply-outcomes.ts
+  - extensions/pi-claude-marketplace/orchestrators/reconcile/notify.ts
+findings:
+  critical: 1
+  warning: 2
+  info: 2
+  total: 5
+status: issues_found
+---
+
+# Phase 86: Code Review Report
+
+**Reviewed:** 2026-07-26
+**Depth:** standard
+**Files Reviewed:** 13
+**Status:** issues_found
+
+## Summary
+
+Reviewed the Phase 86 frontmatter-compliance change set: the skills degrade/augment
+helpers, the two staging gates (source-parse gate-1, staged-byte gate-2), the command
+neutralize path, the `malformed skill` / `malformed command` catalog additions, and the
+degrade thread from `install.ts` through the reconcile projection.
+
+The gate boundaries, catalog additions, dedup ("one token per plugin"), warning-severity
+stamping, and `redactAbsolutePaths` info-disclosure containment are all correct. Gate-2 is
+correctly inside the outer cleanup `try` in both `bridges/skills/stage.ts` and
+`bridges/commands/stage.ts`, so a gate-2 throw propagates loudly (D-86-04 holds — no
+Pi-rejected bytes can ship). The command neutralize `\n---` search matches
+`parseFrontmatter`'s own delimiter search and preserves body bytes (including CRLF)
+verbatim. The completeness proof in `notify-reasons.ts` correctly covers the two new
+reasons.
+
+One BLOCKER: the `description` node-span replacement recognizes only `>`/`|` block
+scalars, so a **valid, gate-1-parseable** skill whose `description` is a multi-line plain
+or quoted scalar is mis-rewritten when augmentation triggers — orphaning continuation
+lines and producing invalid YAML. Gate-2 contains the damage (no corrupt bytes ship) but
+the whole plugin install hard-fails and rolls back. Verified against the `yaml` parser.
+
+## Critical Issues
+
+### CR-01: `descriptionValueEnd` only spans `>`/`|` block scalars — multi-line plain / quoted descriptions are corrupted, failing the whole install
+
+**File:** `extensions/pi-claude-marketplace/bridges/skills/frontmatter-degrade.ts:173-195` (and `211-242`)
+
+**Issue:**
+`descriptionValueEnd` decides how many lines the `description` node spans by testing only
+`/^[>|]/` on the inline value. YAML scalars also span multiple lines as **plain** scalars
+(indented continuation) and as **quoted** scalars (single/double). For those, the inline
+value does not start with `>` or `|`, so `descriptionValueEnd` returns `keyIndex` and
+`setDescriptionScalar` replaces only the `description:` line, leaving the continuation
+lines orphaned.
+
+This is reachable with idiomatic input whenever augmentation changes the value
+(`augmentSkillDescription` calls `setDescriptionScalar` only when `effective !== sourceDescription`):
+
+- a multi-line **plain** description plus a `when_to_use` (folded in), or
+- a description longer than 1,536 chars (almost always wrapped across lines) that gets
+  truncated, or
+- a non-string / multi-line `description` (list/map) where `sourceDescription` collapses
+  to `""` and is refilled from the body.
+
+Example source (valid; gate-1 parses `description` = `"This is a fairly long plain scalar that wraps"`):
+
+```yaml
+---
+name: my-skill
+description: This is a fairly long
+  plain scalar that wraps
+when_to_use: Use for X
+---
+```
+
+`setDescriptionScalar` rewrites only line 3, producing:
+
+```yaml
+---
+name: my-skill
+description: "This is a fairly long plain scalar that wraps\nUse for X"
+  plain scalar that wraps
+when_to_use: Use for X
+---
+```
+
+Confirmed against the `yaml` parser: gate-2 throws
+`All mapping items must start at the same column at line 3, column 1`. The skills phase
+throw unwinds the ledger, so a **valid** plugin fails to install entirely. Gate-2 does its
+job (no corrupt bytes ship), but a should-succeed install becomes a hard rollback — the
+opposite of the WTU-01 / SKILL-02 "augment, never reject" intent. Unlike the `name` path
+(CR/WR-01 below), `setDescriptionScalar` has no post-write value verification, so gate-2 is
+the only backstop.
+
+**Fix:** Detect the full node span for every multi-line scalar, not just block scalars.
+Drop the `/^[>|]/` gate and always absorb subsequent more-indented (non-key) continuation
+lines up to `blockEnd`:
+
+```ts
+function descriptionValueEnd(lines: readonly string[], keyIndex: number, blockEnd: number): number {
+  // A description value spans continuation lines for block (`>`/`|`),
+  // multi-line plain, AND multi-line quoted scalars — all continue via
+  // deeper indentation than the col-0 key. Absorb every indented, non-blank
+  // continuation line; stop at the first line that returns to column 0.
+  let lastReplaced = keyIndex;
+  for (let i = keyIndex + 1; i < blockEnd; i++) {
+    const line = lines[i] ?? "";
+    if (line.trim() === "") {
+      continue; // trailing blank spacing preserved (not absorbed)
+    }
+    if (/^\s/.test(line)) {
+      lastReplaced = i;
+      continue;
+    }
+    break;
+  }
+  return lastReplaced;
+}
+```
+
+(Apply the same broadening to `nameValueEnd` in `rewrite-frontmatter.ts` — see WR-01.)
+
+## Warnings
+
+### WR-01: `nameValueEnd` has the same block-scalar-only span gap for the `name` field
+
+**File:** `extensions/pi-claude-marketplace/bridges/skills/rewrite-frontmatter.ts:39-61`
+
+**Issue:** Identical root cause as CR-01: `nameValueEnd` tests only `/^[>|]/`, so a source
+`name` written as a multi-line plain/quoted scalar orphans its continuation lines.
+Confirmed behavior: the orphaned line folds into the inline replacement
+(`name: <gen>\n  continued` parses `name` = `"<gen> continued"`), which the SKILL-03
+verification at line 118-124 (`frontmatter.name !== newName`) correctly rejects with a
+loud throw. So no wrong-named skill ships, but the install still hard-fails on an otherwise
+valid skill. Lower likelihood than CR-01 (skill names are single-token slugs), but same
+defect class and should be fixed together.
+
+**Fix:** Broaden `nameValueEnd` the same way as CR-01's `descriptionValueEnd` fix (absorb
+all indented continuation lines regardless of the inline indicator).
+
+### WR-02: Stale "35-entry" catalog-size comments in `notify-reasons.ts` contradict the code and the sibling file
+
+**File:** `extensions/pi-claude-marketplace/shared/notify-reasons.ts:7-8,14`
+
+**Issue:** This phase grew the `REASONS` closed set from 35 to 37 (adding `"malformed skill"`
+and `"malformed command"`) and updated `notify.ts:80` to "37-entry membership", but left
+two "35-entry" claims in `notify-reasons.ts`:
+
+- line 7-8: `OUT-08: the 35-entry membership AND order must stay byte-identical...`
+- line 14: `...instead of the flat 35-entry set.`
+
+These now misstate the size of the very closed set the module is documenting as
+catalog-stable, and disagree with `notify.ts`. A maintainer reading the stability contract
+gets the wrong count.
+
+**Fix:** Update both occurrences to `37-entry` (or make them count-agnostic, e.g. "the
+full closed `REASONS` set"), matching `notify.ts:80`.
+
+## Info
+
+### IN-01: `emitSafeDoubleQuotedScalar` collapses only `\r?\n`; a lone `\r` (or U+2028/U+2029) survives into the scalar
+
+**File:** `extensions/pi-claude-marketplace/bridges/skills/frontmatter-degrade.ts:146-150`
+
+**Issue:** The one-line collapse uses `value.replace(/\r?\n/g, " ")`. A description value
+containing a bare carriage return (not part of a CRLF) or a Unicode line/paragraph
+separator is not collapsed and is emitted inside the double-quoted scalar, where a YAML
+parser may treat it as a line break — tripping gate-2 and hard-failing the install. Very
+low likelihood (parsed values rarely contain lone `\r`), and it fails safe via gate-2, but
+the collapse is not fully newline-agnostic as the comment implies.
+
+**Fix:** Collapse all line-break forms, e.g. `value.replace(/\r\n|\r|\n|\u2028|\u2029/g, " ")`.
+
+### IN-02: `truncate1536` can split a UTF-16 surrogate pair at the boundary
+
+**File:** `extensions/pi-claude-marketplace/bridges/skills/frontmatter-degrade.ts:135-137`
+
+**Issue:** The hard cut `text.slice(0, 1536)` operates on UTF-16 code units, so a
+supplementary-plane character straddling indices 1535/1536 is split into a lone high
+surrogate. When the staged file is written with `utf8` encoding, Node replaces the lone
+surrogate with U+FFFD, so the emitted skill listing ends in a replacement character.
+Cosmetic only (gate-2 accepts it; no structural corruption) and acknowledged by the
+"hard cut on code units" comment, but noted for completeness against the "multi-byte
+content" concern.
+
+**Fix (optional):** If exactness matters, trim a trailing lone high surrogate after slicing
+(`if (0xd800 <= cut.charCodeAt(cut.length-1) <= 0xdbff) cut = cut.slice(0, -1)`).
+
+---
+
+_Reviewed: 2026-07-26_
+_Reviewer: Claude (gsd-code-reviewer)_
+_Depth: standard_

--- a/.planning/phases/86-skill-and-command-frontmatter-compliance/86-VALIDATION.md
+++ b/.planning/phases/86-skill-and-command-frontmatter-compliance/86-VALIDATION.md
@@ -1,0 +1,91 @@
+---
+phase: 86
+slug: skill-and-command-frontmatter-compliance
+# status lifecycle: draft (seeded by plan-phase) → validated (set by validate-phase §6)
+# audit-milestone §5.5 distinguishes NOT-VALIDATED (draft) from PARTIAL (validated + nyquist_compliant: false) (#2117)
+status: draft
+nyquist_compliant: false
+wave_0_complete: false
+created: 2026-07-26
+---
+
+# Phase 86 — Validation Strategy
+
+> Per-phase validation contract for feedback sampling during execution.
+
+---
+
+## Test Infrastructure
+
+| Property | Value |
+|----------|-------|
+| **Framework** | `node:test` (built-in) + `node:assert/strict` |
+| **Config file** | none — glob-driven via `package.json` `test` script |
+| **Quick run command** | `node --test "tests/bridges/skills/**/*.test.ts" "tests/bridges/commands/**/*.test.ts"` |
+| **Full suite command** | `npm run check` (typecheck + lint + format:check + `npm test` + `npm run test:integration`) |
+| **Estimated runtime** | ~30s quick; ~2–3 min full |
+
+---
+
+## Sampling Rate
+
+- **After every task commit:** Run the quick command (skills + commands bridge tests) plus `npm run typecheck`
+- **After every plan wave:** Run `npm test` (full unit set) + `npm run test:integration`
+- **Before `/gsd-verify-work`:** `npm run check` must be green
+- **Max feedback latency:** ~30 seconds (quick command)
+
+---
+
+## Per-Task Verification Map
+
+> Seeded from RESEARCH.md Phase Requirements → Test Map. Task IDs are populated
+> once plans exist; the requirement → test-command mapping below is authoritative.
+
+| Requirement | Behavior | Threat Ref | Test Type | Automated Command | File Exists |
+|-------------|----------|------------|-----------|-------------------|-------------|
+| PARSE-01 | source gate parses before rewrite/substitution | T-86 V5 | unit | `node --test "tests/bridges/skills/stage.test.ts"` | ✅ extend |
+| PARSE-02 | staged self-inflicted breakage throws (not degraded) | T-86 V5 | unit | `node --test "tests/bridges/skills/stage.test.ts"` | ✅ extend |
+| SKILL-01 | unparseable skill → `disable-model-invocation` block, body verbatim | — | unit | `node --test "tests/bridges/skills/stage.test.ts"` | ✅ extend |
+| SKILL-02 | empty/absent desc → first-body-line fallback | — | unit | new helper test + `stage.test.ts` | ❌ Wave 0 |
+| SKILL-03 | written `name` == generated name; folded scalar cannot corrupt | — | unit | `node --test "tests/bridges/skills/rewrite-frontmatter.test.ts"` | ✅ extend |
+| WTU-01 | `when_to_use` appended into `description` | — | unit | new helper test | ❌ Wave 0 |
+| WTU-02 | combined truncated at 1,536 (hard cut); >1024 still loads in Pi | DoS-context | unit | new helper test | ❌ Wave 0 |
+| CMD-01 | unparseable command → neutralized (name-from-file, first-body-line) | — | unit | `node --test "tests/bridges/commands/stage.test.ts"` | ✅ extend |
+| WARN-01 | degrade → reason token on row + detail via `notifyDiagnostic` | — | unit | `tests/shared/notify-v2.test.ts` + orchestrator test | ✅ extend |
+| CLASS-01 | REASONS 35→37 byte-stable; FAILURE_REASONS membership; proof compiles | — | unit + typecheck | `npm run typecheck` + `tests/shared/notify-v2.test.ts` | ✅ extend |
+| NREG-01 | valid + non-empty desc + no `when_to_use` → byte-for-byte identical | Tampering | unit | `stage.test.ts` byte-equality assertion | ✅ extend |
+
+*Status: ⬜ pending · ✅ green · ❌ red · ⚠️ flaky*
+
+---
+
+## Wave 0 Requirements
+
+- [ ] New skills helper module test — first-paragraph extraction, `when_to_use` fold, 1,536 truncation, safe scalar emit (covers SKILL-02, WTU-01, WTU-02)
+- [ ] Fixtures: a skill whose source frontmatter throws (unquoted `: ` mid-scalar); a description-less skill; a skill with a `>-`/`|` block-scalar description; a folded multi-line `name`; a command whose frontmatter throws (covers PARSE/SKILL/CMD arms)
+- [ ] Byte-equality (NREG-01) assertion helper for the happy path
+- [ ] Framework install: none — `node:test` already present
+
+---
+
+## Manual-Only Verifications
+
+| Behavior | Requirement | Why Manual | Test Instructions |
+|----------|-------------|------------|-------------------|
+| `/skill:<name>` resolves + never auto-invoked after `/reload` for a degraded skill | SKILL-01 | Requires a live Pi `/reload` and skill listing | Install a plugin with an unparseable skill; `/reload`; confirm `/skill:<name>` runs and the model does not auto-invoke it |
+| A >1024-char combined description loads in Pi (warning, not `skill: null`) | WTU-02 / D-86-05 | Requires observing a live Pi startup diagnostic | Install a skill whose combined `description`+`when_to_use` is 1025–1536 chars; `/reload`; confirm the skill loads with a non-fatal warning |
+
+*Automated coverage backs every requirement; the two rows above are live-`/reload` observability confirmations.*
+
+---
+
+## Validation Sign-Off
+
+- [ ] All tasks have `<automated>` verify or Wave 0 dependencies
+- [ ] Sampling continuity: no 3 consecutive tasks without automated verify
+- [ ] Wave 0 covers all MISSING references
+- [ ] No watch-mode flags
+- [ ] Feedback latency < 30s
+- [ ] `nyquist_compliant: true` set in frontmatter
+
+**Approval:** pending

--- a/.planning/phases/86-skill-and-command-frontmatter-compliance/86-VERIFICATION.md
+++ b/.planning/phases/86-skill-and-command-frontmatter-compliance/86-VERIFICATION.md
@@ -1,0 +1,137 @@
+---
+phase: 86-skill-and-command-frontmatter-compliance
+verified: 2026-07-26T14:42:35Z
+status: passed
+score: 27/27 must-haves verified (code-level); 3 backstop truths confirmed via live Pi /reload UAT 2026-07-26
+behavior_unverified: 0
+overrides_applied: 0
+human_verified: "2026-07-26 — operator ran the live Pi /reload UAT (fmc-uat marketplace); all 3 backstop truths confirmed PASS: SKILL-01 (/skill: resolves + never auto-invoked), CMD-01 (neutralized command loads name-from-filename + first-body-line), WTU-02/D-86-05 (>1024-combined skill loads with the non-fatal warning, not dropped). WARN-01 warning surface also observed."
+human_verification:
+  - test: "Install a plugin containing a skill whose SKILL.md frontmatter cannot be parsed (unquoted `: ` mid-scalar, or similar), then run `/reload` in a live Pi session."
+    expected: "`/skill:<generated-name>` resolves and runs; the model never auto-invokes it (disable-model-invocation observed); no `skill: null` drop."
+    why_human: "Requires Pi's live skill loader + `/reload` cycle; not exercisable by node:test. Unit tests only prove the synthesized frontmatter block's shape and that it re-parses (SKILL-01 backstop, 86-02-SUMMARY.md D5, human_judgment: true)."
+  - test: "Install a plugin containing a command whose frontmatter cannot be parsed, then run `/reload`."
+    expected: "The command resolves under name-from-filename with a description taken from the first body line (Claude Code's literal malformed-frontmatter behavior); no synthesized description, no disable flag."
+    why_human: "Requires Pi's live command loader + `/reload` cycle; not exercisable by node:test. Unit tests only prove the neutralized bytes re-parse to empty frontmatter (CMD-01 backstop, 86-04-SUMMARY.md D5, human_judgment: true)."
+  - test: "Install a skill whose combined `description` + `when_to_use` is 1,025-1,536 characters, then run `/reload` and observe Pi's startup diagnostics."
+    expected: "The skill loads (Pi returns a `Skill`, not `null`) and Pi emits its known non-fatal >1,024-char warning; the skill is NOT silently dropped or truncated to 1,024."
+    why_human: "Requires observing a live Pi startup diagnostic; not exercisable by node:test. The unit test only proves `parseFrontmatter` re-parses the staged >1024 description without throwing and that its length exceeds 1,024 (WTU-02 / D-86-05 backstop, VALIDATION.md manual-only row)."
+---
+
+# Phase 86: Skill and command frontmatter compliance Verification Report
+
+**Phase Goal:** The skills and commands bridges reach observable parity with Claude Code's frontmatter-loading behavior — source frontmatter parsed with Pi's own `parseFrontmatter` (re-exported through `platform/pi-api.ts`) before name-rewrite/substitution, staged bytes re-parsed as a Pi-acceptability backstop; unparseable skill → synthesized `disable-model-invocation` block (body verbatim); unparseable command → neutralized (name-from-filename, description-from-first-body-line); description-less skill → first-paragraph fallback; `when_to_use` folded into the description (truncated at 1,536); every degraded/neutralized component surfaces an install-time warning classified under new per-kind `FAILURE_REASONS` tokens (`malformed skill`, `malformed command`) paralleling `malformed mcp`; the ~99% of already-valid components written byte-for-byte unchanged.
+**Verified:** 2026-07-26T14:42:35Z
+**Status:** passed (code-level verification + operator live Pi /reload UAT)
+**Re-verification:** No — initial verification
+
+## Goal Achievement
+
+### Observable Truths
+
+| # | Truth | Status | Evidence |
+|---|-------|--------|----------|
+| 1 | `parseFrontmatter` re-exported from `platform/pi-api.ts`, sole sanctioned import site | ✓ VERIFIED | `platform/pi-api.ts:38`; every gate (`skills/stage.ts:24`, `commands/stage.ts:28`, `skills/rewrite-frontmatter.ts:10`) imports it only from there |
+| 2 | REASONS grows 35→37, `malformed skill`/`malformed command` appended after `malformed mcp`, existing 35 byte-identical | ✓ VERIFIED | `shared/notify.ts` tail three entries in order `malformed mcp`, `malformed skill`, `malformed command`; `tests/architecture/notify-closed-set-locks.test.ts:35` asserts `REASONS.length === 37`; test run: pass |
+| 3 | Both new tokens filed under `FAILURE_REASONS`, `_ReasonsCoverageProof` compiles | ✓ VERIFIED | `shared/notify-reasons.ts` `FAILURE_REASONS` includes both after `malformed mcp`; `npm run typecheck` green (compiles the proof) |
+| 4 | Gate 1 parses SOURCE before rewrite/substitution (skills + commands) | ✓ VERIFIED | `skills/stage.ts:254` (`parseFrontmatter(content)` before `rewriteFrontmatterName`); `commands/stage.ts:197` (before `substituteClaudeVars`) |
+| 5 | Gate-1 throw on a skill synthesizes `disable-model-invocation` block, body verbatim, no hard-fail | ✓ VERIFIED | `skills/stage.ts:256-269` calls `synthesizeUnparseableSkill(extractBodyAfterFrontmatter(content), ...)`; `frontmatter-degrade.ts:46-55`; unit test `stage.test.ts` (SKILL-01/PARSE-01 case) passes |
+| 6 | Gate-1 throw on a command neutralizes by stripping the WHOLE `---`...`---` block (not delimiter-only) | ✓ VERIFIED | `commands/stage.ts:116-126` `neutralizeCommandFrontmatter` slices from the closing `\n---` line onward; test asserts staged output has no `---` block and re-parses empty |
+| 7 | Gate 2 re-parses STAGED bytes; a throw on the non-degrade/happy arm is our defect and rethrows loudly (never masked as author degradation) | ✓ VERIFIED | `skills/stage.ts:287` and `commands/stage.ts:219` both call `parseFrontmatter(content)` unconditionally after write, outside any degrade branch, so a throw here propagates to the `appendLeakToError`/`cleanupStaging` catch |
+| 8 | Description-less well-formed skill gets first-paragraph fallback, skips blanks/headings/fences | ✓ VERIFIED | `frontmatter-degrade.ts:91-114` `firstBodyParagraph`; wired at `skills/stage.ts:155` `augmentSkillDescription`; unit tests pass (SKILL-02 cases) |
+| 9 | `when_to_use` folded into `description` with single `\n`, empty → unchanged | ✓ VERIFIED | `frontmatter-degrade.ts:122-128` `foldWhenToUse`; wired at `stage.ts:156`; WTU-01 unit tests pass |
+| 10 | Combined text hard-cut at 1,536 UTF-16 code units, no ellipsis, never Pi's 1,024 threshold | ✓ VERIFIED | `frontmatter-degrade.ts:135-137` `truncate1536` (`LISTING_CAP = 1536`); WTU-02 unit tests (1535/1536/1537 boundary) pass |
+| 11 | `setDescriptionScalar` replaces the FULL description node span (incl. `>-`/`\|` block scalars), never a lone line replace | ✓ VERIFIED | `frontmatter-degrade.ts:173-242` `descriptionValueEnd` + `setDescriptionScalar`; block-scalar fixture test passes, sibling keys byte-identical |
+| 12 | Written skill `name` always equals generated name; folded/multi-line source `name:` cannot corrupt it (verified via re-parse, not blind regex) | ✓ VERIFIED | `rewrite-frontmatter.ts:107-127` `rewriteFrontmatterName` re-parses result and throws on mismatch; `rewrite-frontmatter.test.ts` folded-name + absent-name cases pass |
+| 13 | Degrade record `{generatedName, parseError}` collected per bridge, threaded to install orchestrator | ✓ VERIFIED | `skills/stage.ts:220,265-268,309`; `commands/stage.ts:177,205-208,245`; `install.ts:884,907,946` collect into `installCtx.frontmatterDegradations` |
+| 14 | Standalone install row carries ONE `malformed skill`/`malformed command` token per plugin regardless of component count, at `warning` severity on `(installed)` (not `partially-installed`) | ✓ VERIFIED | `install.ts:1757-1768` pushes token once per kind via `.some(...)`; `1797-1799` sets `warning` when `frontmatterDegradations.length > 0`; status stays `"installed"` (`1818-1828`); `install.test.ts` case passes |
+| 15 | Zero degraded components → no token, no warning stamp (byte-identity) | ✓ VERIFIED | `install.ts:1823` `...(reasons.length > 0 && { reasons })`; severity falls through to `companionSeverity` when `frontmatterDegradations.length === 0`; NREG-01 test in `install.test.ts` / `notify.test.ts` |
+| 16 | Valid skill/command written byte-for-byte identical, gates mutate nothing on happy path | ✓ VERIFIED | `stage.test.ts` NREG-01 case builds expected bytes via independent literal replacement (not production helpers) and asserts `assert.equal(staged, expected)`; same pattern in `commands/stage.test.ts`; both pass |
+| 17 | `InstallPluginOutcome.degradedKinds` inert seam present for orchestrated row | ✓ VERIFIED | `install.ts:234,1845,1853` |
+| 18 | Reconcile `plugin-installed` arm pushes token + raises severity to `warning` when `degradedKinds` non-empty; unchanged (`info`, no reasons) when empty | ✓ VERIFIED | `reconcile/notify.ts:483-525` `degradedKindReasons`/`installedRowFromOutcome`; `reconcile/apply-outcomes.ts:107` field; `reconcile/apply.ts:607-610` propagation; `notify.test.ts`/`apply.test.ts` cases pass |
+| 19 | Per-component free-text detail rides existing `postCommitWarnings → notifyDiagnostic` channel, no new notify variant | ✓ VERIFIED | `install.ts:1684-1690` pushes detail into `postCommitWarnings` (orchestrated only, D-19-01); `apply.ts:1380-1397` `surfacePostCommitWarnings` routes it to `notifyDiagnostic` |
+| 20 | Detail lines redacted via `redactAbsolutePaths` before `notifyDiagnostic` | ✓ VERIFIED | `apply.ts:1391-1395` applies `redactAbsolutePaths(w)` per line; `apply.test.ts` case asserts an absolute path collapses to its basename |
+| 21 | CMD-01 neutralized output has no synthesized description and no disable flag | ✓ VERIFIED | `commands/stage.ts` neutralize path only strips bytes — no description/flag insertion anywhere in the file; `stage.test.ts` case asserts absence of both |
+| 22 | REQUIREMENTS.md traceability: all 11 IDs (PARSE-01/02, SKILL-01/02/03, WTU-01/02, CMD-01, WARN-01, CLASS-01, NREG-01) marked complete, mapped to Phase 86, no orphans | ✓ VERIFIED | `.planning/REQUIREMENTS.md` lines 12-40 + 68-78 |
+| 23 | SKILL-01 backstop: degraded skill's `/skill:<name>` resolves + never auto-invoked after live `/reload` | ⚠️ PRESENT_BEHAVIOR_UNVERIFIED | Code present + unit-tested at the synthesis-shape level (`disable-model-invocation: true` present in staged bytes, re-parses); the live Pi loader/auto-invocation behavior is not exercisable by `node:test` — see Human Verification |
+| 24 | CMD-01 backstop: neutralized command resolves under `/reload` with name-from-filename + first-body-line description | ⚠️ PRESENT_BEHAVIOR_UNVERIFIED | Code present + unit-tested at the neutralize-shape level (block stripped, re-parses to empty frontmatter); live Pi command-loader behavior not exercisable by `node:test` — see Human Verification |
+| 25 | WTU-02/D-86-05 backstop: a >1,024-combined-char skill still loads in Pi (non-fatal warning, not `skill: null`) | ⚠️ PRESENT_BEHAVIOR_UNVERIFIED | Unit test proves the staged bytes re-parse to a non-empty >1024-length description (not silently truncated to 1024); the live Pi startup-diagnostic behavior is not exercisable by `node:test` — see Human Verification |
+
+**Score:** 22/25 truths verified at the code level (3 present, behavior-unverified — all pre-flagged by the phase's own plans/SUMMARYs as backstop truths requiring a live Pi session)
+
+### Required Artifacts
+
+| Artifact | Expected | Status | Details |
+|----------|----------|--------|---------|
+| `extensions/pi-claude-marketplace/platform/pi-api.ts` | `parseFrontmatter` re-export + semantics doc | ✓ VERIFIED | Lines 17-38, doc comment pins throw/return semantics |
+| `extensions/pi-claude-marketplace/shared/notify.ts` | REASONS 35→37 | ✓ VERIFIED | Tail three: `malformed mcp`, `malformed skill`, `malformed command` |
+| `extensions/pi-claude-marketplace/shared/notify-reasons.ts` | Both tokens in `FAILURE_REASONS` | ✓ VERIFIED | Lines ~110-121; `_ReasonsCoverageProof` compiles |
+| `extensions/pi-claude-marketplace/bridges/skills/frontmatter-degrade.ts` | NEW module, 5 exports | ✓ VERIFIED | `synthesizeUnparseableSkill`, `firstBodyParagraph`, `foldWhenToUse`, `truncate1536`, `setDescriptionScalar` all present |
+| `extensions/pi-claude-marketplace/bridges/skills/stage.ts` | Gate 1 + gate 2 + augment arm | ✓ VERIFIED | Lines 247-288 |
+| `extensions/pi-claude-marketplace/bridges/skills/rewrite-frontmatter.ts` | SKILL-03 name verification | ✓ VERIFIED | Lines 107-127 |
+| `extensions/pi-claude-marketplace/bridges/commands/stage.ts` | Gate 1 + gate 2 + neutralize arm | ✓ VERIFIED | Lines 116-126, 191-219 |
+| `extensions/pi-claude-marketplace/bridges/skills/types.ts` / `commands/types.ts` | `degraded` field | ✓ VERIFIED | Both files line ~65-66 |
+| `extensions/pi-claude-marketplace/orchestrators/plugin/install.ts` | `frontmatterDegradations`, standalone tokens, `degradedKinds` seam | ✓ VERIFIED | Lines 231-234, 385-388, 884-946, 1684-1690, 1757-1853 |
+| `extensions/pi-claude-marketplace/orchestrators/reconcile/apply-outcomes.ts` | `PluginInstalledOutcome.degradedKinds` | ✓ VERIFIED | Line 107 |
+| `extensions/pi-claude-marketplace/orchestrators/reconcile/apply.ts` | propagation + redaction | ✓ VERIFIED | Lines 607-610, 1380-1397 |
+| `extensions/pi-claude-marketplace/orchestrators/reconcile/notify.ts` | token push + severity raise | ✓ VERIFIED | Lines 475-525 |
+| Fixtures (`tests/bridges/_fixtures/...`) | unparseable/block-scalar/heading fixtures | ✓ VERIFIED | `skill-no-description`, `skill-block-scalar-description`, `skill-heading-codeblock-body`, `unparseable-skill-plugin`, `unparseable-command-plugin` all present on disk |
+
+### Key Link Verification
+
+| From | To | Via | Status | Details |
+|------|----|----|--------|---------|
+| `platform/pi-api.ts` re-export | all gates | sole import site | ✓ WIRED | grep confirms only `platform/pi-api.ts` imports the peer symbol; all bridge files import from there |
+| `REASONS` (notify.ts) | `FAILURE_REASONS` (notify-reasons.ts) | lockstep compile guard | ✓ WIRED | `_ReasonsCoverageProof` compiles (`npm run typecheck` green) |
+| skills/stage.ts gate seam | degrade record | `result.degraded` | ✓ WIRED | Returned from `prepareStageSkills`, consumed by `install.ts:907` |
+| commands/stage.ts gate seam | degrade record | `result.degraded` | ✓ WIRED | Returned from `prepareStageCommands`, consumed by `install.ts:946` |
+| `installCtx.frontmatterDegradations` | standalone `reasons[]` + `postCommitWarnings` + `InstallPluginOutcome.degradedKinds` | install.ts surfacing site | ✓ WIRED | Lines 1684-1690 (detail), 1757-1768 (token), 1845-1853 (outcome seam) |
+| `InstallPluginOutcome.degradedKinds` | `PluginInstalledOutcome.degradedKinds` | apply.ts propagation | ✓ WIRED | Lines 607-610 |
+| `PluginInstalledOutcome.degradedKinds` | reconcile notify composer | `installedRowFromOutcome` | ✓ WIRED | notify.ts lines 483-525 |
+| `postCommitWarnings` | `notifyDiagnostic` | `surfacePostCommitWarnings` + `redactAbsolutePaths` | ✓ WIRED | apply.ts lines 1380-1397 |
+
+### Behavioral Spot-Checks
+
+| Behavior | Command | Result | Status |
+|----------|---------|--------|--------|
+| Targeted phase test files (10 files) | `node --test "tests/bridges/skills/stage.test.ts" "tests/bridges/skills/rewrite-frontmatter.test.ts" "tests/bridges/skills/frontmatter-degrade.test.ts" "tests/bridges/commands/stage.test.ts" "tests/orchestrators/plugin/install.test.ts" "tests/orchestrators/reconcile/notify.test.ts" "tests/orchestrators/reconcile/apply.test.ts" "tests/platform/pi-api.test.ts" "tests/architecture/notify-closed-set-locks.test.ts" "tests/shared/notify-v2.test.ts"` | 385 pass / 0 fail | ✓ PASS |
+| Typecheck (proves `_ReasonsCoverageProof` compiles at 37 entries) | `npm run typecheck` | clean, no TS2344 | ✓ PASS |
+| Working tree clean (no uncommitted phase changes) | `git status --short` | empty | ✓ PASS |
+| Debt-marker scan on all 11 touched source files | `grep -n -E "TBD|FIXME|XXX|TODO|HACK"` | no matches | ✓ PASS |
+
+Full unit/integration suite reused from the authoritative test-state context supplied to this verification (not re-run): unit 3049/3050 pass (1 pre-existing platform skip); integration 16/18 pass (2 pre-existing, out-of-scope failures documented in `deferred-items.md`, reproduced against `HEAD~2` by the executor).
+
+### Requirements Coverage
+
+| Requirement | Source Plan | Description | Status | Evidence |
+|-------------|------------|-------------|--------|----------|
+| PARSE-01 | 86-02, 86-04 | Source parsed before rewrite/substitution, both seams | ✓ SATISFIED | `stage.ts:254` (skills), `commands/stage.ts:197` |
+| PARSE-02 | 86-02, 86-04 | Staged bytes re-parsed; self-defect throws loudly | ✓ SATISFIED | `stage.ts:287`, `commands/stage.ts:219` |
+| SKILL-01 | 86-02 | Unparseable skill synthesizes `disable-model-invocation` block | ✓ SATISFIED (code) / backstop truth flagged | `frontmatter-degrade.ts:46-55`; live-reload confirmation is human_needed |
+| SKILL-02 | 86-01, 86-03 | First-paragraph fallback for description-less skill | ✓ SATISFIED | `frontmatter-degrade.ts:91-114`, `stage.ts:145-166` |
+| SKILL-03 | 86-03 | Written name equals generated name, corruption-proof | ✓ SATISFIED | `rewrite-frontmatter.ts:107-127` |
+| WTU-01 | 86-01, 86-03 | `when_to_use` folded into description | ✓ SATISFIED | `frontmatter-degrade.ts:122-128` |
+| WTU-02 | 86-01, 86-03 | 1,536 truncation cap | ✓ SATISFIED (code) / backstop truth flagged | `frontmatter-degrade.ts:135-137`; live >1024-load confirmation is human_needed |
+| CMD-01 | 86-04 | Unparseable command neutralized (strip whole block) | ✓ SATISFIED (code) / backstop truth flagged | `commands/stage.ts:116-126`; live-reload confirmation is human_needed |
+| WARN-01 | 86-02, 86-05 | Degrade → warning row + `notifyDiagnostic` detail | ✓ SATISFIED | `install.ts:1757-1768`, `reconcile/notify.ts:483-525`, `apply.ts:1380-1397` |
+| CLASS-01 | 86-01, 86-05 | Failure-class classification, byte-stable catalog | ✓ SATISFIED | `notify.ts` REASONS tail, `notify-reasons.ts` FAILURE_REASONS |
+| NREG-01 | 86-02, 86-03, 86-04 | Byte-for-byte unchanged happy path | ✓ SATISFIED | `stage.test.ts` / `commands/stage.test.ts` NREG-01 cases (independent-literal-replacement assertions) |
+
+No orphaned requirements: `.planning/REQUIREMENTS.md` lists exactly these 11 IDs against Phase 86, all mapped to a plan's `requirements:` frontmatter field.
+
+### Anti-Patterns Found
+
+None. Debt-marker scan (`TBD`/`FIXME`/`XXX`/`TODO`/`HACK`) across all 11 touched source files returned zero matches. No empty-implementation stubs, no hardcoded-empty-data patterns, no console.log-only handlers. The `placeholder`-named constants (`UNPARSEABLE_SKILL_DESCRIPTION`, `MISSING_DESCRIPTION_PLACEHOLDER`) are intentional, design-mandated fixed strings (D-86-02/A4, SKILL-02 empty-body fallback), not incomplete-work markers — both are documented in-code with their rationale and covered by unit tests.
+
+### Human Verification Required
+
+See the `human_verification` frontmatter block above (3 items). All three are pre-identified by the phase's own plans (`86-VALIDATION.md` Manual-Only Verifications table; `86-02-SUMMARY.md`/`86-04-SUMMARY.md` D5 rows marked `human_judgment: true`) as requiring a live Pi `/reload` session, not fabricated by this verification. Each has a code-level unit-test approximation that passes, but the actual runtime behavior (skill/command resolution after reload, non-auto-invocation, Pi's >1024 startup diagnostic) cannot be observed by `node:test`.
+
+### Gaps Summary
+
+No code-level gaps found. All 11 requirement IDs trace cleanly from PLAN frontmatter through REQUIREMENTS.md to implemented, tested, wired code across all 5 plans (01-05). Every must-have truth, artifact, and key link declared across the 5 PLAN.md files was independently verified against the current source (not the SUMMARY narrative) by reading the actual gate/wiring code and running the 10 relevant test files (385/385 pass). The only open item is the three backstop truths that require a live Pi `/reload` session to observe — these were correctly and honestly flagged by the executing plans themselves rather than silently claimed as passed, so this verification routes them to human_needed rather than fabricating a live-session result.
+
+---
+
+_Verified: 2026-07-26T14:42:35Z_
+_Verifier: Claude (gsd-verifier)_

--- a/.planning/phases/86-skill-and-command-frontmatter-compliance/deferred-items.md
+++ b/.planning/phases/86-skill-and-command-frontmatter-compliance/deferred-items.md
@@ -1,0 +1,22 @@
+# Deferred / Out-of-Scope Items — Phase 86
+
+## Pre-existing integration test failures (NOT introduced by Plan 03)
+
+Two `tests/integration/*` cases fail on the current branch. They fail
+IDENTICALLY when the Plan 03 source changes are reverted to the pre-plan
+commit (verified 2026-07-26 by checking out the three bridge sources at
+`HEAD~2` and re-running only these two tests: 0 pass / 2 fail), so they are
+pre-existing and outside this plan's scope (they exercise the pi-subagents
+agent/skill resolution surface, not the skills-bridge augment arm):
+
+- `tests/integration/provenance-invisibility.test.ts` —
+  `T-d8i-01: provenance stays invisible to pi-subagents' own frontmatter parser`
+  (asserts `frontmatter.provenance` carries the generated marker).
+- `tests/integration/skill-path-resolution.test.ts` —
+  `SC-2 / AGSK-06: emitted skillPath resolves the staged skill via
+  pi-subagents' resolveSkillsWithFallback and stays out of the global catalog`.
+
+Both assert against `@earendil-works/pi-coding-agent` / pi-subagents runtime
+resolution and write their own `SKILL.md` fixtures inline (they do not call
+`prepareStageSkills`). Likely tied to the peer-dep migration to
+`@earendil-works/pi-coding-agent ^0.79.x`. Left for a dedicated fix.

--- a/.planning/v1.15-MILESTONE-AUDIT.md
+++ b/.planning/v1.15-MILESTONE-AUDIT.md
@@ -1,0 +1,76 @@
+---
+milestone: v1.15
+audited: 2026-07-26
+status: passed
+scores:
+  requirements: 11/11
+  phases: 1/1
+  integration: verified
+  flows: 1/1
+gaps: {}
+tech_debt:
+  - phase: 86-skill-and-command-frontmatter-compliance
+    items:
+      - "IN-01 (code-review Info, deferred): newline collapse in the degrade helper does not normalize a lone CR or U+2028/U+2029 line separators — fail-safe (worst case a slightly-off but valid description); out of the Critical+Warning fix scope."
+      - "IN-02 (code-review Info, deferred): truncate1536 can split a UTF-16 surrogate pair at the 1,536 boundary — fail-safe (a lone half-surrogate, still valid YAML); out of fix scope."
+      - "Nyquist VALIDATION.md is status: draft (NOT-VALIDATED) — seeded by plan-phase but never reconciled by /gsd-validate-phase. Coverage is real (3049 unit tests green, requirement→test map satisfied); this is a process TODO (run /gsd-validate-phase 86 to promote to validated), not a coverage failure."
+pre_existing_out_of_scope:
+  - "tests/integration/{provenance-invisibility,skill-path-resolution}.test.ts fail (2) — PRE-EXISTING from PR #92 (commit 58c7aa2a, pi-subagents skill-path resolution). Phase 86 touched no integration tests, no agents-bridge, no pi-subagents resolution code. Not a v1.15 regression. Tracked in 86 deferred-items."
+---
+
+# Milestone v1.15 — frontmatter-compliance — Audit
+
+**Audited:** 2026-07-26
+**Status:** PASSED
+**Definition of done:** The skills and commands bridges reach observable parity with Claude Code's frontmatter-loading behavior — never write bytes Pi rejects, degrade a malformed component the way Claude Code does, fold `when_to_use` into the description Pi reads, and attribute failures to the right component (GitHub issue #101), with the ~99% of already-valid components written byte-for-byte unchanged.
+
+## Requirements Coverage — 11/11 satisfied
+
+3-source cross-reference (REQUIREMENTS.md traceability × VERIFICATION.md × SUMMARY frontmatter):
+
+| REQ-ID | VERIFICATION | SUMMARY `requirements_completed` | REQUIREMENTS.md | Final |
+|--------|--------------|----------------------------------|-----------------|-------|
+| PARSE-01 | passed | 86-02, 86-04 | Complete | ✅ satisfied |
+| PARSE-02 | passed | 86-02, 86-04 | Complete | ✅ satisfied |
+| SKILL-01 | passed (+ live UAT) | 86-02 | Complete | ✅ satisfied |
+| SKILL-02 | passed | 86-01, 86-03 | Complete | ✅ satisfied |
+| SKILL-03 | passed | 86-03 | Complete | ✅ satisfied |
+| WTU-01 | passed | 86-01, 86-03 | Complete | ✅ satisfied |
+| WTU-02 | passed (+ live UAT) | 86-01, 86-03 | Complete | ✅ satisfied |
+| CMD-01 | passed (+ live UAT) | 86-04 | Complete | ✅ satisfied |
+| WARN-01 | passed | 86-02, 86-05 | Complete | ✅ satisfied |
+| CLASS-01 | passed | 86-01, 86-05 | Complete | ✅ satisfied |
+| NREG-01 | passed | 86-02, 86-04 | Complete | ✅ satisfied |
+
+No orphaned requirements (every REQ-ID appears in the phase VERIFICATION.md). No unsatisfied requirements → FAIL gate not triggered.
+
+## Phases — 1/1 verified
+
+| Phase | Status | Verification |
+|-------|--------|--------------|
+| 86 — Skill and command frontmatter compliance | Complete | passed (code-level 27/27 must-haves + operator live-Pi /reload UAT for the 3 backstop truths) |
+
+## Cross-phase Integration & E2E Flows — verified
+
+Single-phase milestone, so there is no inter-phase seam to bridge. The one E2E flow this milestone delivers — *install a plugin with a malformed skill/command → degrade (synthesize / neutralize / fold / fallback) → surface + classify the warning → the ~99% valid components unchanged* — was verified two ways:
+
+- **Static trace (gsd-verifier):** the degrade signal is wired end-to-end — bridge `degraded[]` → `installCtx.frontmatterDegradations` → standalone `reasons[]` / `postCommitWarnings` → `InstallPluginOutcome.degradedKinds` → `PluginInstalledOutcome.degradedKinds` → reconcile `installedRowFromOutcome` → `notifyDiagnostic` with `redactAbsolutePaths`. Confirmed present across `bridges/skills/stage.ts`, `bridges/commands/stage.ts`, `orchestrators/plugin/install.ts`, `orchestrators/reconcile/{apply,apply-outcomes,notify}.ts`.
+- **Live E2E (operator UAT, 2026-07-26):** installed the `fmc-uat` marketplace (malformed skill + malformed command + >1024-combined skill) into a live Pi, ran `/reload`, and confirmed: install never hard-failed; `(installed) {malformed skill}` / `{malformed command}` warning + per-component diagnostic surfaced (WARN-01); `/skill:` resolves + never auto-invoked (SKILL-01); command loads name-from-filename + first-body-line (CMD-01); >1024 skill loads with the non-fatal warning, not dropped (WTU-02).
+
+## Quality bar
+
+- typecheck ✅ · eslint (whole-repo) ✅ · prettier ✅
+- Unit suite: 3049 pass / 0 fail / 1 pre-existing skip (includes every new Phase 86 test)
+- Code review: 1 blocker + 2 warnings found and fixed (CR-01 multi-line-scalar span, WR-01 name span, WR-02 stale comment) with FAIL-before/PASS-after regression tests; 2 Info findings deferred (fail-safe, see tech_debt)
+
+## Tech Debt (non-blocking)
+
+See frontmatter `tech_debt`. Summary: 2 fail-safe code-review Info edge cases (IN-01 lone-CR/LS-PS newline, IN-02 surrogate-pair split) and the Nyquist VALIDATION.md sitting at `status: draft` (run `/gsd-validate-phase 86` to reconcile — coverage is already green). None block the milestone.
+
+## Pre-existing, out of scope
+
+2 integration-test failures (`provenance-invisibility`, `skill-path-resolution`) predate this milestone (PR #92 / commit 58c7aa2a, pi-subagents skill-path resolution). Phase 86 touched none of that surface. Independently confirmed. Not a v1.15 regression.
+
+## Verdict
+
+**PASSED.** All 11 requirements satisfied and independently cross-referenced; the phase verified (code + live UAT); the single E2E flow confirmed live; quality bar green for all v1.15 code. Remaining items are minor, non-blocking, and documented above.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.11.1] - 2026-07-27
+
+- Skill and command sources whose YAML frontmatter cannot be parsed now degrade gracefully instead of failing the install. An unparseable skill is synthesized into a known-good `disable-model-invocation` block (its body preserved verbatim, still invocable by name and never auto-invoked); an unparseable command has its malformed frontmatter block stripped so Pi falls back to name-from-filename and description-from-first-body-line. The degraded plugin still installs and its row carries a `{malformed skill}` / `{malformed command}` marker at warning severity rather than hard-failing the whole install. Line-ending edge cases (lone-CR sources) and sources whose body opens with a second malformed block degrade the same way.
+- Generated skill descriptions are augmented for the Pi skill listing: an absent or empty `description` is filled from the first genuine body paragraph, a `when_to_use` field is folded in, and the combined text is capped at 1,536 characters -- so a generated skill stays loadable and discoverable without diverging from Claude Code's listing budget. Path variables (`${CLAUDE_PLUGIN_ROOT}` / `${CLAUDE_PLUGIN_DATA}`) referenced in a description are substituted before the value is quoted, so a Windows-style path can no longer break the emitted frontmatter.
+
 ## [0.11.0] - 2026-07-24
 
 - Marketplace and plugin manifests can now declare `mcpServers` as a string reference to a wrapped `.mcp.json` file (relative to the plugin root), not only as an inline server map. The referenced file is read, unwrapped, and its servers install at byte-for-byte parity with the inline form. A reference that is missing, malformed, not wrapped, or escapes the plugin root (including via a symlink) degrades just that one plugin to `(unavailable)` with a `{malformed mcp}` reason -- it never fails the rest of the marketplace load, and an unreadable reference file surfaces its own permission/unreadable reason instead of being reported as malformed.

--- a/docs/research/issue-101-skill-frontmatter-diagnosis.md
+++ b/docs/research/issue-101-skill-frontmatter-diagnosis.md
@@ -1,17 +1,14 @@
-# Issue #101 — Pi-incompatible `SKILL.md` frontmatter: diagnosis and design
+# Issue #101 -- Pi-incompatible `SKILL.md` frontmatter: diagnosis and design
 
-Status: diagnosis complete, not implemented. No code changed.
-Reported by: fank (Florian Kinder). Investigated 2026-07-24.
+Status: diagnosis complete, not implemented. No code changed. Reported by: fank (Florian Kinder). Investigated 2026-07-24.
 
 ## Summary
 
-The skills bridge writes `SKILL.md` bytes without ever checking that Pi can parse
-them. An install reports success; Pi then rejects the generated skill at the next
-startup and the skill silently does not exist.
+The skills bridge writes `SKILL.md` bytes without ever checking that Pi can parse them. An install reports success; Pi then rejects the generated skill at the next startup and the skill silently does not exist.
 
 The same gap exists in the commands bridge, where the failure is fully silent.
 
----
+______________________________________________________________________
 
 ## Root cause
 
@@ -22,15 +19,9 @@ bridges/skills/stage.ts:161-164
   readFile → rewriteFrontmatterName() → substituteClaudeVars() → writeFile
 ```
 
-`rewriteFrontmatterName` (`bridges/skills/rewrite-frontmatter.ts:33-42`) is a regex
-replace on the `name:` line — it never parses. Discovery
-(`bridges/skills/discover.ts:56-59`) only checks that `SKILL.md` exists as a regular
-file. So an install can fail for reasons the bridge invents (RN-6 collisions, path
-safety, fs errors) but never for *"the consumer cannot read what we just wrote."*
+`rewriteFrontmatterName` (`bridges/skills/rewrite-frontmatter.ts:33-42`) is a regex replace on the `name:` line -- it never parses. Discovery (`bridges/skills/discover.ts:56-59`) only checks that `SKILL.md` exists as a regular file. So an install can fail for reasons the bridge invents (RN-6 collisions, path safety, fs errors) but never for *"the consumer cannot read what we just wrote."*
 
-The consumer is strict. Pi's `core/skills.js::loadSkillFromFile` →
-`utils/frontmatter.js::parseFrontmatter` → `yaml.parse()`, which throws on a plain
-(unquoted) scalar containing `: `:
+The consumer is strict. Pi's `core/skills.js::loadSkillFromFile` → `utils/frontmatter.js::parseFrontmatter` → `yaml.parse()`, which throws on a plain (unquoted) scalar containing `: `:
 
 ```
 name: example
@@ -38,73 +29,50 @@ description: Use this skill for checks. Triggers on: "test", "lint".
 → YAMLParseError: Nested mappings are not allowed in compact mappings at line 2, column 14
 ```
 
-Pi catches the throw, downgrades it to a **warning** diagnostic and returns
-`skill: null`. `orchestrators/discover.ts:99-101` has already handed Pi the path, so
-the user sees a YAML error at startup and a skill that does not exist.
+Pi catches the throw, downgrades it to a **warning** diagnostic and returns `skill: null`. `orchestrators/discover.ts:99-101` has already handed Pi the path, so the user sees a YAML error at startup and a skill that does not exist.
 
 ## Why the gap exists
 
-The agents bridge already solves this class of problem correctly:
-`bridges/agents/frontmatter.ts` parses source frontmatter with a parser mirroring the
-consumer's (pi-subagents' line-based reader) and **re-emits** every scalar through
-`emitYamlScalar`, so what lands on disk is readable by construction.
+The agents bridge already solves this class of problem correctly: `bridges/agents/frontmatter.ts` parses source frontmatter with a parser mirroring the consumer's (pi-subagents' line-based reader) and **re-emits** every scalar through `emitYamlScalar`, so what lands on disk is readable by construction.
 
-The skills bridge never got that treatment. `rewrite-frontmatter.ts:5` records the
-choice as deliberate ("Pure string manipulation -- no YAML parsing, no eval") for
-injection-safety (T-03-17). That reasoning conflates two concerns: injection-safety
-says *don't evaluate untrusted input*; output-validity says *don't emit bytes your
-consumer will reject*. The current code buys the first at the cost of the second —
-for the one component kind whose consumer is strictest (real YAML vs. line-based).
+The skills bridge never got that treatment. `rewrite-frontmatter.ts:5` records the choice as deliberate ("Pure string manipulation -- no YAML parsing, no eval") for injection-safety (T-03-17). That reasoning conflates two concerns: injection-safety says *don't evaluate untrusted input*; output-validity says *don't emit bytes your consumer will reject*. The current code buys the first at the cost of the second -- for the one component kind whose consumer is strictest (real YAML vs. line-based).
 
----
+______________________________________________________________________
 
 ## Blast radius
 
-| kind | exposed? | symptom |
-| --- | --- | --- |
-| skills | yes | Pi warning at startup; skill absent |
-| commands / prompts | yes — `bridges/commands/stage.ts:159-160` copies verbatim | **fully silent**: `core/prompt-templates.js::loadTemplateFromFile` wraps everything in `try { … } catch { return null }`, no diagnostic |
-| agents | no | round-tripped through `emitYamlScalar`; AG-6 contract tolerates `:` in values |
+| kind               | exposed?                                                   | symptom                                                                                                                                 |
+| ------------------ | ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| skills             | yes                                                        | Pi warning at startup; skill absent                                                                                                     |
+| commands / prompts | yes -- `bridges/commands/stage.ts:159-160` copies verbatim | **fully silent**: `core/prompt-templates.js::loadTemplateFromFile` wraps everything in `try { … } catch { return null }`, no diagnostic |
+| agents             | no                                                         | round-tripped through `emitYamlScalar`; AG-6 contract tolerates `:` in values                                                           |
 
 Two adjacent members of the same family (bridge reports success, Pi rejects at load):
 
-- **Missing `description`** — Pi returns `skill: null` when absent or empty.
-  `rewrite-frontmatter.ts:22-23` *manufactures* this case: it synthesizes a
-  frontmatter block containing only `name:` when the source has none.
-- **Silent name corruption** — a multi-line `name:` has only its first line replaced.
-  Verified: `name: >\n  my\n  skill` → `name: acme-skill my skill`. Still valid YAML,
-  so no error anywhere; Pi's `validateName` warns, the skill loads under a name that
-  is not the generated one, `/skill:<generated-name>` does not resolve, and RN-6's
-  uniqueness guarantee no longer holds on disk.
+- **Missing `description`** -- Pi returns `skill: null` when absent or empty. `rewrite-frontmatter.ts:22-23` *manufactures* this case: it synthesizes a frontmatter block containing only `name:` when the source has none.
+- **Silent name corruption** -- a multi-line `name:` has only its first line replaced. Verified: `name: >\n  my\n  skill` → `name: acme-skill my skill`. Still valid YAML, so no error anywhere; Pi's `validateName` warns, the skill loads under a name that is not the generated one, `/skill:<generated-name>` does not resolve, and RN-6's uniqueness guarantee no longer holds on disk.
 
 ## Prevalence
 
-Scanned the 190 `SKILL.md` under `~/.claude`: **2 fail Pi's parser**, 1 has no usable
-frontmatter. Both failures are in the maintainer's own marketplace
-(`acolomba-claude-plugins`): `stocks/skills/stocks-murphy-technical-analysis` and
-`llm-wiki/skills/llm-wiki-scaffold`. Offending prose:
+Scanned the 190 `SKILL.md` under `~/.claude`: **2 fail Pi's parser**, 1 has no usable frontmatter. Both failures are in the maintainer's own marketplace (`acolomba-claude-plugins`): `stocks/skills/stocks-murphy-technical-analysis` and `llm-wiki/skills/llm-wiki-scaffold`. Offending prose:
 
 > `… Runs Murphy-style technical analysis: trend (Dow Theory), support/resistance, …`
 
-An unquoted `: ` mid-sentence. Commands corpus: 0/84 locally — the code gap is
-identical, but command descriptions are short, whereas skills' trigger-prose is what
-hits it.
+An unquoted `: ` mid-sentence. Commands corpus: 0/84 locally -- the code gap is identical, but command descriptions are short, whereas skills' trigger-prose is what hits it.
 
----
+______________________________________________________________________
 
 ## Upstream: how Claude Code actually parses this
 
-Verified directly; do not re-derive (Claude Code ships as a compiled binary, not an
-npm package).
+Verified directly; do not re-derive (Claude Code ships as a compiled binary, not an npm package).
 
-**Parser: js-yaml, strict — Claude Code is NOT lenient.** Fingerprinted
-`~/.local/share/claude/versions/2.1.212`:
+**Parser: js-yaml, strict -- Claude Code is NOT lenient.** Fingerprinted `~/.local/share/claude/versions/2.1.212`:
 
-| signature | hits |
-| --- | --- |
-| js-yaml (`bad indentation of a mapping entry`, …) | 1 |
-| `yaml` / eemeli (`Nested mappings are not allowed`, …) | 0 |
-| gray-matter | 0 |
+| signature                                              | hits |
+| ------------------------------------------------------ | ---- |
+| js-yaml (`bad indentation of a mapping entry`, …)      | 1    |
+| `yaml` / eemeli (`Nested mappings are not allowed`, …) | 0    |
+| gray-matter                                            | 0    |
 
 js-yaml rejects the same input Pi rejects:
 
@@ -113,114 +81,76 @@ description: Runs analysis: trend and volume.     → FAIL bad indentation of a 
 description: Use for checks. Triggers on: "test". → FAIL bad indentation of a mapping entry (2:41)
 ```
 
-**Failure policy is the real divergence** — code.claude.com/docs/en/skills.md,
-verbatim:
+**Failure policy is the real divergence** -- code.claude.com/docs/en/skills.md, verbatim:
 
-> "If the frontmatter YAML is malformed, Claude Code loads the skill body with empty
-> metadata, so `/skill-name` still works but Claude has no `description` to match
-> against. Run with `--debug` to see the parse error."
+> "If the frontmatter YAML is malformed, Claude Code loads the skill body with empty metadata, so `/skill-name` still works but Claude has no `description` to match against. Run with `--debug` to see the parse error."
 
-| | parse | on failure |
-| --- | --- | --- |
-| Claude Code | js-yaml, strict | body loads, metadata empty, `/name` works, no auto-invoke; error only under `--debug` |
-| Pi | `yaml`, strict | empty description ⇒ `skill: null`, skill gone; warning at startup |
-| bridge today | none | reports success, defers to Pi |
+|              | parse           | on failure                                                                            |
+| ------------ | --------------- | ------------------------------------------------------------------------------------- |
+| Claude Code  | js-yaml, strict | body loads, metadata empty, `/name` works, no auto-invoke; error only under `--debug` |
+| Pi           | `yaml`, strict  | empty description ⇒ `skill: null`, skill gone; warning at startup                     |
+| bridge today | none            | reports success, defers to Pi                                                         |
 
-**Consequence:** the two offending plugins are broken in Claude Code too — their
-descriptions have always been empty there, so Claude never auto-invokes them. Neither
-host tells the plugin author, which is why the defect ships into published
-marketplaces.
+**Consequence:** the two offending plugins are broken in Claude Code too -- their descriptions have always been empty there, so Claude never auto-invokes them. Neither host tells the plugin author, which is why the defect ships into published marketplaces.
 
-**Field contract:** `description` is *Recommended*, not required — "If omitted, uses
-the first paragraph of markdown content." `when_to_use` is a Claude Code extension
-appended to `description` in the listing; combined text truncated at 1,536 chars. Pi
-requires a non-empty `description`, so a spec-conformant description-less Claude skill
-silently vanishes in Pi.
+**Field contract:** `description` is *Recommended*, not required -- "If omitted, uses the first paragraph of markdown content." `when_to_use` is a Claude Code extension appended to `description` in the listing; combined text truncated at 1,536 chars. Pi requires a non-empty `description`, so a spec-conformant description-less Claude skill silently vanishes in Pi.
 
----
+______________________________________________________________________
 
 ## Design
 
 ### Rejected: quote repair
 
-An earlier proposal parsed leniently and re-quoted only the offending top-level plain
-scalars, then verified. It measured well (2 fixed, 187 byte-identical, 0 regressions
-on the corpus) but was rejected: it rewrites third-party content — which the issue
-author explicitly flagged as undesirable — and adds a heuristic to maintain and test
-for inputs outside the sampled corpus.
+An earlier proposal parsed leniently and re-quoted only the offending top-level plain scalars, then verified. It measured well (2 fixed, 187 byte-identical, 0 regressions on the corpus) but was rejected: it rewrites third-party content -- which the issue author explicitly flagged as undesirable -- and adds a heuristic to maintain and test for inputs outside the sampled corpus.
 
-Also rejected: whole-block re-emit in the agents-bridge style. Skills' target format
-is real YAML with real structure, and flattening it would damage ~13% of real skills
-(19/190 nested maps or lists, 6 block scalars, 2 flow collections, 24 continuation
-lines). The agents bridge gets away with it only because pi-subagents' target format
-is flat.
+Also rejected: whole-block re-emit in the agents-bridge style. Skills' target format is real YAML with real structure, and flattening it would damage ~13% of real skills (19/190 nested maps or lists, 6 block scalars, 2 flow collections, 24 continuation lines). The agents bridge gets away with it only because pi-subagents' target format is flat.
 
 ### Chosen: mirror Claude Code's behavior via Pi's own machinery
 
-Literal parity fails. Claude Code's "empty metadata" leaves `/skill-name` working; in
-Pi, empty metadata means the skill does not exist (the `!frontmatter.description`
-guard returns `skill: null` before the skill object is built). Same mechanism,
-opposite outcome.
+Literal parity fails. Claude Code's "empty metadata" leaves `/skill-name` working; in Pi, empty metadata means the skill does not exist (the `!frontmatter.description` guard returns `skill: null` before the skill object is built). Same mechanism, opposite outcome.
 
-Claude Code's observable behavior decomposes into two properties — **(a)** invocable
-by name, **(b)** never auto-invoked, because there is no description to match. Pi has
-a first-class field for exactly that pair:
+Claude Code's observable behavior decomposes into two properties -- **(a)** invocable by name, **(b)** never auto-invoked, because there is no description to match. Pi has a first-class field for exactly that pair:
 
 ```js
 // pi-coding-agent core/skills.js
 disableModelInvocation: frontmatter["disable-model-invocation"] === true
 ```
 
-`formatSkillsForPrompt` filters those out, with Pi's own comment: *"they can only be
-invoked explicitly via /skill:name commands."*
+`formatSkillsForPrompt` filters those out, with Pi's own comment: *"they can only be invoked explicitly via /skill:name commands."*
 
-So on unparseable frontmatter, replace the block — **body untouched** — with:
+So on unparseable frontmatter, replace the block -- **body untouched** -- with:
 
 ```yaml
 ---
 name: <generated-name>
-description: <plugin> skill "<source>" — source frontmatter could not be parsed.
+description: <plugin> skill "<source>" -- source frontmatter could not be parsed.
 disable-model-invocation: true
 ---
 ```
 
-`/skill:<generated-name>` works, the model never auto-invokes it, and because disabled
-skills are excluded from the listing the placeholder description costs zero context —
-it exists only to clear Pi's non-empty gate.
+`/skill:<generated-name>` works, the model never auto-invokes it, and because disabled skills are excluded from the listing the placeholder description costs zero context -- it exists only to clear Pi's non-empty gate.
 
-This mutates metadata we could not read, not the author's values, and does not
-hard-fail: a one-bad-skill plugin still installs.
+This mutates metadata we could not read, not the author's values, and does not hard-fail: a one-bad-skill plugin still installs.
 
 ### Work items
 
-| item | notes |
-| --- | --- |
-| strict-parse gate on **staged** bytes | post-substitution, so a `${CLAUDE_PLUGIN_ROOT}` expansion that breaks YAML is also caught. Seams: `skills/stage.ts:163-164`, `commands/stage.ts:159-160` |
-| use Pi's own `parseFrontmatter` | public root export (`dist/index.d.ts:29`); import via the existing `platform/pi-api.ts` boundary for byte-identical accept/reject semantics. **Verify** it was already exported at the declared peer floor `>=0.74.0` (dev dep is 0.79.10) |
-| unparseable → synthesized `disable-model-invocation` frontmatter | body preserved verbatim |
-| install-time warning row | names the source skill and the parse error — the `--debug` analog, surfaced rather than hidden. Satisfies the issue's core ask |
-| `name` must equal generated name post-rewrite | catches the folded-scalar corruption |
-| absent `description` → first-paragraph fallback | separate case; genuine parity; skill stays fully model-invocable |
-| commands bridge | same seam, same helper |
+| item                                                             | notes                                                                                                                                                                                                                                      |
+| ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| strict-parse gate on **staged** bytes                            | post-substitution, so a `${CLAUDE_PLUGIN_ROOT}` expansion that breaks YAML is also caught. Seams: `skills/stage.ts:163-164`, `commands/stage.ts:159-160`                                                                                   |
+| use Pi's own `parseFrontmatter`                                  | public root export (`dist/index.d.ts:29`); import via the existing `platform/pi-api.ts` boundary for byte-identical accept/reject semantics. **Verify** it was already exported at the declared peer floor `>=0.74.0` (dev dep is 0.79.10) |
+| unparseable → synthesized `disable-model-invocation` frontmatter | body preserved verbatim                                                                                                                                                                                                                    |
+| install-time warning row                                         | names the source skill and the parse error -- the `--debug` analog, surfaced rather than hidden. Satisfies the issue's core ask                                                                                                            |
+| `name` must equal generated name post-rewrite                    | catches the folded-scalar corruption                                                                                                                                                                                                       |
+| absent `description` → first-paragraph fallback                  | separate case; genuine parity; skill stays fully model-invocable                                                                                                                                                                           |
+| commands bridge                                                  | same seam, same helper                                                                                                                                                                                                                     |
 
-Files that already parse and already satisfy Pi's load requirements are written
-**verbatim** — no rewriting, no behavior change for the ~99% that work today.
+Files that already parse and already satisfy Pi's load requirements are written **verbatim** -- no rewriting, no behavior change for the ~99% that work today.
 
 ### Classification
 
-A malformation of a *supported* component, not an unsupported kind — so failure-class,
-not soft-degrade. Precedent: `malformed mcp` (MCPR-03 / D-02) at
-`shared/notify-reasons.ts:110-113`, which files a broken `mcpServers` string reference
-under `FAILURE_REASONS` and comments explicitly that it does **not** belong in
-`UNSUPPORTED_REASONS` for exactly this reason. `"unparseable"` already exists in the
-closed set; a dedicated token paralleling `malformed mcp` would be an OUT-08 catalog
-amendment (the `REASONS` tuple must stay byte-stable).
+A malformation of a *supported* component, not an unsupported kind -- so failure-class, not soft-degrade. Precedent: `malformed mcp` (MCPR-03 / D-02) at `shared/notify-reasons.ts:110-113`, which files a broken `mcpServers` string reference under `FAILURE_REASONS` and comments explicitly that it does **not** belong in `UNSUPPORTED_REASONS` for exactly this reason. `"unparseable"` already exists in the closed set; a dedicated token paralleling `malformed mcp` would be an OUT-08 catalog amendment (the `REASONS` tuple must stay byte-stable).
 
 ### Open questions
 
-1. Placeholder description: fixed string, or does it name the parse error? Leaning
-   fixed and short, with the parse error carried by the install-time warning where it
-   is actionable.
-2. `when_to_use` is a Claude Code extension appended to `description` in the listing.
-   Pi does not know the field, so that text is currently lost. Adjacent; decide
-   separately.
+1. Placeholder description: fixed string, or does it name the parse error? Leaning fixed and short, with the parse error carried by the install-time warning where it is actionable.
+2. `when_to_use` is a Claude Code extension appended to `description` in the listing. Pi does not know the field, so that text is currently lost. Adjacent; decide separately.

--- a/docs/research/issue-101-skill-frontmatter-diagnosis.md
+++ b/docs/research/issue-101-skill-frontmatter-diagnosis.md
@@ -14,16 +14,16 @@ ______________________________________________________________________
 
 `prepareStageSkills` treats `SKILL.md` as opaque text:
 
-```
+```text
 bridges/skills/stage.ts:161-164
   readFile → rewriteFrontmatterName() → substituteClaudeVars() → writeFile
 ```
 
 `rewriteFrontmatterName` (`bridges/skills/rewrite-frontmatter.ts:33-42`) is a regex replace on the `name:` line -- it never parses. Discovery (`bridges/skills/discover.ts:56-59`) only checks that `SKILL.md` exists as a regular file. So an install can fail for reasons the bridge invents (RN-6 collisions, path safety, fs errors) but never for *"the consumer cannot read what we just wrote."*
 
-The consumer is strict. Pi's `core/skills.js::loadSkillFromFile` → `utils/frontmatter.js::parseFrontmatter` → `yaml.parse()`, which throws on a plain (unquoted) scalar containing `: `:
+The consumer is strict. Pi's `core/skills.js::loadSkillFromFile` → `utils/frontmatter.js::parseFrontmatter` → `yaml.parse()`, which throws on a plain (unquoted) scalar containing an unquoted `:` followed by a space:
 
-```
+```text
 name: example
 description: Use this skill for checks. Triggers on: "test", "lint".
 → YAMLParseError: Nested mappings are not allowed in compact mappings at line 2, column 14
@@ -58,7 +58,7 @@ Scanned the 190 `SKILL.md` under `~/.claude`: **2 fail Pi's parser**, 1 has no u
 
 > `… Runs Murphy-style technical analysis: trend (Dow Theory), support/resistance, …`
 
-An unquoted `: ` mid-sentence. Commands corpus: 0/84 locally -- the code gap is identical, but command descriptions are short, whereas skills' trigger-prose is what hits it.
+An unquoted `:` followed by a space mid-sentence. Commands corpus: 0/84 locally -- the code gap is identical, but command descriptions are short, whereas skills' trigger-prose is what hits it.
 
 ______________________________________________________________________
 
@@ -76,7 +76,7 @@ Verified directly; do not re-derive (Claude Code ships as a compiled binary, not
 
 js-yaml rejects the same input Pi rejects:
 
-```
+```text
 description: Runs analysis: trend and volume.     → FAIL bad indentation of a mapping entry (2:27)
 description: Use for checks. Triggers on: "test". → FAIL bad indentation of a mapping entry (2:41)
 ```

--- a/docs/research/issue-101-skill-frontmatter-diagnosis.md
+++ b/docs/research/issue-101-skill-frontmatter-diagnosis.md
@@ -1,0 +1,226 @@
+# Issue #101 — Pi-incompatible `SKILL.md` frontmatter: diagnosis and design
+
+Status: diagnosis complete, not implemented. No code changed.
+Reported by: fank (Florian Kinder). Investigated 2026-07-24.
+
+## Summary
+
+The skills bridge writes `SKILL.md` bytes without ever checking that Pi can parse
+them. An install reports success; Pi then rejects the generated skill at the next
+startup and the skill silently does not exist.
+
+The same gap exists in the commands bridge, where the failure is fully silent.
+
+---
+
+## Root cause
+
+`prepareStageSkills` treats `SKILL.md` as opaque text:
+
+```
+bridges/skills/stage.ts:161-164
+  readFile → rewriteFrontmatterName() → substituteClaudeVars() → writeFile
+```
+
+`rewriteFrontmatterName` (`bridges/skills/rewrite-frontmatter.ts:33-42`) is a regex
+replace on the `name:` line — it never parses. Discovery
+(`bridges/skills/discover.ts:56-59`) only checks that `SKILL.md` exists as a regular
+file. So an install can fail for reasons the bridge invents (RN-6 collisions, path
+safety, fs errors) but never for *"the consumer cannot read what we just wrote."*
+
+The consumer is strict. Pi's `core/skills.js::loadSkillFromFile` →
+`utils/frontmatter.js::parseFrontmatter` → `yaml.parse()`, which throws on a plain
+(unquoted) scalar containing `: `:
+
+```
+name: example
+description: Use this skill for checks. Triggers on: "test", "lint".
+→ YAMLParseError: Nested mappings are not allowed in compact mappings at line 2, column 14
+```
+
+Pi catches the throw, downgrades it to a **warning** diagnostic and returns
+`skill: null`. `orchestrators/discover.ts:99-101` has already handed Pi the path, so
+the user sees a YAML error at startup and a skill that does not exist.
+
+## Why the gap exists
+
+The agents bridge already solves this class of problem correctly:
+`bridges/agents/frontmatter.ts` parses source frontmatter with a parser mirroring the
+consumer's (pi-subagents' line-based reader) and **re-emits** every scalar through
+`emitYamlScalar`, so what lands on disk is readable by construction.
+
+The skills bridge never got that treatment. `rewrite-frontmatter.ts:5` records the
+choice as deliberate ("Pure string manipulation -- no YAML parsing, no eval") for
+injection-safety (T-03-17). That reasoning conflates two concerns: injection-safety
+says *don't evaluate untrusted input*; output-validity says *don't emit bytes your
+consumer will reject*. The current code buys the first at the cost of the second —
+for the one component kind whose consumer is strictest (real YAML vs. line-based).
+
+---
+
+## Blast radius
+
+| kind | exposed? | symptom |
+| --- | --- | --- |
+| skills | yes | Pi warning at startup; skill absent |
+| commands / prompts | yes — `bridges/commands/stage.ts:159-160` copies verbatim | **fully silent**: `core/prompt-templates.js::loadTemplateFromFile` wraps everything in `try { … } catch { return null }`, no diagnostic |
+| agents | no | round-tripped through `emitYamlScalar`; AG-6 contract tolerates `:` in values |
+
+Two adjacent members of the same family (bridge reports success, Pi rejects at load):
+
+- **Missing `description`** — Pi returns `skill: null` when absent or empty.
+  `rewrite-frontmatter.ts:22-23` *manufactures* this case: it synthesizes a
+  frontmatter block containing only `name:` when the source has none.
+- **Silent name corruption** — a multi-line `name:` has only its first line replaced.
+  Verified: `name: >\n  my\n  skill` → `name: acme-skill my skill`. Still valid YAML,
+  so no error anywhere; Pi's `validateName` warns, the skill loads under a name that
+  is not the generated one, `/skill:<generated-name>` does not resolve, and RN-6's
+  uniqueness guarantee no longer holds on disk.
+
+## Prevalence
+
+Scanned the 190 `SKILL.md` under `~/.claude`: **2 fail Pi's parser**, 1 has no usable
+frontmatter. Both failures are in the maintainer's own marketplace
+(`acolomba-claude-plugins`): `stocks/skills/stocks-murphy-technical-analysis` and
+`llm-wiki/skills/llm-wiki-scaffold`. Offending prose:
+
+> `… Runs Murphy-style technical analysis: trend (Dow Theory), support/resistance, …`
+
+An unquoted `: ` mid-sentence. Commands corpus: 0/84 locally — the code gap is
+identical, but command descriptions are short, whereas skills' trigger-prose is what
+hits it.
+
+---
+
+## Upstream: how Claude Code actually parses this
+
+Verified directly; do not re-derive (Claude Code ships as a compiled binary, not an
+npm package).
+
+**Parser: js-yaml, strict — Claude Code is NOT lenient.** Fingerprinted
+`~/.local/share/claude/versions/2.1.212`:
+
+| signature | hits |
+| --- | --- |
+| js-yaml (`bad indentation of a mapping entry`, …) | 1 |
+| `yaml` / eemeli (`Nested mappings are not allowed`, …) | 0 |
+| gray-matter | 0 |
+
+js-yaml rejects the same input Pi rejects:
+
+```
+description: Runs analysis: trend and volume.     → FAIL bad indentation of a mapping entry (2:27)
+description: Use for checks. Triggers on: "test". → FAIL bad indentation of a mapping entry (2:41)
+```
+
+**Failure policy is the real divergence** — code.claude.com/docs/en/skills.md,
+verbatim:
+
+> "If the frontmatter YAML is malformed, Claude Code loads the skill body with empty
+> metadata, so `/skill-name` still works but Claude has no `description` to match
+> against. Run with `--debug` to see the parse error."
+
+| | parse | on failure |
+| --- | --- | --- |
+| Claude Code | js-yaml, strict | body loads, metadata empty, `/name` works, no auto-invoke; error only under `--debug` |
+| Pi | `yaml`, strict | empty description ⇒ `skill: null`, skill gone; warning at startup |
+| bridge today | none | reports success, defers to Pi |
+
+**Consequence:** the two offending plugins are broken in Claude Code too — their
+descriptions have always been empty there, so Claude never auto-invokes them. Neither
+host tells the plugin author, which is why the defect ships into published
+marketplaces.
+
+**Field contract:** `description` is *Recommended*, not required — "If omitted, uses
+the first paragraph of markdown content." `when_to_use` is a Claude Code extension
+appended to `description` in the listing; combined text truncated at 1,536 chars. Pi
+requires a non-empty `description`, so a spec-conformant description-less Claude skill
+silently vanishes in Pi.
+
+---
+
+## Design
+
+### Rejected: quote repair
+
+An earlier proposal parsed leniently and re-quoted only the offending top-level plain
+scalars, then verified. It measured well (2 fixed, 187 byte-identical, 0 regressions
+on the corpus) but was rejected: it rewrites third-party content — which the issue
+author explicitly flagged as undesirable — and adds a heuristic to maintain and test
+for inputs outside the sampled corpus.
+
+Also rejected: whole-block re-emit in the agents-bridge style. Skills' target format
+is real YAML with real structure, and flattening it would damage ~13% of real skills
+(19/190 nested maps or lists, 6 block scalars, 2 flow collections, 24 continuation
+lines). The agents bridge gets away with it only because pi-subagents' target format
+is flat.
+
+### Chosen: mirror Claude Code's behavior via Pi's own machinery
+
+Literal parity fails. Claude Code's "empty metadata" leaves `/skill-name` working; in
+Pi, empty metadata means the skill does not exist (the `!frontmatter.description`
+guard returns `skill: null` before the skill object is built). Same mechanism,
+opposite outcome.
+
+Claude Code's observable behavior decomposes into two properties — **(a)** invocable
+by name, **(b)** never auto-invoked, because there is no description to match. Pi has
+a first-class field for exactly that pair:
+
+```js
+// pi-coding-agent core/skills.js
+disableModelInvocation: frontmatter["disable-model-invocation"] === true
+```
+
+`formatSkillsForPrompt` filters those out, with Pi's own comment: *"they can only be
+invoked explicitly via /skill:name commands."*
+
+So on unparseable frontmatter, replace the block — **body untouched** — with:
+
+```yaml
+---
+name: <generated-name>
+description: <plugin> skill "<source>" — source frontmatter could not be parsed.
+disable-model-invocation: true
+---
+```
+
+`/skill:<generated-name>` works, the model never auto-invokes it, and because disabled
+skills are excluded from the listing the placeholder description costs zero context —
+it exists only to clear Pi's non-empty gate.
+
+This mutates metadata we could not read, not the author's values, and does not
+hard-fail: a one-bad-skill plugin still installs.
+
+### Work items
+
+| item | notes |
+| --- | --- |
+| strict-parse gate on **staged** bytes | post-substitution, so a `${CLAUDE_PLUGIN_ROOT}` expansion that breaks YAML is also caught. Seams: `skills/stage.ts:163-164`, `commands/stage.ts:159-160` |
+| use Pi's own `parseFrontmatter` | public root export (`dist/index.d.ts:29`); import via the existing `platform/pi-api.ts` boundary for byte-identical accept/reject semantics. **Verify** it was already exported at the declared peer floor `>=0.74.0` (dev dep is 0.79.10) |
+| unparseable → synthesized `disable-model-invocation` frontmatter | body preserved verbatim |
+| install-time warning row | names the source skill and the parse error — the `--debug` analog, surfaced rather than hidden. Satisfies the issue's core ask |
+| `name` must equal generated name post-rewrite | catches the folded-scalar corruption |
+| absent `description` → first-paragraph fallback | separate case; genuine parity; skill stays fully model-invocable |
+| commands bridge | same seam, same helper |
+
+Files that already parse and already satisfy Pi's load requirements are written
+**verbatim** — no rewriting, no behavior change for the ~99% that work today.
+
+### Classification
+
+A malformation of a *supported* component, not an unsupported kind — so failure-class,
+not soft-degrade. Precedent: `malformed mcp` (MCPR-03 / D-02) at
+`shared/notify-reasons.ts:110-113`, which files a broken `mcpServers` string reference
+under `FAILURE_REASONS` and comments explicitly that it does **not** belong in
+`UNSUPPORTED_REASONS` for exactly this reason. `"unparseable"` already exists in the
+closed set; a dedicated token paralleling `malformed mcp` would be an OUT-08 catalog
+amendment (the `REASONS` tuple must stay byte-stable).
+
+### Open questions
+
+1. Placeholder description: fixed string, or does it name the parse error? Leaning
+   fixed and short, with the parse error carried by the install-time warning where it
+   is actionable.
+2. `when_to_use` is a Claude Code extension appended to `description` in the listing.
+   Pi does not know the field, so that text is currently lost. Adjacent; decide
+   separately.

--- a/extensions/pi-claude-marketplace/bridges/commands/stage.ts
+++ b/extensions/pi-claude-marketplace/bridges/commands/stage.ts
@@ -125,7 +125,7 @@ export function assertNoCommandCollisions(discovered: readonly DiscoveredCommand
  * the opening delimiter, so the loop terminates.
  */
 function neutralizeCommandFrontmatter(content: string): string {
-  let normalized = content.replaceAll(/\r\n/g, "\n").replaceAll(/\r/g, "\n");
+  let normalized = content.replaceAll("\r\n", "\n").replaceAll("\r", "\n");
 
   for (;;) {
     if (!normalized.startsWith("---")) {

--- a/extensions/pi-claude-marketplace/bridges/commands/stage.ts
+++ b/extensions/pi-claude-marketplace/bridges/commands/stage.ts
@@ -44,6 +44,7 @@ import { substituteClaudeVars } from "../../shared/vars.ts";
 import { discoverPluginCommands } from "./discover.ts";
 
 import type {
+  CommandDegradeRecord,
   CommandsReplacement,
   DiscoveredCommand,
   PreparedCommandsStaging,
@@ -102,27 +103,55 @@ export function assertNoCommandCollisions(discovered: readonly DiscoveredCommand
 /**
  * CMD-01 / D-86-07: neutralize an unparseable command source by stripping the
  * ENTIRE malformed frontmatter block -- the opening `---` line through the
- * matching closing `---` line -- leaving the real body verbatim. A re-parse of
- * the result RETURNS empty, so Pi's command loader falls back to
- * name-from-filename + description-from-first-body-line (NOT delimiter-only
- * stripping, which would leave ex-frontmatter junk as the first body line).
- * Called ONLY on the gate-1 throw arm, where a closed `---`...`---` block is
- * present by construction.
+ * matching closing `---` line -- leaving the real body. A re-parse of the
+ * result RETURNS empty, so Pi's command loader falls back to name-from-filename
+ * + description-from-first-body-line (NOT delimiter-only stripping, which would
+ * leave ex-frontmatter junk as the first body line). Called ONLY on the gate-1
+ * throw arm, where a closed `---`...`---` block is present by construction.
  *
- * Delimiters are located by index on the source as-is -- via the `\n---` search
- * `parseFrontmatter` itself uses (line-ending agnostic) -- never by a fixed
- * byte offset, so the surviving body bytes are untouched (no CRLF re-encoding).
+ * Newlines are first normalized (CR/CRLF -> LF) with the SAME two-step replace
+ * `parseFrontmatter` applies before its own `\n---` close search, so this scan
+ * agrees with the parser for every line-ending style -- including lone-CR
+ * sources, which would otherwise hide the close from a raw `\n---` search and
+ * turn a graceful degrade into a gate-2 hard-fail. The body is emitted with LF
+ * line endings (what Pi's loader normalizes the staged file to on read anyway).
+ *
+ * Successive leading malformed blocks are stripped until the remainder PARSES
+ * (RETURNS) under Pi's loader: a source whose body itself opens with a second
+ * malformed `---`...`---` block would otherwise re-throw at the PARSE-02 backstop
+ * and turn a graceful degrade into a hard-fail. A leading block that parses
+ * cleanly, or a remainder with no opening `---`, is Pi-acceptable and kept
+ * verbatim (matching what Pi's own loader would do). Each pass removes at least
+ * the opening delimiter, so the loop terminates.
  */
 function neutralizeCommandFrontmatter(content: string): string {
-  const closeIdx = content.indexOf("\n---", 3);
-  if (closeIdx === -1) {
-    // Defensive: no closed block means parseFrontmatter would have RETURNED, so
-    // this arm is unreachable on a genuine throw. Leave the content unchanged.
-    return content;
-  }
+  let normalized = content.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
 
-  const afterClose = content.indexOf("\n", closeIdx + 1);
-  return afterClose === -1 ? "" : content.slice(afterClose + 1);
+  for (;;) {
+    if (!normalized.startsWith("---")) {
+      // No opening fence: parseFrontmatter RETURNS the body as-is, nothing to strip.
+      return normalized;
+    }
+
+    const closeIdx = normalized.indexOf("\n---", 3);
+    if (closeIdx === -1) {
+      // Opening `---` but no close: parseFrontmatter RETURNS, leave unchanged.
+      return normalized;
+    }
+
+    const afterClose = normalized.indexOf("\n", closeIdx + 1);
+    const stripped = afterClose === -1 ? "" : normalized.slice(afterClose + 1);
+
+    try {
+      // A clean parse (empty or valid frontmatter, or no opening fence) means the
+      // remainder is Pi-acceptable -- stop here.
+      parseFrontmatter(stripped);
+      return stripped;
+    } catch {
+      // The remainder still opens with a malformed block; strip it too.
+      normalized = stripped;
+    }
+  }
 }
 
 /**
@@ -163,7 +192,7 @@ export async function prepareStageCommands(
         warnings: Object.freeze([...discoverWarnings]),
         // CMD-01: the noop branch stages no commands, so no source is parsed and
         // nothing can degrade -- always empty here.
-        degraded: Object.freeze<{ generatedName: string; parseError: string }[]>([]),
+        degraded: Object.freeze<CommandDegradeRecord[]>([]),
       },
     };
   }
@@ -174,7 +203,7 @@ export async function prepareStageCommands(
 
   const renamePairs: { from: string; to: string }[] = [];
   const stagedNames: string[] = [];
-  const degraded: { generatedName: string; parseError: string }[] = [];
+  const degraded: CommandDegradeRecord[] = [];
 
   try {
     for (const command of discovered) {

--- a/extensions/pi-claude-marketplace/bridges/commands/stage.ts
+++ b/extensions/pi-claude-marketplace/bridges/commands/stage.ts
@@ -25,6 +25,7 @@ import { mkdir, readFile, rename, unlink, writeFile } from "node:fs/promises";
 import path from "node:path";
 
 import { assertSafeName } from "../../domain/name.ts";
+import { parseFrontmatter } from "../../platform/pi-api.ts";
 import {
   appendLeakToError,
   appendLeaks,
@@ -99,6 +100,32 @@ export function assertNoCommandCollisions(discovered: readonly DiscoveredCommand
 }
 
 /**
+ * CMD-01 / D-86-07: neutralize an unparseable command source by stripping the
+ * ENTIRE malformed frontmatter block -- the opening `---` line through the
+ * matching closing `---` line -- leaving the real body verbatim. A re-parse of
+ * the result RETURNS empty, so Pi's command loader falls back to
+ * name-from-filename + description-from-first-body-line (NOT delimiter-only
+ * stripping, which would leave ex-frontmatter junk as the first body line).
+ * Called ONLY on the gate-1 throw arm, where a closed `---`...`---` block is
+ * present by construction.
+ *
+ * Delimiters are located by index on the source as-is -- via the `\n---` search
+ * `parseFrontmatter` itself uses (line-ending agnostic) -- never by a fixed
+ * byte offset, so the surviving body bytes are untouched (no CRLF re-encoding).
+ */
+function neutralizeCommandFrontmatter(content: string): string {
+  const closeIdx = content.indexOf("\n---", 3);
+  if (closeIdx === -1) {
+    // Defensive: no closed block means parseFrontmatter would have RETURNED, so
+    // this arm is unreachable on a genuine throw. Leave the content unchanged.
+    return content;
+  }
+
+  const afterClose = content.indexOf("\n", closeIdx + 1);
+  return afterClose === -1 ? "" : content.slice(afterClose + 1);
+}
+
+/**
  * Stage commands into a fresh `<commandsStagingDir>/<uuid>/` tree. Reads
  * each source `.md`, substitutes `${CLAUDE_PLUGIN_ROOT}` /
  * `${CLAUDE_PLUGIN_DATA}` (CM-3), and writes the substituted body to a
@@ -134,8 +161,8 @@ export async function prepareStageCommands(
         stagedNames: Object.freeze<string[]>([]),
         recorded: Object.freeze<StagedCommandRecord[]>([]),
         warnings: Object.freeze([...discoverWarnings]),
-        // CMD-01: no source-parse gate on the command seam yet; the neutralize
-        // arm that populates this lands with the command gates.
+        // CMD-01: the noop branch stages no commands, so no source is parsed and
+        // nothing can degrade -- always empty here.
         degraded: Object.freeze<{ generatedName: string; parseError: string }[]>([]),
       },
     };
@@ -147,6 +174,7 @@ export async function prepareStageCommands(
 
   const renamePairs: { from: string; to: string }[] = [];
   const stagedNames: string[] = [];
+  const degraded: { generatedName: string; parseError: string }[] = [];
 
   try {
     for (const command of discovered) {
@@ -159,8 +187,36 @@ export async function prepareStageCommands(
       await assertPathInside(locations.promptsTargetDir, targetFile, "target command file");
 
       let content = await readFile(command.commandFile, "utf8");
+
+      // PARSE-01: parse the SOURCE frontmatter BEFORE substitution to establish
+      // attribution ground truth + the degrade trigger. A THROW means a closed
+      // `---` block whose inner YAML is malformed (an author defect); a RETURN
+      // (including absent/empty frontmatter) is the byte-identical passthrough
+      // (NREG-01). The parse is READ-ONLY -- validate, never eval (T-03-17).
+      try {
+        parseFrontmatter(content);
+      } catch (parseErr) {
+        // CMD-01 / D-86-07: neutralize by stripping the entire malformed
+        // frontmatter block, leaving the real body, so Pi's command loader
+        // takes name-from-filename + description-from-first-body-line. No
+        // synthesized placeholder and no disable flag -- Pi's command loader
+        // has no non-empty-description gate.
+        content = neutralizeCommandFrontmatter(content);
+        degraded.push({
+          generatedName: command.generatedName,
+          parseError: errorMessage(parseErr),
+        });
+      }
+
       content = substituteClaudeVars(content, { pluginRoot, pluginData: pluginDataDir });
       await writeFile(stagedFile, content, "utf8");
+
+      // PARSE-02 / D-86-04: re-parse the STAGED bytes as a Pi-acceptability
+      // backstop. The neutralized output is designed to RETURN, so a THROW here
+      // is OUR self-inflicted defect (substitution produced bytes Pi rejects) --
+      // throw loudly so it rides the cleanup catch below; never mask it as
+      // author degradation.
+      parseFrontmatter(content);
 
       renamePairs.push({ from: stagedFile, to: targetFile });
       stagedNames.push(command.generatedName);
@@ -183,8 +239,10 @@ export async function prepareStageCommands(
       stagedNames: Object.freeze(stagedNames),
       recorded: Object.freeze(recorded),
       warnings: Object.freeze([...discoverWarnings]),
-      // CMD-01: inert until the command neutralize arm lands.
-      degraded: Object.freeze<{ generatedName: string; parseError: string }[]>([]),
+      // CMD-01: one record per command whose SOURCE frontmatter was unparseable
+      // and neutralized (D-86-07). The install orchestrator maps these to the
+      // `{malformed command}` reason token + per-component detail.
+      degraded: Object.freeze(degraded),
     },
     _previousNames: Object.freeze([...previousNames]),
     _renamePairs: Object.freeze(renamePairs),

--- a/extensions/pi-claude-marketplace/bridges/commands/stage.ts
+++ b/extensions/pi-claude-marketplace/bridges/commands/stage.ts
@@ -125,7 +125,7 @@ export function assertNoCommandCollisions(discovered: readonly DiscoveredCommand
  * the opening delimiter, so the loop terminates.
  */
 function neutralizeCommandFrontmatter(content: string): string {
-  let normalized = content.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  let normalized = content.replaceAll(/\r\n/g, "\n").replaceAll(/\r/g, "\n");
 
   for (;;) {
     if (!normalized.startsWith("---")) {

--- a/extensions/pi-claude-marketplace/bridges/commands/stage.ts
+++ b/extensions/pi-claude-marketplace/bridges/commands/stage.ts
@@ -134,6 +134,9 @@ export async function prepareStageCommands(
         stagedNames: Object.freeze<string[]>([]),
         recorded: Object.freeze<StagedCommandRecord[]>([]),
         warnings: Object.freeze([...discoverWarnings]),
+        // CMD-01: no source-parse gate on the command seam yet; the neutralize
+        // arm that populates this lands with the command gates.
+        degraded: Object.freeze<{ generatedName: string; parseError: string }[]>([]),
       },
     };
   }
@@ -180,6 +183,8 @@ export async function prepareStageCommands(
       stagedNames: Object.freeze(stagedNames),
       recorded: Object.freeze(recorded),
       warnings: Object.freeze([...discoverWarnings]),
+      // CMD-01: inert until the command neutralize arm lands.
+      degraded: Object.freeze<{ generatedName: string; parseError: string }[]>([]),
     },
     _previousNames: Object.freeze([...previousNames]),
     _renamePairs: Object.freeze(renamePairs),

--- a/extensions/pi-claude-marketplace/bridges/commands/types.ts
+++ b/extensions/pi-claude-marketplace/bridges/commands/types.ts
@@ -56,6 +56,13 @@ export interface StageCommandsCommitResult {
   /** W-05: callers read `recorded` to populate state.json. */
   readonly recorded: readonly StagedCommandRecord[];
   readonly warnings: readonly string[];
+  /**
+   * CMD-01 / PARSE-01: one record per command whose SOURCE frontmatter could
+   * not be parsed and was neutralized. The orchestrator maps these to the
+   * `{malformed command}` reason token and the per-component detail line.
+   * Always empty until the command neutralize arm lands.
+   */
+  readonly degraded: readonly { generatedName: string; parseError: string }[];
 }
 
 /** Discriminated union -- `kind: "noop" | "staged"`. */

--- a/extensions/pi-claude-marketplace/bridges/commands/types.ts
+++ b/extensions/pi-claude-marketplace/bridges/commands/types.ts
@@ -50,6 +50,15 @@ export interface StagedCommandRecord {
   readonly targetPath: string;
 }
 
+/**
+ * CMD-01 / PARSE-01: one record per command whose SOURCE frontmatter could not
+ * be parsed and was neutralized.
+ */
+export interface CommandDegradeRecord {
+  readonly generatedName: string;
+  readonly parseError: string;
+}
+
 /** Result returned to callers after commit (or noop). */
 export interface StageCommandsCommitResult {
   readonly stagedNames: readonly string[];
@@ -57,12 +66,10 @@ export interface StageCommandsCommitResult {
   readonly recorded: readonly StagedCommandRecord[];
   readonly warnings: readonly string[];
   /**
-   * CMD-01 / PARSE-01: one record per command whose SOURCE frontmatter could
-   * not be parsed and was neutralized. The orchestrator maps these to the
-   * `{malformed command}` reason token and the per-component detail line.
-   * Always empty until the command neutralize arm lands.
+   * The orchestrator maps these to the `{malformed command}` reason token and
+   * the per-component detail line. Empty on the all-valid path (NREG-01).
    */
-  readonly degraded: readonly { generatedName: string; parseError: string }[];
+  readonly degraded: readonly CommandDegradeRecord[];
 }
 
 /** Discriminated union -- `kind: "noop" | "staged"`. */

--- a/extensions/pi-claude-marketplace/bridges/skills/frontmatter-degrade.ts
+++ b/extensions/pi-claude-marketplace/bridges/skills/frontmatter-degrade.ts
@@ -54,6 +54,32 @@ export function synthesizeUnparseableSkill(body: string, generatedName: string):
   );
 }
 
+/** A fenced-code-block delimiter line (```` ``` ```` or `~~~`), leading-trimmed. */
+const FENCE = /^(```|~~~)/;
+
+/**
+ * Advance past a fenced code block whose opener is at `start`, returning the
+ * index just after the closing fence (or the end of input if unterminated).
+ */
+function skipFencedBlock(lines: readonly string[], start: number): number {
+  let i = start + 1;
+  while (i < lines.length && !FENCE.test((lines[i] ?? "").trim())) {
+    i++;
+  }
+
+  return i < lines.length ? i + 1 : i;
+}
+
+/** Collect the contiguous non-blank paragraph starting at `start` (joined by `\n`). */
+function collectParagraph(lines: readonly string[], start: number): string {
+  const paragraph: string[] = [];
+  for (let i = start; i < lines.length && (lines[i] ?? "").trim() !== ""; i++) {
+    paragraph.push(lines[i] ?? "");
+  }
+
+  return paragraph.join("\n");
+}
+
 /**
  * SKILL-02 / D-86-06: derive a `description` from the first GENUINE body line.
  * Skips blank lines, ATX `#` heading lines, and fenced code blocks (```` ``` ````
@@ -66,42 +92,22 @@ export function firstBodyParagraph(body: string): string {
   const lines = body.split("\n");
   let i = 0;
   while (i < lines.length) {
-    const trimmed = lines[i]!.trim();
+    const trimmed = (lines[i] ?? "").trim();
 
-    if (trimmed === "") {
-      i++;
-      continue;
-    }
-
-    // ATX heading line (`#` .. `######`, optionally bare).
-    if (/^#{1,6}(\s|$)/.test(trimmed)) {
+    // Blank line or ATX heading (`#` .. `######`, optionally bare): skip.
+    if (trimmed === "" || /^#{1,6}(\s|$)/.test(trimmed)) {
       i++;
       continue;
     }
 
     // Fenced code block: skip the opener, its contents, and the closing fence.
-    if (/^(```|~~~)/.test(trimmed)) {
-      i++;
-      while (i < lines.length && !/^(```|~~~)/.test(lines[i]!.trim())) {
-        i++;
-      }
-
-      // Consume the closing fence line if present.
-      if (i < lines.length) {
-        i++;
-      }
-
+    if (FENCE.test(trimmed)) {
+      i = skipFencedBlock(lines, i);
       continue;
     }
 
-    // First prose line: collect the contiguous paragraph to the next blank line.
-    const paragraph: string[] = [];
-    while (i < lines.length && lines[i]!.trim() !== "") {
-      paragraph.push(lines[i]!);
-      i++;
-    }
-
-    return paragraph.join("\n");
+    // First prose line: return the contiguous paragraph to the next blank line.
+    return collectParagraph(lines, i);
   }
 
   return "";
@@ -143,6 +149,51 @@ function emitSafeDoubleQuotedScalar(value: string): string {
   return `"${escaped}"`;
 }
 
+/** The top-level frontmatter `description` key token (including its colon). */
+const DESCRIPTION_KEY = "description:";
+
+/** Index of the closing `---` fence (frontmatter block end), or `lines.length`. */
+function frontmatterBlockEnd(lines: readonly string[]): number {
+  for (let i = 1; i < lines.length; i++) {
+    if ((lines[i] ?? "").trim() === "---") {
+      return i;
+    }
+  }
+
+  return lines.length;
+}
+
+/**
+ * Given the `description` key line at `keyIndex`, return the index of the LAST
+ * line its value spans: the key line itself for an inline scalar, or -- when the
+ * inline value is a block-scalar indicator (`>` / `|`, optionally with a chomp /
+ * indent modifier) -- the last indented continuation line. Trailing blank lines
+ * are NOT absorbed so inter-key blank spacing is preserved byte-for-byte.
+ */
+function descriptionValueEnd(lines: readonly string[], keyIndex: number, blockEnd: number): number {
+  const inlineValue = (lines[keyIndex] ?? "").slice(DESCRIPTION_KEY.length).trim();
+  if (!/^[>|]/.test(inlineValue)) {
+    return keyIndex;
+  }
+
+  let lastReplaced = keyIndex;
+  for (let i = keyIndex + 1; i < blockEnd; i++) {
+    const line = lines[i] ?? "";
+    if (line.trim() === "") {
+      continue;
+    }
+
+    if (/^\s/.test(line)) {
+      lastReplaced = i;
+      continue;
+    }
+
+    break;
+  }
+
+  return lastReplaced;
+}
+
 /**
  * SKILL-03 class: set the frontmatter `description` to `value` by replacing the
  * FULL `description` node span -- including a `>-` / `|` block scalar spanning
@@ -152,37 +203,20 @@ function emitSafeDoubleQuotedScalar(value: string): string {
  * SKILL-03 corruption class). `content` is the full source file (with `---`
  * fences); the returned string is the same file with the description node
  * rewritten. If no top-level `description:` key is present the content is
- * returned unchanged.
- *
- * Node-span scan: locate the top-level (zero-indent) `description:` line. If its
- * inline value is a block-scalar indicator (`>` / `|`, optionally with a chomp /
- * indent modifier), consume the following continuation lines -- blank lines and
- * lines indented under the key -- up to the last indented content line (trailing
- * blank lines are left intact so inter-key spacing survives). The key line
- * through that last continuation line are replaced by a single
- * `description: "<escaped>"` line.
+ * returned unchanged. Only the frontmatter block (opening `---` through the next
+ * `---`) is scanned, so a body line starting with `description:` is never matched.
  */
 export function setDescriptionScalar(content: string, value: string): string {
   const lines = content.split("\n");
-
-  // The frontmatter block is between the opening `---` (line 0) and the next
-  // `---` line. Only scan for the key inside that block so a body line that
-  // happens to start with `description:` is never matched.
   if (lines[0]?.trim() !== "---") {
     return content;
   }
 
-  let blockEnd = lines.length;
-  for (let i = 1; i < lines.length; i++) {
-    if (lines[i]!.trim() === "---") {
-      blockEnd = i;
-      break;
-    }
-  }
+  const blockEnd = frontmatterBlockEnd(lines);
 
   let keyIndex = -1;
   for (let i = 1; i < blockEnd; i++) {
-    if (/^description:/.test(lines[i]!)) {
+    if ((lines[i] ?? "").startsWith(DESCRIPTION_KEY)) {
       keyIndex = i;
       break;
     }
@@ -192,31 +226,8 @@ export function setDescriptionScalar(content: string, value: string): string {
     return content;
   }
 
-  const inlineValue = lines[keyIndex]!.slice("description:".length).trim();
-  const isBlockScalar = /^[>|]/.test(inlineValue);
-
-  let lastReplaced = keyIndex;
-  if (isBlockScalar) {
-    // Consume block-scalar continuation lines: blank or indented, up to (but not
-    // including) the next zero-indent key or the closing delimiter. Trailing
-    // blank lines are NOT absorbed -- lastReplaced tracks the last indented
-    // content line so inter-key blank spacing is preserved byte-for-byte.
-    for (let i = keyIndex + 1; i < blockEnd; i++) {
-      const line = lines[i]!;
-      if (line.trim() === "") {
-        continue;
-      }
-
-      if (/^\s/.test(line)) {
-        lastReplaced = i;
-        continue;
-      }
-
-      break;
-    }
-  }
-
-  const replacement = `description: ${emitSafeDoubleQuotedScalar(value)}`;
+  const lastReplaced = descriptionValueEnd(lines, keyIndex, blockEnd);
+  const replacement = `${DESCRIPTION_KEY} ${emitSafeDoubleQuotedScalar(value)}`;
   const rebuilt = [...lines.slice(0, keyIndex), replacement, ...lines.slice(lastReplaced + 1)];
   return rebuilt.join("\n");
 }

--- a/extensions/pi-claude-marketplace/bridges/skills/frontmatter-degrade.ts
+++ b/extensions/pi-claude-marketplace/bridges/skills/frontmatter-degrade.ts
@@ -1,0 +1,222 @@
+// bridges/skills/frontmatter-degrade.ts
+//
+// Pure string-in / string-out helpers for the skills degrade + augment arms.
+// Every function is READ-ONLY toward author input: it reads bytes to VALIDATE
+// or COMPUTE a value, never `eval`s or executes them, so the T-03-17
+// injection-safety property is preserved (reading-to-validate is not
+// evaluating). The only bytes these helpers EMIT into a frontmatter position
+// (`setDescriptionScalar`, `synthesizeUnparseableSkill`) go through the safe
+// double-quoted scalar emitter or are fixed YAML-safe constants, so an author
+// value can never re-form a new YAML key (the AG-8 provenance-injection class).
+//
+// This module deliberately does NOT re-emit the whole frontmatter block (the
+// agents-bridge `emitGeneratedAgentFile` approach): skills' target is real
+// structured YAML, and a whole-block re-emit flattens nested maps / block
+// scalars / flow collections, breaking the NREG-01 byte-for-byte invariant on
+// the ~99% happy path. `setDescriptionScalar` instead replaces exactly the
+// `description` node span and leaves every sibling key byte-identical.
+
+/**
+ * SKILL-01 / D-86-02 / A4: the fixed placeholder description synthesized onto an
+ * unparseable skill. A short YAML-safe constant -- NOT interpolated with plugin
+ * or source names. The skill carries `disable-model-invocation: true`, so this
+ * string is excluded from the model listing and costs zero context; it exists
+ * only to clear Pi's non-empty-`description` gate. The actionable detail (plugin,
+ * component, parse error) rides the install-time warning channel instead.
+ */
+const UNPARSEABLE_SKILL_DESCRIPTION = "Source frontmatter could not be parsed.";
+
+/**
+ * WTU-02 / D-86-05 / A2: the combined `description` + `when_to_use` listing cap,
+ * in JS `.length` UTF-16 code units, matching Claude Code's 1,536-char skill
+ * listing budget. Kept at 1,536 even though Pi's loader emits a non-fatal
+ * warning above 1,024 -- truncating to 1,024 would silently drop trigger
+ * keywords and diverge from Claude Code.
+ */
+const LISTING_CAP = 1536;
+
+/**
+ * SKILL-01 / D-86-02: synthesize a known-good frontmatter block for a skill
+ * whose SOURCE frontmatter could not be parsed. Emits the generated `name`, the
+ * fixed placeholder `description`, and `disable-model-invocation: true`, then
+ * appends the markdown body verbatim. The block is byte-shaped so Pi's own
+ * `parseFrontmatter` accepts it (gate-2 backstop). `generatedName` is an
+ * `assertSafeName`-checked token upstream, so it needs no escaping.
+ */
+export function synthesizeUnparseableSkill(body: string, generatedName: string): string {
+  return (
+    "---\n" +
+    `name: ${generatedName}\n` +
+    `description: ${UNPARSEABLE_SKILL_DESCRIPTION}\n` +
+    "disable-model-invocation: true\n" +
+    "---\n\n" +
+    body
+  );
+}
+
+/**
+ * SKILL-02 / D-86-06: derive a `description` from the first GENUINE body line.
+ * Skips blank lines, ATX `#` heading lines, and fenced code blocks (```` ``` ````
+ * / `~~~` and their contents), lands on the first plain body line, and returns
+ * the contiguous paragraph up to the next blank line (verbatim, joined by
+ * `\n`). Returns `""` when the body has no prose (all blank / heading / fence).
+ * Mirrors Claude Code's "first paragraph of markdown content" fallback.
+ */
+export function firstBodyParagraph(body: string): string {
+  const lines = body.split("\n");
+  let i = 0;
+  while (i < lines.length) {
+    const trimmed = lines[i]!.trim();
+
+    if (trimmed === "") {
+      i++;
+      continue;
+    }
+
+    // ATX heading line (`#` .. `######`, optionally bare).
+    if (/^#{1,6}(\s|$)/.test(trimmed)) {
+      i++;
+      continue;
+    }
+
+    // Fenced code block: skip the opener, its contents, and the closing fence.
+    if (/^(```|~~~)/.test(trimmed)) {
+      i++;
+      while (i < lines.length && !/^(```|~~~)/.test(lines[i]!.trim())) {
+        i++;
+      }
+
+      // Consume the closing fence line if present.
+      if (i < lines.length) {
+        i++;
+      }
+
+      continue;
+    }
+
+    // First prose line: collect the contiguous paragraph to the next blank line.
+    const paragraph: string[] = [];
+    while (i < lines.length && lines[i]!.trim() !== "") {
+      paragraph.push(lines[i]!);
+      i++;
+    }
+
+    return paragraph.join("\n");
+  }
+
+  return "";
+}
+
+/**
+ * WTU-01 / A1: fold `when_to_use` into the Pi `description`. An empty or absent
+ * `whenToUse` returns `description` unchanged (no trailing separator); a
+ * non-empty one appends it after a single `\n` separator. Operates on JS string
+ * values (UTF-16 code units) with no byte/codepoint reinterpretation.
+ */
+export function foldWhenToUse(description: string, whenToUse: string | undefined): string {
+  if (whenToUse === undefined || whenToUse === "") {
+    return description;
+  }
+
+  return `${description}\n${whenToUse}`;
+}
+
+/**
+ * WTU-02 / A2: hard-cut `text` at the 1,536 UTF-16-code-unit listing cap. Text
+ * at or below the cap is returned unchanged; longer text is cut to exactly the
+ * first 1,536 code units with no ellipsis. Empty input returns empty.
+ */
+export function truncate1536(text: string): string {
+  return text.length <= LISTING_CAP ? text : text.slice(0, LISTING_CAP);
+}
+
+/**
+ * Emit `value` as a safe double-quoted single-line YAML scalar. Embedded
+ * newlines collapse to spaces, then `\` and `"` are escaped, so the emitted
+ * scalar cannot re-form a new YAML key on a following line (the AG-8
+ * provenance-injection class). Backslashes are escaped BEFORE quotes so an
+ * author `"` is not double-processed.
+ */
+function emitSafeDoubleQuotedScalar(value: string): string {
+  const oneLine = value.replace(/\r?\n/g, " ");
+  const escaped = oneLine.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  return `"${escaped}"`;
+}
+
+/**
+ * SKILL-03 class: set the frontmatter `description` to `value` by replacing the
+ * FULL `description` node span -- including a `>-` / `|` block scalar spanning
+ * several lines -- with a single safe double-quoted scalar, leaving every
+ * sibling key byte-identical. NEVER a lone `^description:.*$` line replace (that
+ * corrupts a multi-line block scalar by orphaning its continuation lines -- the
+ * SKILL-03 corruption class). `content` is the full source file (with `---`
+ * fences); the returned string is the same file with the description node
+ * rewritten. If no top-level `description:` key is present the content is
+ * returned unchanged.
+ *
+ * Node-span scan: locate the top-level (zero-indent) `description:` line. If its
+ * inline value is a block-scalar indicator (`>` / `|`, optionally with a chomp /
+ * indent modifier), consume the following continuation lines -- blank lines and
+ * lines indented under the key -- up to the last indented content line (trailing
+ * blank lines are left intact so inter-key spacing survives). The key line
+ * through that last continuation line are replaced by a single
+ * `description: "<escaped>"` line.
+ */
+export function setDescriptionScalar(content: string, value: string): string {
+  const lines = content.split("\n");
+
+  // The frontmatter block is between the opening `---` (line 0) and the next
+  // `---` line. Only scan for the key inside that block so a body line that
+  // happens to start with `description:` is never matched.
+  if (lines[0]?.trim() !== "---") {
+    return content;
+  }
+
+  let blockEnd = lines.length;
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i]!.trim() === "---") {
+      blockEnd = i;
+      break;
+    }
+  }
+
+  let keyIndex = -1;
+  for (let i = 1; i < blockEnd; i++) {
+    if (/^description:/.test(lines[i]!)) {
+      keyIndex = i;
+      break;
+    }
+  }
+
+  if (keyIndex === -1) {
+    return content;
+  }
+
+  const inlineValue = lines[keyIndex]!.slice("description:".length).trim();
+  const isBlockScalar = /^[>|]/.test(inlineValue);
+
+  let lastReplaced = keyIndex;
+  if (isBlockScalar) {
+    // Consume block-scalar continuation lines: blank or indented, up to (but not
+    // including) the next zero-indent key or the closing delimiter. Trailing
+    // blank lines are NOT absorbed -- lastReplaced tracks the last indented
+    // content line so inter-key blank spacing is preserved byte-for-byte.
+    for (let i = keyIndex + 1; i < blockEnd; i++) {
+      const line = lines[i]!;
+      if (line.trim() === "") {
+        continue;
+      }
+
+      if (/^\s/.test(line)) {
+        lastReplaced = i;
+        continue;
+      }
+
+      break;
+    }
+  }
+
+  const replacement = `description: ${emitSafeDoubleQuotedScalar(value)}`;
+  const rebuilt = [...lines.slice(0, keyIndex), replacement, ...lines.slice(lastReplaced + 1)];
+  return rebuilt.join("\n");
+}

--- a/extensions/pi-claude-marketplace/bridges/skills/frontmatter-degrade.ts
+++ b/extensions/pi-claude-marketplace/bridges/skills/frontmatter-degrade.ts
@@ -144,8 +144,8 @@ export function truncate1536(text: string): string {
  * author `"` is not double-processed.
  */
 function emitSafeDoubleQuotedScalar(value: string): string {
-  const oneLine = value.replace(/\r?\n/g, " ");
-  const escaped = oneLine.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  const oneLine = value.replaceAll(/\r?\n/g, " ");
+  const escaped = oneLine.replaceAll(/\\/g, String.raw`\\`).replaceAll(/"/g, '\\"');
   return `"${escaped}"`;
 }
 

--- a/extensions/pi-claude-marketplace/bridges/skills/frontmatter-degrade.ts
+++ b/extensions/pi-claude-marketplace/bridges/skills/frontmatter-degrade.ts
@@ -202,9 +202,11 @@ function descriptionValueEnd(lines: readonly string[], keyIndex: number, blockEn
  * corrupts a multi-line block scalar by orphaning its continuation lines -- the
  * SKILL-03 corruption class). `content` is the full source file (with `---`
  * fences); the returned string is the same file with the description node
- * rewritten. If no top-level `description:` key is present the content is
- * returned unchanged. Only the frontmatter block (opening `---` through the next
- * `---`) is scanned, so a body line starting with `description:` is never matched.
+ * rewritten. When no top-level `description:` key is present the scalar is
+ * INSERTED as the last frontmatter line (SKILL-02 fill for a description-less
+ * source). Only the frontmatter block (opening `---` through the next `---`) is
+ * scanned, so a body line starting with `description:` is never matched. Content
+ * without an opening `---` fence is returned unchanged.
  */
 export function setDescriptionScalar(content: string, value: string): string {
   const lines = content.split("\n");
@@ -222,12 +224,19 @@ export function setDescriptionScalar(content: string, value: string): string {
     }
   }
 
+  const replacement = `${DESCRIPTION_KEY} ${emitSafeDoubleQuotedScalar(value)}`;
+
+  // SKILL-02: a description-less source has no `description:` key to replace.
+  // Insert one as the last frontmatter line (just before the closing `---`),
+  // preserving sibling key order. Only reached when the augment arm has a
+  // non-empty value to fill; NREG-01 keeps a present-and-unchanged description
+  // out of this function entirely.
   if (keyIndex === -1) {
-    return content;
+    const rebuilt = [...lines.slice(0, blockEnd), replacement, ...lines.slice(blockEnd)];
+    return rebuilt.join("\n");
   }
 
   const lastReplaced = descriptionValueEnd(lines, keyIndex, blockEnd);
-  const replacement = `${DESCRIPTION_KEY} ${emitSafeDoubleQuotedScalar(value)}`;
   const rebuilt = [...lines.slice(0, keyIndex), replacement, ...lines.slice(lastReplaced + 1)];
   return rebuilt.join("\n");
 }

--- a/extensions/pi-claude-marketplace/bridges/skills/frontmatter-degrade.ts
+++ b/extensions/pi-claude-marketplace/bridges/skills/frontmatter-degrade.ts
@@ -145,7 +145,7 @@ export function truncate1536(text: string): string {
  */
 function emitSafeDoubleQuotedScalar(value: string): string {
   const oneLine = value.replaceAll(/\r?\n/g, " ");
-  const escaped = oneLine.replaceAll(/\\/g, String.raw`\\`).replaceAll(/"/g, '\\"');
+  const escaped = oneLine.replaceAll("\\", String.raw`\\`).replaceAll('"', String.raw`\"`);
   return `"${escaped}"`;
 }
 

--- a/extensions/pi-claude-marketplace/bridges/skills/frontmatter-degrade.ts
+++ b/extensions/pi-claude-marketplace/bridges/skills/frontmatter-degrade.ts
@@ -165,17 +165,20 @@ function frontmatterBlockEnd(lines: readonly string[]): number {
 
 /**
  * Given the `description` key line at `keyIndex`, return the index of the LAST
- * line its value spans: the key line itself for an inline scalar, or -- when the
- * inline value is a block-scalar indicator (`>` / `|`, optionally with a chomp /
- * indent modifier) -- the last indented continuation line. Trailing blank lines
- * are NOT absorbed so inter-key blank spacing is preserved byte-for-byte.
+ * line its value spans. A scalar value continues onto later lines for EVERY
+ * multi-line form -- block (`>` / `|`, optionally with a chomp / indent
+ * modifier), multi-line plain, and multi-line single/double-quoted -- and in all
+ * of them the continuation lines are indented deeper than the column-0 key.
+ * Absorb every indented (non-blank) continuation line up to `blockEnd`, stopping
+ * at the first line that returns to column 0 (the next top-level key or the
+ * closing fence). An inline scalar has no continuation, so the first following
+ * line is already at column 0 and the key line itself is returned. Detecting the
+ * FULL node span for all multi-line forms -- not just block scalars (CR-01) --
+ * prevents orphaned continuation lines that would make gate-2 reject the staged
+ * bytes. Trailing blank lines are NOT absorbed so inter-key blank spacing is
+ * preserved byte-for-byte.
  */
 function descriptionValueEnd(lines: readonly string[], keyIndex: number, blockEnd: number): number {
-  const inlineValue = (lines[keyIndex] ?? "").slice(DESCRIPTION_KEY.length).trim();
-  if (!/^[>|]/.test(inlineValue)) {
-    return keyIndex;
-  }
-
   let lastReplaced = keyIndex;
   for (let i = keyIndex + 1; i < blockEnd; i++) {
     const line = lines[i] ?? "";
@@ -196,11 +199,12 @@ function descriptionValueEnd(lines: readonly string[], keyIndex: number, blockEn
 
 /**
  * SKILL-03 class: set the frontmatter `description` to `value` by replacing the
- * FULL `description` node span -- including a `>-` / `|` block scalar spanning
- * several lines -- with a single safe double-quoted scalar, leaving every
- * sibling key byte-identical. NEVER a lone `^description:.*$` line replace (that
- * corrupts a multi-line block scalar by orphaning its continuation lines -- the
- * SKILL-03 corruption class). `content` is the full source file (with `---`
+ * FULL `description` node span -- including any multi-line scalar (block `>-` /
+ * `|`, multi-line plain, or multi-line quoted) spanning several lines -- with a
+ * single safe double-quoted scalar, leaving every sibling key byte-identical.
+ * NEVER a lone `^description:.*$` line replace (that corrupts a multi-line
+ * scalar by orphaning its continuation lines -- the SKILL-03 / CR-01 corruption
+ * class). `content` is the full source file (with `---`
  * fences); the returned string is the same file with the description node
  * rewritten. When no top-level `description:` key is present the scalar is
  * INSERTED as the last frontmatter line (SKILL-02 fill for a description-less

--- a/extensions/pi-claude-marketplace/bridges/skills/rewrite-frontmatter.ts
+++ b/extensions/pi-claude-marketplace/bridges/skills/rewrite-frontmatter.ts
@@ -30,18 +30,18 @@ function frontmatterBlockEnd(lines: readonly string[]): number {
 
 /**
  * Given the `name` key line at `keyIndex`, return the index of the LAST line its
- * value spans: the key line itself for an inline scalar, or -- when the inline
- * value is a block-scalar indicator (`>` / `|`, optionally with a chomp / indent
- * modifier) -- the last indented continuation line. Absorbing the continuation
- * lines is what prevents a folded source `name:` from leaving orphaned prose
- * (the SKILL-03 corruption class, e.g. `<gen> a b`).
+ * value spans. A scalar value continues onto later lines for EVERY multi-line
+ * form -- block (`>` / `|`, optionally with a chomp / indent modifier),
+ * multi-line plain, and multi-line single/double-quoted -- and in all of them
+ * the continuation lines are indented deeper than the column-0 key. Absorb every
+ * indented (non-blank) continuation line up to `blockEnd`, stopping at the first
+ * line that returns to column 0. An inline scalar has no continuation, so the
+ * key line itself is returned. Absorbing the full node span for all multi-line
+ * forms -- not just block scalars (WR-01) -- prevents a multi-line source `name:`
+ * from leaving orphaned prose that folds into the parsed name and trips the
+ * SKILL-03 verify (the corruption class, e.g. `<gen> a b`).
  */
 function nameValueEnd(lines: readonly string[], keyIndex: number, blockEnd: number): number {
-  const inlineValue = (lines[keyIndex] ?? "").slice(NAME_KEY.length).trim();
-  if (!/^[>|]/.test(inlineValue)) {
-    return keyIndex;
-  }
-
   let lastReplaced = keyIndex;
   for (let i = keyIndex + 1; i < blockEnd; i++) {
     const line = lines[i] ?? "";
@@ -63,8 +63,9 @@ function nameValueEnd(lines: readonly string[], keyIndex: number, blockEnd: numb
 /**
  * Replace (or insert) the `name` field inside a frontmatter block that opens on
  * `lines[0]` and closes at the next `---`. Replaces the FULL `name` node span --
- * including a folded (`>`) / literal (`|`) block scalar spanning several lines --
- * with a single inline `name: <newName>`, leaving every sibling key untouched.
+ * including any multi-line scalar (block `>` / `|`, multi-line plain, or
+ * multi-line quoted) spanning several lines -- with a single inline
+ * `name: <newName>`, leaving every sibling key untouched.
  * When no `name:` key exists it is inserted as the first frontmatter line.
  */
 function rewriteNameNode(content: string, newName: string): string {

--- a/extensions/pi-claude-marketplace/bridges/skills/rewrite-frontmatter.ts
+++ b/extensions/pi-claude-marketplace/bridges/skills/rewrite-frontmatter.ts
@@ -2,42 +2,126 @@
 //
 // SK-3: rewrite the `name:` field in a SKILL.md frontmatter block, preserve
 // every other frontmatter field, and add a frontmatter block when the source
-// file has none. Pure string manipulation -- no YAML parsing, no eval -- so
+// file has none. The rewrite is pure string manipulation -- no YAML eval -- so
 // untrusted plugin-author content cannot inject behavior (T-03-17 mitigation).
+// The only parse is a READ-ONLY backstop that VALIDATES the written name
+// (SKILL-03): parse-to-verify is not evaluating.
+
+import { parseFrontmatter } from "../../platform/pi-api.ts";
+
+/** The top-level frontmatter `name` key token (including its colon). */
+const NAME_KEY = "name:";
+
+/** A fresh `name`-only frontmatter block prepended ahead of `content`. */
+function freshBlock(newName: string, content: string): string {
+  return `---\nname: ${newName}\n---\n\n${content}`;
+}
+
+/** Index of the closing `---` fence (frontmatter block end), or `lines.length`. */
+function frontmatterBlockEnd(lines: readonly string[]): number {
+  for (let i = 1; i < lines.length; i++) {
+    if ((lines[i] ?? "").trim() === "---") {
+      return i;
+    }
+  }
+
+  return lines.length;
+}
+
+/**
+ * Given the `name` key line at `keyIndex`, return the index of the LAST line its
+ * value spans: the key line itself for an inline scalar, or -- when the inline
+ * value is a block-scalar indicator (`>` / `|`, optionally with a chomp / indent
+ * modifier) -- the last indented continuation line. Absorbing the continuation
+ * lines is what prevents a folded source `name:` from leaving orphaned prose
+ * (the SKILL-03 corruption class, e.g. `<gen> a b`).
+ */
+function nameValueEnd(lines: readonly string[], keyIndex: number, blockEnd: number): number {
+  const inlineValue = (lines[keyIndex] ?? "").slice(NAME_KEY.length).trim();
+  if (!/^[>|]/.test(inlineValue)) {
+    return keyIndex;
+  }
+
+  let lastReplaced = keyIndex;
+  for (let i = keyIndex + 1; i < blockEnd; i++) {
+    const line = lines[i] ?? "";
+    if (line.trim() === "") {
+      continue;
+    }
+
+    if (/^\s/.test(line)) {
+      lastReplaced = i;
+      continue;
+    }
+
+    break;
+  }
+
+  return lastReplaced;
+}
+
+/**
+ * Replace (or insert) the `name` field inside a frontmatter block that opens on
+ * `lines[0]` and closes at the next `---`. Replaces the FULL `name` node span --
+ * including a folded (`>`) / literal (`|`) block scalar spanning several lines --
+ * with a single inline `name: <newName>`, leaving every sibling key untouched.
+ * When no `name:` key exists it is inserted as the first frontmatter line.
+ */
+function rewriteNameNode(content: string, newName: string): string {
+  const lines = content.split("\n");
+  const blockEnd = frontmatterBlockEnd(lines);
+
+  let keyIndex = -1;
+  for (let i = 1; i < blockEnd; i++) {
+    if ((lines[i] ?? "").startsWith(NAME_KEY)) {
+      keyIndex = i;
+      break;
+    }
+  }
+
+  const replacement = `${NAME_KEY} ${newName}`;
+  if (keyIndex === -1) {
+    return [lines[0], replacement, ...lines.slice(1)].join("\n");
+  }
+
+  const lastReplaced = nameValueEnd(lines, keyIndex, blockEnd);
+  return [...lines.slice(0, keyIndex), replacement, ...lines.slice(lastReplaced + 1)].join("\n");
+}
 
 /**
  * Rewrite the `name:` field in a SKILL.md frontmatter block to `newName`.
  *
  * Behavior:
- *   - If `content` does not start with `---`, prepend a fresh frontmatter
- *     block with only `name: <newName>`.
- *   - If `content` starts with `---` but no closing `\n---` is found, treat
- *     it as malformed and prepend a fresh frontmatter block.
- *   - If a `name:` line exists in the frontmatter, replace it (multiline regex,
- *     anchored to line start).
- *   - If no `name:` line exists, prepend `\nname: <newName>` to the
- *     frontmatter body so all other fields survive.
+ *   - If `content` does not start with `---`, prepend a fresh frontmatter block
+ *     with only `name: <newName>`.
+ *   - If `content` starts with `---` but no closing `\n---` is found, treat it
+ *     as malformed and prepend a fresh frontmatter block.
+ *   - Otherwise replace the full `name` node span (folded / block scalars
+ *     included) with an inline `name: <newName>`, or insert one when absent, so
+ *     all other fields survive.
+ *
+ * SKILL-03 backstop: the result is re-parsed with Pi's own `parseFrontmatter`
+ * and the parsed `name` MUST equal `newName`; a mismatch is our own defect
+ * (never a silently wrong-named skill) and throws loudly.
  */
 export function rewriteFrontmatterName(content: string, newName: string): string {
-  if (!content.startsWith("---")) {
-    return `---\nname: ${newName}\n---\n\n${content}`;
-  }
-
-  const end = content.indexOf("\n---", 3);
-  if (end === -1) {
-    return `---\nname: ${newName}\n---\n\n${content}`;
-  }
-
-  const frontmatter = content.slice(3, end);
-  const body = content.slice(end + 4);
-  const nameRegex = /^name:.*$/m;
-
-  let newFrontmatter: string;
-  if (nameRegex.test(frontmatter)) {
-    newFrontmatter = frontmatter.replace(nameRegex, `name: ${newName}`);
+  let result: string;
+  if (!content.startsWith("---") || !content.includes("\n---", 3)) {
+    result = freshBlock(newName, content);
   } else {
-    newFrontmatter = `\nname: ${newName}` + frontmatter;
+    result = rewriteNameNode(content, newName);
   }
 
-  return `---${newFrontmatter}\n---${body}`;
+  // SKILL-03: verify the WRITTEN name against the re-parsed value, never a blind
+  // `^name:` line match -- a folded / multi-line source scalar cannot silently
+  // corrupt the generated name.
+  const { frontmatter } = parseFrontmatter(result);
+  if (frontmatter.name !== newName) {
+    throw new Error(
+      `Skill name rewrite produced ${JSON.stringify(frontmatter.name)}, ` +
+        `expected the generated name ${JSON.stringify(newName)}.`,
+    );
+  }
+
+  return result;
 }

--- a/extensions/pi-claude-marketplace/bridges/skills/stage.ts
+++ b/extensions/pi-claude-marketplace/bridges/skills/stage.ts
@@ -33,7 +33,13 @@ import { assertPathInside } from "../../shared/path-safety.ts";
 import { substituteClaudeVars } from "../../shared/vars.ts";
 
 import { discoverPluginSkills } from "./discover.ts";
-import { synthesizeUnparseableSkill } from "./frontmatter-degrade.ts";
+import {
+  firstBodyParagraph,
+  foldWhenToUse,
+  setDescriptionScalar,
+  synthesizeUnparseableSkill,
+  truncate1536,
+} from "./frontmatter-degrade.ts";
 import { rewriteFrontmatterName } from "./rewrite-frontmatter.ts";
 
 import type {
@@ -108,6 +114,55 @@ function extractBodyAfterFrontmatter(content: string): string {
   }
 
   return normalized.trim();
+}
+
+/**
+ * SKILL-02 empty probe: a well-formed skill with neither a `description` nor any
+ * prose body yields an empty first-paragraph candidate, and Pi drops a skill
+ * whose `description` is empty (`skill: null`). Emit a short fixed non-empty
+ * scalar so the skill still loads. Distinct from the unparseable-source
+ * placeholder (D-86-02): the frontmatter parsed cleanly here; only the
+ * description is absent.
+ */
+const MISSING_DESCRIPTION_PLACEHOLDER = "No description provided.";
+
+/**
+ * SKILL-02 / WTU-01 / WTU-02: augment the `description` on the well-formed
+ * (gate-1 RETURN) arm. Reads the PARSED `description` / `when_to_use` values and
+ * the parsed `body`:
+ *   - SKILL-02 / D-86-06: an absent or empty `description` is filled from the
+ *     first body paragraph (`firstBodyParagraph`); an empty candidate falls back
+ *     to a fixed non-empty placeholder so Pi still loads the skill.
+ *   - WTU-01 / A1: a non-empty `when_to_use` is folded in after a single `\n`.
+ *   - WTU-02 / D-86-05 / A2: the combined text is hard-cut at 1,536 code units
+ *     (never Pi's 1,024 warning threshold).
+ * The value is written back through `setDescriptionScalar` (full node-span
+ * replace + safe double-quoted scalar), so a `>-`/`|` block-scalar source
+ * `description` cannot be corrupted (the SKILL-03 class). NREG-01: when the
+ * effective value equals the source `description` AND no `when_to_use` was
+ * folded, the frontmatter is left byte-identical (no re-emit).
+ */
+function augmentSkillDescription(
+  content: string,
+  frontmatter: Record<string, unknown>,
+  body: string,
+): string {
+  const rawDescription = frontmatter.description;
+  const sourceDescription = typeof rawDescription === "string" ? rawDescription : "";
+  const rawWhenToUse = frontmatter.when_to_use;
+  const whenToUse = typeof rawWhenToUse === "string" ? rawWhenToUse : "";
+
+  const base = sourceDescription === "" ? firstBodyParagraph(body) : sourceDescription;
+  const folded = foldWhenToUse(base, whenToUse === "" ? undefined : whenToUse);
+  const effective = truncate1536(folded === "" ? MISSING_DESCRIPTION_PLACEHOLDER : folded);
+
+  // NREG-01: a present, in-cap `description` with no `when_to_use` is unchanged
+  // -- do NOT re-emit it as a double-quoted scalar (byte-for-byte invariant).
+  if (effective === sourceDescription) {
+    return content;
+  }
+
+  return setDescriptionScalar(content, effective);
 }
 
 /**
@@ -194,16 +249,15 @@ export async function prepareStageSkills(input: StageSkillsInput): Promise<Prepa
       // means a closed `---` block whose inner YAML is malformed (an author
       // defect); a RETURN (including absent/empty frontmatter) is the happy
       // arm. The parse is READ-ONLY -- validate, never eval (preserves T-03-17).
-      let sourceUnparseable = false;
+      let parsed: { frontmatter: Record<string, unknown>; body: string } | undefined;
       try {
-        parseFrontmatter(content);
+        parsed = parseFrontmatter(content);
       } catch (parseErr) {
         // SKILL-01 / D-86-02: unparseable source -> synthesize a known-good
         // `disable-model-invocation` block (body preserved verbatim) so the
         // skill still installs (no hard-fail), stays invocable by `/name`, and
         // is never auto-invoked. The actionable detail (plugin, component,
         // parse error) rides the install-time warning channel instead.
-        sourceUnparseable = true;
         content = synthesizeUnparseableSkill(
           extractBodyAfterFrontmatter(content),
           skill.generatedName,
@@ -214,12 +268,13 @@ export async function prepareStageSkills(input: StageSkillsInput): Promise<Prepa
         });
       }
 
-      // NREG-01: the parseable arm keeps today's SK-3 name rewrite byte-for-byte
-      // (the augment arm is layered on separately); the synthesized arm already
-      // emits the generated `name`, so it skips the rewrite. SK-4 substitution
-      // runs on both arms.
-      if (!sourceUnparseable) {
+      // The parseable (gate-1 RETURN) arm keeps today's SK-3 name rewrite, then
+      // layers the SKILL-02 / WTU-01 / WTU-02 augment arm on the parsed values;
+      // the synthesized arm already emits the generated `name` + a placeholder
+      // `description`, so it skips both. SK-4 substitution runs on both arms.
+      if (parsed !== undefined) {
         content = rewriteFrontmatterName(content, skill.generatedName);
+        content = augmentSkillDescription(content, parsed.frontmatter, parsed.body);
       }
 
       content = substituteClaudeVars(content, { pluginRoot, pluginData: pluginDataDir });

--- a/extensions/pi-claude-marketplace/bridges/skills/stage.ts
+++ b/extensions/pi-claude-marketplace/bridges/skills/stage.ts
@@ -106,7 +106,7 @@ export function assertNoSkillCollisions(discovered: readonly DiscoveredSkill[]):
  * normalized+trimmed content if no opening/closing delimiter is found.
  */
 function extractBodyAfterFrontmatter(content: string): string {
-  const normalized = content.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  const normalized = content.replaceAll(/\r\n/g, "\n").replaceAll(/\r/g, "\n");
   if (!normalized.startsWith("---")) {
     return normalized.trim();
   }

--- a/extensions/pi-claude-marketplace/bridges/skills/stage.ts
+++ b/extensions/pi-claude-marketplace/bridges/skills/stage.ts
@@ -106,7 +106,7 @@ export function assertNoSkillCollisions(discovered: readonly DiscoveredSkill[]):
  * normalized+trimmed content if no opening/closing delimiter is found.
  */
 function extractBodyAfterFrontmatter(content: string): string {
-  const normalized = content.replaceAll(/\r\n/g, "\n").replaceAll(/\r/g, "\n");
+  const normalized = content.replaceAll("\r\n", "\n").replaceAll("\r", "\n");
   if (!normalized.startsWith("---")) {
     return normalized.trim();
   }

--- a/extensions/pi-claude-marketplace/bridges/skills/stage.ts
+++ b/extensions/pi-claude-marketplace/bridges/skills/stage.ts
@@ -45,6 +45,7 @@ import { rewriteFrontmatterName } from "./rewrite-frontmatter.ts";
 import type {
   DiscoveredSkill,
   PreparedSkillsStaging,
+  SkillDegradeRecord,
   SkillsReplacement,
   StagedSkillRecord,
   StageSkillsInput,
@@ -92,28 +93,30 @@ export function assertNoSkillCollisions(discovered: readonly DiscoveredSkill[]):
 
 /**
  * SKILL-01: extract the markdown body from a skill source whose frontmatter
- * block failed to parse, reproducing `parseFrontmatter`'s body normalization
- * (CRLF->LF, then trimmed) so the synthesized block preserves the body
- * byte-for-byte identically to the parseable path (PARSE-01 encoding parity).
- * Called ONLY on the gate-1 throw arm, where a closed `---` block is present by
- * construction -- the body is everything after the closing delimiter. Falls
- * back to the whole normalized+trimmed content if no closing delimiter is found.
+ * block failed to parse, reproducing `parseFrontmatter`'s OWN split so the
+ * synthesized block preserves the body byte-for-byte identically to the
+ * parseable path (PARSE-01 encoding parity). Newlines are normalized (CR/CRLF ->
+ * LF, including lone CR) exactly as the parser does; the opening fence is the
+ * parser's anchored `---` prefix (`startsWith`, NOT a per-line `trim`); and the
+ * close is the parser's `\n---` prefix search. An exotic delimiter -- a `---x`
+ * line or an indented `---` -- is therefore classified identically to Pi rather
+ * than by a looser `line.trim() === "---"` match. Called ONLY on the gate-1
+ * throw arm, where a closed `---` block is present by construction -- the body
+ * is everything after the closing delimiter, trimmed. Falls back to the whole
+ * normalized+trimmed content if no opening/closing delimiter is found.
  */
 function extractBodyAfterFrontmatter(content: string): string {
-  const normalized = content.replace(/\r\n/g, "\n");
-  const lines = normalized.split("\n");
-  if (lines[0]?.trim() === "---") {
-    for (let i = 1; i < lines.length; i++) {
-      if (lines[i]?.trim() === "---") {
-        return lines
-          .slice(i + 1)
-          .join("\n")
-          .trim();
-      }
-    }
+  const normalized = content.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  if (!normalized.startsWith("---")) {
+    return normalized.trim();
   }
 
-  return normalized.trim();
+  const closeIndex = normalized.indexOf("\n---", 3);
+  if (closeIndex === -1) {
+    return normalized.trim();
+  }
+
+  return normalized.slice(closeIndex + 4).trim();
 }
 
 /**
@@ -146,6 +149,7 @@ function augmentSkillDescription(
   content: string,
   frontmatter: Record<string, unknown>,
   body: string,
+  vars: { pluginRoot: string; pluginData: string },
 ): string {
   const rawDescription = frontmatter.description;
   const sourceDescription = typeof rawDescription === "string" ? rawDescription : "";
@@ -154,10 +158,21 @@ function augmentSkillDescription(
 
   const base = sourceDescription === "" ? firstBodyParagraph(body) : sourceDescription;
   const folded = foldWhenToUse(base, whenToUse === "" ? undefined : whenToUse);
-  const effective = truncate1536(folded === "" ? MISSING_DESCRIPTION_PLACEHOLDER : folded);
+  // SK-4 / AG-8: substitute the Claude path vars BEFORE the value is escaped into
+  // the double-quoted scalar. The later whole-file `substituteClaudeVars` (below)
+  // would otherwise splice a Windows path's backslashes into the ALREADY-escaped
+  // scalar, forming an invalid `\U...`-class escape that fails the PARSE-02
+  // backstop; substituting first lets `emitSafeDoubleQuotedScalar` escape those
+  // backslashes. The cap is applied pre-substitution (the WTU-02 listing budget
+  // measures the authored text), matching the prior whole-file ordering.
+  const effective = substituteClaudeVars(
+    truncate1536(folded === "" ? MISSING_DESCRIPTION_PLACEHOLDER : folded),
+    vars,
+  );
 
-  // NREG-01: a present, in-cap `description` with no `when_to_use` is unchanged
-  // -- do NOT re-emit it as a double-quoted scalar (byte-for-byte invariant).
+  // NREG-01: a present, in-cap `description` with no `when_to_use` and no path
+  // var to expand is unchanged -- do NOT re-emit it as a double-quoted scalar
+  // (byte-for-byte invariant).
   if (effective === sourceDescription) {
     return content;
   }
@@ -217,7 +232,7 @@ export async function prepareStageSkills(input: StageSkillsInput): Promise<Prepa
   const renamePairs: { from: string; to: string }[] = [];
   const stagedNames: string[] = [];
   const recorded: StagedSkillRecord[] = [];
-  const degraded: { generatedName: string; parseError: string }[] = [];
+  const degraded: SkillDegradeRecord[] = [];
 
   try {
     for (const skill of discovered) {
@@ -274,7 +289,10 @@ export async function prepareStageSkills(input: StageSkillsInput): Promise<Prepa
       // `description`, so it skips both. SK-4 substitution runs on both arms.
       if (parsed !== undefined) {
         content = rewriteFrontmatterName(content, skill.generatedName);
-        content = augmentSkillDescription(content, parsed.frontmatter, parsed.body);
+        content = augmentSkillDescription(content, parsed.frontmatter, parsed.body, {
+          pluginRoot,
+          pluginData: pluginDataDir,
+        });
       }
 
       content = substituteClaudeVars(content, { pluginRoot, pluginData: pluginDataDir });

--- a/extensions/pi-claude-marketplace/bridges/skills/stage.ts
+++ b/extensions/pi-claude-marketplace/bridges/skills/stage.ts
@@ -21,6 +21,7 @@ import { cp, mkdir, readFile, rename, rm, stat, writeFile } from "node:fs/promis
 import path from "node:path";
 
 import { assertSafeName } from "../../domain/name.ts";
+import { parseFrontmatter } from "../../platform/pi-api.ts";
 import { appendLeakToError, errorMessage, ManualRecoveryError } from "../../shared/errors.ts";
 import {
   cleanupStaging,
@@ -32,6 +33,7 @@ import { assertPathInside } from "../../shared/path-safety.ts";
 import { substituteClaudeVars } from "../../shared/vars.ts";
 
 import { discoverPluginSkills } from "./discover.ts";
+import { synthesizeUnparseableSkill } from "./frontmatter-degrade.ts";
 import { rewriteFrontmatterName } from "./rewrite-frontmatter.ts";
 
 import type {
@@ -83,6 +85,32 @@ export function assertNoSkillCollisions(discovered: readonly DiscoveredSkill[]):
 }
 
 /**
+ * SKILL-01: extract the markdown body from a skill source whose frontmatter
+ * block failed to parse, reproducing `parseFrontmatter`'s body normalization
+ * (CRLF->LF, then trimmed) so the synthesized block preserves the body
+ * byte-for-byte identically to the parseable path (PARSE-01 encoding parity).
+ * Called ONLY on the gate-1 throw arm, where a closed `---` block is present by
+ * construction -- the body is everything after the closing delimiter. Falls
+ * back to the whole normalized+trimmed content if no closing delimiter is found.
+ */
+function extractBodyAfterFrontmatter(content: string): string {
+  const normalized = content.replace(/\r\n/g, "\n");
+  const lines = normalized.split("\n");
+  if (lines[0]?.trim() === "---") {
+    for (let i = 1; i < lines.length; i++) {
+      if (lines[i]?.trim() === "---") {
+        return lines
+          .slice(i + 1)
+          .join("\n")
+          .trim();
+      }
+    }
+  }
+
+  return normalized.trim();
+}
+
+/**
  * Phase-1 of the skills bridge two-phase commit:
  *   1. Discover skills in the source plugin (SK-5).
  *   2. Refuse on RN-6 collisions.
@@ -122,6 +150,7 @@ export async function prepareStageSkills(input: StageSkillsInput): Promise<Prepa
         stagedNames: Object.freeze([]),
         recorded: Object.freeze([]),
         warnings: Object.freeze([...discoverWarnings]),
+        degraded: Object.freeze([]),
       },
     };
   }
@@ -133,6 +162,7 @@ export async function prepareStageSkills(input: StageSkillsInput): Promise<Prepa
   const renamePairs: { from: string; to: string }[] = [];
   const stagedNames: string[] = [];
   const recorded: StagedSkillRecord[] = [];
+  const degraded: { generatedName: string; parseError: string }[] = [];
 
   try {
     for (const skill of discovered) {
@@ -156,12 +186,50 @@ export async function prepareStageSkills(input: StageSkillsInput): Promise<Prepa
         force: false,
       });
 
-      // SK-3 rewrite + SK-4 substitute on the SKILL.md only.
       const skillMdPath = path.join(stagedDir, "SKILL.md");
       let content = await readFile(skillMdPath, "utf8");
-      content = rewriteFrontmatterName(content, skill.generatedName);
+
+      // PARSE-01: parse the SOURCE frontmatter BEFORE any rewrite/substitution
+      // to establish attribution ground truth and the degrade trigger. A THROW
+      // means a closed `---` block whose inner YAML is malformed (an author
+      // defect); a RETURN (including absent/empty frontmatter) is the happy
+      // arm. The parse is READ-ONLY -- validate, never eval (preserves T-03-17).
+      let sourceUnparseable = false;
+      try {
+        parseFrontmatter(content);
+      } catch (parseErr) {
+        // SKILL-01 / D-86-02: unparseable source -> synthesize a known-good
+        // `disable-model-invocation` block (body preserved verbatim) so the
+        // skill still installs (no hard-fail), stays invocable by `/name`, and
+        // is never auto-invoked. The actionable detail (plugin, component,
+        // parse error) rides the install-time warning channel instead.
+        sourceUnparseable = true;
+        content = synthesizeUnparseableSkill(
+          extractBodyAfterFrontmatter(content),
+          skill.generatedName,
+        );
+        degraded.push({
+          generatedName: skill.generatedName,
+          parseError: errorMessage(parseErr),
+        });
+      }
+
+      // NREG-01: the parseable arm keeps today's SK-3 name rewrite byte-for-byte
+      // (the augment arm is layered on separately); the synthesized arm already
+      // emits the generated `name`, so it skips the rewrite. SK-4 substitution
+      // runs on both arms.
+      if (!sourceUnparseable) {
+        content = rewriteFrontmatterName(content, skill.generatedName);
+      }
+
       content = substituteClaudeVars(content, { pluginRoot, pluginData: pluginDataDir });
       await writeFile(skillMdPath, content, "utf8");
+
+      // PARSE-02 / D-86-04: re-parse the STAGED bytes as a Pi-acceptability
+      // backstop. A THROW here means our OWN rewrite/substitution produced
+      // bytes Pi would reject -- our defect, not the author's. Throw loudly so
+      // it rides the cleanup catch below; never mask it as author degradation.
+      parseFrontmatter(content);
 
       renamePairs.push({ from: stagedDir, to: targetDir });
       stagedNames.push(skill.generatedName);
@@ -183,6 +251,7 @@ export async function prepareStageSkills(input: StageSkillsInput): Promise<Prepa
       stagedNames: Object.freeze(stagedNames),
       recorded: Object.freeze(recorded),
       warnings: Object.freeze([...discoverWarnings]),
+      degraded: Object.freeze(degraded),
     },
     _previousNames: Object.freeze(previousNames),
     _renamePairs: Object.freeze(renamePairs),

--- a/extensions/pi-claude-marketplace/bridges/skills/types.ts
+++ b/extensions/pi-claude-marketplace/bridges/skills/types.ts
@@ -51,6 +51,15 @@ export interface StagedSkillRecord {
   readonly targetPath: string;
 }
 
+/**
+ * SKILL-01 / PARSE-01: one record per skill whose SOURCE frontmatter could not
+ * be parsed and was synthesized into a `disable-model-invocation` block.
+ */
+export interface SkillDegradeRecord {
+  readonly generatedName: string;
+  readonly parseError: string;
+}
+
 /** Result returned by `commitPreparedSkills` and embedded in the noop variant. */
 export interface StageSkillsCommitResult {
   readonly stagedNames: readonly string[];
@@ -58,12 +67,10 @@ export interface StageSkillsCommitResult {
   readonly recorded: readonly StagedSkillRecord[];
   readonly warnings: readonly string[];
   /**
-   * SKILL-01 / PARSE-01: one record per skill whose SOURCE frontmatter could
-   * not be parsed and was synthesized into a `disable-model-invocation` block.
    * The orchestrator maps these to the `{malformed skill}` reason token and the
    * per-component parse-error detail line. Empty on the all-valid path (NREG-01).
    */
-  readonly degraded: readonly { generatedName: string; parseError: string }[];
+  readonly degraded: readonly SkillDegradeRecord[];
 }
 
 /** `prepareStageSkills` returns a discriminated union; orchestrators MUST narrow on `kind`. */

--- a/extensions/pi-claude-marketplace/bridges/skills/types.ts
+++ b/extensions/pi-claude-marketplace/bridges/skills/types.ts
@@ -57,6 +57,13 @@ export interface StageSkillsCommitResult {
   /** W-05: callers read `recorded` to populate state.json. */
   readonly recorded: readonly StagedSkillRecord[];
   readonly warnings: readonly string[];
+  /**
+   * SKILL-01 / PARSE-01: one record per skill whose SOURCE frontmatter could
+   * not be parsed and was synthesized into a `disable-model-invocation` block.
+   * The orchestrator maps these to the `{malformed skill}` reason token and the
+   * per-component parse-error detail line. Empty on the all-valid path (NREG-01).
+   */
+  readonly degraded: readonly { generatedName: string; parseError: string }[];
 }
 
 /** `prepareStageSkills` returns a discriminated union; orchestrators MUST narrow on `kind`. */

--- a/extensions/pi-claude-marketplace/orchestrators/plugin/install.ts
+++ b/extensions/pi-claude-marketplace/orchestrators/plugin/install.ts
@@ -122,7 +122,11 @@ import {
 } from "../../shared/errors.ts";
 import { classifyGitTransportFailure } from "../../shared/git-failure-classifiers.ts";
 import { notifyWithContext } from "../../shared/notify-context.ts";
-import { companionSeverity } from "../../shared/notify-reasons.ts";
+import {
+  companionSeverity,
+  malformedReasonsForKinds,
+  type DegradeKind,
+} from "../../shared/notify-reasons.ts";
 import { notify } from "../../shared/notify.ts";
 import { PathContainmentError } from "../../shared/path-safety.ts";
 import { narrowUnsupportedKinds } from "../../shared/probe-classifiers.ts";
@@ -231,7 +235,7 @@ export type InstallPluginOutcome =
        * `{malformed skill}` / `{malformed command}` token onto its installed
        * row. Absent when nothing degraded.
        */
-      readonly degradedKinds?: readonly ("skill" | "command")[];
+      readonly degradedKinds?: readonly DegradeKind[];
     }
   | {
       /**
@@ -386,7 +390,7 @@ interface InstallCtx {
   // the per-component parse-error detail (orchestrated postCommitWarnings), and
   // the `degradedKinds` outcome seam the reconcile composer consumes.
   frontmatterDegradations: {
-    kind: "skill" | "command";
+    kind: DegradeKind;
     generatedName: string;
     parseError: string;
   }[];
@@ -940,8 +944,7 @@ export async function runInstallLedger(
       c.commandsPrep = prep;
       // Set before commit for the same reason as stagedSkillNames above.
       c.stagedCommandNames = prep.result.recorded.map((r) => r.generatedName);
-      // CMD-01 / WARN-01: collect per-command degrade records (inert until the
-      // command neutralize arm populates `prep.result.degraded`).
+      // CMD-01 / WARN-01: collect per-command frontmatter degrade records.
       for (const d of prep.result.degraded) {
         c.frontmatterDegradations.push({ kind: "command", ...d });
       }
@@ -1759,13 +1762,9 @@ export async function installPlugin(opts: InstallPluginOptions): Promise<Install
     // (mirrors orphan rewake's one-row-per-plugin). The free-text parse-error
     // detail rode postCommitWarnings above (orchestrated only). Reasons share
     // the brace block with any companion soft-dep markers per MSG-GR-4.
-    if (installCtx.frontmatterDegradations.some((d) => d.kind === "skill")) {
-      reasons.push("malformed skill");
-    }
-
-    if (installCtx.frontmatterDegradations.some((d) => d.kind === "command")) {
-      reasons.push("malformed command");
-    }
+    reasons.push(
+      ...malformedReasonsForKinds(installCtx.frontmatterDegradations.map((d) => d.kind)),
+    );
 
     // FSTAT-07 / D-66-04: when the live resolved state is `partially-available`, the
     // install was partially completed with one or more components dropped -- the

--- a/extensions/pi-claude-marketplace/orchestrators/plugin/install.ts
+++ b/extensions/pi-claude-marketplace/orchestrators/plugin/install.ts
@@ -224,6 +224,14 @@ export type InstallPluginOutcome =
       readonly declaresMcp: boolean;
       /** Post-commit warnings collected in orchestrated mode instead of firing individually. */
       readonly postCommitWarnings?: readonly string[];
+      /**
+       * WARN-01 / D-86-03: the component kinds that degraded on a
+       * frontmatter-parse failure (synthesized skill / neutralized command).
+       * The orchestrated reconcile composer reads this to push the
+       * `{malformed skill}` / `{malformed command}` token onto its installed
+       * row. Absent when nothing degraded.
+       */
+      readonly degradedKinds?: readonly ("skill" | "command")[];
     }
   | {
       /**
@@ -372,6 +380,16 @@ interface InstallCtx {
   bridgeWarnings: string[];
   // Bridge-side per-record AG-5 foreign-content rows -- routed to notifyWarning post-success.
   agentForeignFailures: { generatedName: string; reason: string }[];
+  // SKILL-01 / CMD-01 / WARN-01: per-component frontmatter-parse degrade records
+  // collected from the skills + commands bridges. Feed the one-per-plugin
+  // `{malformed skill}` / `{malformed command}` reason token (standalone row),
+  // the per-component parse-error detail (orchestrated postCommitWarnings), and
+  // the `degradedKinds` outcome seam the reconcile composer consumes.
+  frontmatterDegradations: {
+    kind: "skill" | "command";
+    generatedName: string;
+    parseError: string;
+  }[];
   // Mutable handle to the state snapshot loaded by the caller's locked transaction.
   readonly stateSnapshot: ExtensionState;
 }
@@ -863,6 +881,7 @@ export async function runInstallLedger(
     stagedMcpServerNames: [],
     bridgeWarnings: [],
     agentForeignFailures: [],
+    frontmatterDegradations: [],
     stateSnapshot: state,
   };
 
@@ -883,6 +902,11 @@ export async function runInstallLedger(
       // Set before commit so undo can remove any dirs that were placed if
       // commit fails mid-loop (partial rename success leaves K orphans).
       c.stagedSkillNames = prep.result.recorded.map((r) => r.generatedName);
+      // SKILL-01 / WARN-01: collect per-skill frontmatter degrade records.
+      for (const d of prep.result.degraded) {
+        c.frontmatterDegradations.push({ kind: "skill", ...d });
+      }
+
       const leak = await commitPreparedSkills(prep);
       if (leak !== undefined) {
         c.bridgeWarnings.push(leak);
@@ -916,6 +940,12 @@ export async function runInstallLedger(
       c.commandsPrep = prep;
       // Set before commit for the same reason as stagedSkillNames above.
       c.stagedCommandNames = prep.result.recorded.map((r) => r.generatedName);
+      // CMD-01 / WARN-01: collect per-command degrade records (inert until the
+      // command neutralize arm populates `prep.result.degraded`).
+      for (const d of prep.result.degraded) {
+        c.frontmatterDegradations.push({ kind: "command", ...d });
+      }
+
       const leak = await commitPreparedCommands(prep);
       if (leak !== undefined) {
         c.bridgeWarnings.push(leak);
@@ -1645,6 +1675,20 @@ export async function installPlugin(opts: InstallPluginOptions): Promise<Install
     // else: D-19-01 -- dropped in standalone mode.
   }
 
+  // WARN-01 / D-86-03: skills/commands whose SOURCE frontmatter could not be
+  // parsed were degraded (synthesized / neutralized) but still installed. The
+  // per-component `<plugin>/<component>: <parse error>` detail rides
+  // postCommitWarnings (orchestrated only, per D-19-01); the closed-set reason
+  // token rides the install row below. Standalone drops the detail exactly like
+  // agentForeignFailures.
+  for (const d of installCtx.frontmatterDegradations) {
+    const msg = `${plugin}/${d.generatedName}: ${d.parseError}`;
+    if (orchestrated) {
+      postCommitWarnings.push(msg);
+    }
+    // else: D-19-01 -- dropped in standalone mode.
+  }
+
   // Bridge-side soft warnings (e.g. agents bridge cleanup-leak return
   // values aggregated during the staged phases). The standalone-mode
   // user-visible warning is DROPPED per D-19-01: bridge-side soft
@@ -1710,6 +1754,19 @@ export async function installPlugin(opts: InstallPluginOptions): Promise<Install
       reasons.push("orphan rewake");
     }
 
+    // WARN-01 / D-86-03: one `{malformed skill}` / `{malformed command}` token
+    // per plugin regardless of how many components of that kind degraded
+    // (mirrors orphan rewake's one-row-per-plugin). The free-text parse-error
+    // detail rode postCommitWarnings above (orchestrated only). Reasons share
+    // the brace block with any companion soft-dep markers per MSG-GR-4.
+    if (installCtx.frontmatterDegradations.some((d) => d.kind === "skill")) {
+      reasons.push("malformed skill");
+    }
+
+    if (installCtx.frontmatterDegradations.some((d) => d.kind === "command")) {
+      reasons.push("malformed command");
+    }
+
     // FSTAT-07 / D-66-04: when the live resolved state is `partially-available`, the
     // install was partially completed with one or more components dropped -- the
     // success row reports `(partially-installed)` carrying the dropped-component
@@ -1734,13 +1791,19 @@ export async function installPlugin(opts: InstallPluginOptions): Promise<Install
     // gains the warning summary line). A loaded companion -- or no declared
     // companion -- keeps the info stamp. Applies to BOTH the clean `installed`
     // and degraded `partially-installed` success arms.
-    const successSeverity = companionSeverity(
-      {
-        declaresAgents: installCtx.stagedAgentNames.length > 0,
-        declaresMcp: installCtx.stagedMcpServerNames.length > 0,
-      },
-      softDepStatus(pi),
-    );
+    // SEV-01 / WARN-01: a degraded-but-installed component (synthesized skill /
+    // neutralized command) is "carried out but short of ideal" -> warning,
+    // independent of companion state. Otherwise the companion probe decides.
+    const successSeverity =
+      installCtx.frontmatterDegradations.length > 0
+        ? "warning"
+        : companionSeverity(
+            {
+              declaresAgents: installCtx.stagedAgentNames.length > 0,
+              declaresMcp: installCtx.stagedMcpServerNames.length > 0,
+            },
+            softDepStatus(pi),
+          );
     const installedRow: InstallMsg =
       installCtx.resolved.state === "partially-available"
         ? {
@@ -1776,12 +1839,18 @@ export async function installPlugin(opts: InstallPluginOptions): Promise<Install
     ]);
   }
 
+  // WARN-01 / D-86-03: the inert seam the orchestrated reconcile composer reads
+  // to push the row token. Set of degraded kinds (skill before command by
+  // collection order), omitted when nothing degraded.
+  const degradedKinds = Array.from(new Set(installCtx.frontmatterDegradations.map((d) => d.kind)));
+
   return {
     status: "installed",
     resourcesChanged: stagedAny,
     declaresAgents: installCtx.stagedAgentNames.length > 0,
     declaresMcp: installCtx.stagedMcpServerNames.length > 0,
     ...(postCommitWarnings.length > 0 && { postCommitWarnings }),
+    ...(degradedKinds.length > 0 && { degradedKinds }),
   };
 }
 

--- a/extensions/pi-claude-marketplace/orchestrators/reconcile/apply-outcomes.ts
+++ b/extensions/pi-claude-marketplace/orchestrators/reconcile/apply-outcomes.ts
@@ -24,6 +24,7 @@
 // field the renderer reads.
 
 import type { Dependency } from "../../shared/concerns/soft-dep.ts";
+import type { DegradeKind } from "../../shared/notify-reasons.ts";
 import type { ContentReason, Reason } from "../../shared/notify.ts";
 import type { Scope } from "../../shared/types.ts";
 
@@ -104,7 +105,7 @@ export interface PluginInstalledOutcome extends PluginOutcomeBase {
    * supported components. Omitted when empty so a clean install renders
    * byte-identically (NREG-01).
    */
-  readonly degradedKinds?: readonly ("skill" | "command")[];
+  readonly degradedKinds?: readonly DegradeKind[];
 }
 
 /**

--- a/extensions/pi-claude-marketplace/orchestrators/reconcile/apply-outcomes.ts
+++ b/extensions/pi-claude-marketplace/orchestrators/reconcile/apply-outcomes.ts
@@ -92,6 +92,19 @@ export interface PluginInstalledOutcome extends PluginOutcomeBase {
    * surfacing channel.
    */
   readonly postCommitWarnings?: readonly string[];
+  /**
+   * WARN-01 / CLASS-01 / D-86-03: the degraded-component kinds whose SOURCE
+   * frontmatter could not be parsed by Pi's own `parseFrontmatter` but which
+   * still installed in degraded form. Propagated verbatim from
+   * `InstallPluginOutcome.degradedKinds`. The reconcile `plugin-installed`
+   * arm reads this to push one `malformed skill` / `malformed command` token
+   * per kind onto the `(installed)` row and raise that row from `info` to
+   * `warning` severity. A degraded-but-installed component keeps the
+   * `(installed)` row -- NOT `(partially-installed)`, which is for DROPPED
+   * supported components. Omitted when empty so a clean install renders
+   * byte-identically (NREG-01).
+   */
+  readonly degradedKinds?: readonly ("skill" | "command")[];
 }
 
 /**

--- a/extensions/pi-claude-marketplace/orchestrators/reconcile/apply.ts
+++ b/extensions/pi-claude-marketplace/orchestrators/reconcile/apply.ts
@@ -599,6 +599,15 @@ async function applyPluginInstalls(
             result.postCommitWarnings.length > 0 && {
               postCommitWarnings: result.postCommitWarnings,
             }),
+          // WARN-01 / D-86-03: propagate the degraded-component kinds so the
+          // reconcile composer can raise the `(installed)` row to `warning`
+          // and push the `malformed skill` / `malformed command` token.
+          // Omitted when empty (NREG-01), mirroring the postCommitWarnings
+          // conditional spread above.
+          ...(result.degradedKinds !== undefined &&
+            result.degradedKinds.length > 0 && {
+              degradedKinds: result.degradedKinds,
+            }),
         });
       } else {
         outcomes.push({
@@ -1368,7 +1377,7 @@ async function rebuildScopeRoutingTableIsolated(
   }
 }
 
-function surfacePostCommitWarnings(
+export function surfacePostCommitWarnings(
   opts: ApplyReconcileOptions,
   outcomes: readonly PerEntryOutcome[],
 ): void {
@@ -1379,7 +1388,11 @@ function surfacePostCommitWarnings(
     }
 
     for (const w of o.postCommitWarnings) {
-      lines.push(w);
+      // T-86-03 / NFR-9: collapse any absolute source path embedded in a
+      // frontmatter parse-error detail (or any other post-commit warning) to
+      // its basename before it reaches the operator-facing notifyDiagnostic
+      // surface -- surface message text only, never a leaked filesystem path.
+      lines.push(redactAbsolutePaths(w));
     }
   }
 

--- a/extensions/pi-claude-marketplace/orchestrators/reconcile/notify.ts
+++ b/extensions/pi-claude-marketplace/orchestrators/reconcile/notify.ts
@@ -47,7 +47,7 @@ import { narrowUnsupportedKinds } from "../../shared/probe-classifiers.ts";
 import { sourceMismatchOutcomeSubject } from "./apply-outcomes.ts";
 import { plannedSourceMismatchSubject } from "./types.ts";
 
-import type { PerEntryOutcome } from "./apply-outcomes.ts";
+import type { PerEntryOutcome, PluginInstalledOutcome } from "./apply-outcomes.ts";
 import type { PendingMsg, ReconcileAppliedMsg } from "./reconcile.messaging.ts";
 import type { PlannedPluginInstall, ReconcilePlan } from "./types.ts";
 import type { MarketplaceManifest } from "../../domain/manifest.ts";
@@ -56,6 +56,7 @@ import type {
   ContentReason,
   MarketplaceNotificationMessage,
   MarketplaceStatus,
+  PluginInstalledMessage,
   PluginNotificationMessage,
   Reason,
   ReconcileAppliedCascadeMessage,
@@ -471,6 +472,58 @@ export function isReconcilePlanListEmpty(plans: readonly ReconcilePlan[]): boole
  * declaresMcp). The reverse asymmetry (a successful disable maps to
  * `disabled`) is structural: `disabled` IS a member of PLUGIN_STATUSES.
  */
+/**
+ * WARN-01 / CLASS-01 / D-86-03: map the degraded-component kinds onto the
+ * closed-set `(installed)`-row reason tokens -- one `malformed skill` /
+ * `malformed command` per kind regardless of how many components of that kind
+ * degraded (one-token-per-kind-per-plugin, mirroring the orphan-rewake
+ * one-per-plugin row token). Empty in / empty out so a clean install carries
+ * no reasons brace (NREG-01).
+ */
+function degradedKindReasons(
+  degradedKinds: readonly ("skill" | "command")[] | undefined,
+): readonly ContentReason[] {
+  if (degradedKinds === undefined || degradedKinds.length === 0) {
+    return [];
+  }
+
+  const reasons: ContentReason[] = [];
+  if (degradedKinds.includes("skill")) {
+    reasons.push("malformed skill");
+  }
+
+  if (degradedKinds.includes("command")) {
+    reasons.push("malformed command");
+  }
+
+  return reasons;
+}
+
+/**
+ * Build the `(installed)` row for a realized reconcile install.
+ *
+ * WARN-01 / CLASS-01 / D-86-03: a skill/command whose source frontmatter could
+ * not be parsed installs in DEGRADED form -- the row keeps status `installed`
+ * (NOT `(partially-installed)`, which is for DROPPED supported components) but
+ * raises to `warning` and carries one `malformed skill` / `malformed command`
+ * token per kind. A clean install (no degradedKinds) is byte-identical to
+ * today: `info`, no reasons brace (NREG-01). The reconcile-applied cascade
+ * suppresses the /reload trailer at the kind level (RECON-04), so `needsReload`
+ * never surfaces a hint.
+ */
+function installedRowFromOutcome(outcome: PluginInstalledOutcome): PluginInstalledMessage {
+  const degradedReasons = degradedKindReasons(outcome.degradedKinds);
+  return {
+    status: "installed",
+    name: outcome.plugin,
+    ...(outcome.version !== undefined && { version: outcome.version }),
+    dependencies: outcome.dependencies,
+    ...(degradedReasons.length > 0 && { reasons: degradedReasons }),
+    severity: degradedReasons.length > 0 ? "warning" : "info",
+    needsReload: true,
+  };
+}
+
 function applyOutcomeToBlock(
   block: MarketplaceBlock<ReconcileAppliedMsg>,
   outcome: PerEntryOutcome,
@@ -495,17 +548,9 @@ function applyOutcomeToBlock(
       block.status = "failed";
       return;
     case "plugin-installed":
-      block.plugins.push({
-        status: "installed",
-        name: outcome.plugin,
-        ...(outcome.version !== undefined && { version: outcome.version }),
-        dependencies: outcome.dependencies,
-        // D-03/D-06: realized install transition -> info, reloads. (The
-        // reconcile-applied cascade still suppresses the /reload trailer at the
-        // kind level -- RECON-04 -- so this needsReload never surfaces a hint.)
-        severity: "info",
-        needsReload: true,
-      });
+      // D-03/D-06 realized install row; WARN-01 / D-86-03 raises it to warning
+      // with the failure-class token when the outcome carries degradedKinds.
+      block.plugins.push(installedRowFromOutcome(outcome));
       return;
     case "plugin-backfilled":
       // BFILL-01 / D-68-04: a load-time backfill re-materialized the plugin in

--- a/extensions/pi-claude-marketplace/orchestrators/reconcile/notify.ts
+++ b/extensions/pi-claude-marketplace/orchestrators/reconcile/notify.ts
@@ -41,6 +41,7 @@
 
 import { resolveStrict } from "../../domain/resolver.ts";
 import { assertNever } from "../../shared/errors.ts";
+import { malformedReasonsForKinds } from "../../shared/notify-reasons.ts";
 import { compareByNameThenScope } from "../../shared/notify.ts";
 import { narrowUnsupportedKinds } from "../../shared/probe-classifiers.ts";
 
@@ -473,33 +474,6 @@ export function isReconcilePlanListEmpty(plans: readonly ReconcilePlan[]): boole
  * `disabled`) is structural: `disabled` IS a member of PLUGIN_STATUSES.
  */
 /**
- * WARN-01 / CLASS-01 / D-86-03: map the degraded-component kinds onto the
- * closed-set `(installed)`-row reason tokens -- one `malformed skill` /
- * `malformed command` per kind regardless of how many components of that kind
- * degraded (one-token-per-kind-per-plugin, mirroring the orphan-rewake
- * one-per-plugin row token). Empty in / empty out so a clean install carries
- * no reasons brace (NREG-01).
- */
-function degradedKindReasons(
-  degradedKinds: readonly ("skill" | "command")[] | undefined,
-): readonly ContentReason[] {
-  if (degradedKinds === undefined || degradedKinds.length === 0) {
-    return [];
-  }
-
-  const reasons: ContentReason[] = [];
-  if (degradedKinds.includes("skill")) {
-    reasons.push("malformed skill");
-  }
-
-  if (degradedKinds.includes("command")) {
-    reasons.push("malformed command");
-  }
-
-  return reasons;
-}
-
-/**
  * Build the `(installed)` row for a realized reconcile install.
  *
  * WARN-01 / CLASS-01 / D-86-03: a skill/command whose source frontmatter could
@@ -512,7 +486,7 @@ function degradedKindReasons(
  * never surfaces a hint.
  */
 function installedRowFromOutcome(outcome: PluginInstalledOutcome): PluginInstalledMessage {
-  const degradedReasons = degradedKindReasons(outcome.degradedKinds);
+  const degradedReasons = malformedReasonsForKinds(outcome.degradedKinds);
   return {
     status: "installed",
     name: outcome.plugin,

--- a/extensions/pi-claude-marketplace/platform/pi-api.ts
+++ b/extensions/pi-claude-marketplace/platform/pi-api.ts
@@ -14,6 +14,29 @@
 
 export { getAgentDir } from "@earendil-works/pi-coding-agent";
 
+/**
+ * PARSE-01: Pi's own frontmatter parser, surfaced here as the ONLY sanctioned
+ * import site so the skills/commands staging gates accept/reject bytes with
+ * byte-identical semantics to Pi's skill and command loaders. Signature:
+ * `<T extends Record<string, unknown>>(content: string) => { frontmatter: T;
+ * body: string }`.
+ *
+ * Verified throw/return semantics (drive the gate branch logic):
+ *  - content NOT starting with the `---` delimiter -> `{ frontmatter: {}, body }`
+ *    (NO throw) -- the SKILL-02 empty-metadata / first-paragraph-fallback branch.
+ *  - an opening `---` with NO closing `\n---` -> `{ frontmatter: {}, body }`
+ *    (NO throw) -- also an empty-metadata result, never a degrade trigger.
+ *  - a CLOSED `---` block whose inner YAML is malformed -> THROWS (via
+ *    `yaml.parse`) -- the SKILL-01 synthesize / CMD-01 neutralize degrade trigger.
+ *  - the returned `body` is CRLF->LF normalized; on the frontmatter-present
+ *    path it is additionally `.trim()`ed (the no-delimiter path leaves the body
+ *    normalized-but-untrimmed).
+ *
+ * READ-ONLY use only: extract field values, never `eval`/execute (preserves the
+ * T-03-17 injection-safety property -- reading-to-validate is not evaluating).
+ */
+export { parseFrontmatter } from "@earendil-works/pi-coding-agent";
+
 export type {
   BeforeAgentStartEvent,
   BeforeAgentStartEventResult,

--- a/extensions/pi-claude-marketplace/platform/pi-api.ts
+++ b/extensions/pi-claude-marketplace/platform/pi-api.ts
@@ -28,7 +28,7 @@ export { getAgentDir } from "@earendil-works/pi-coding-agent";
  *    (NO throw) -- also an empty-metadata result, never a degrade trigger.
  *  - a CLOSED `---` block whose inner YAML is malformed -> THROWS (via
  *    `yaml.parse`) -- the SKILL-01 synthesize / CMD-01 neutralize degrade trigger.
- *  - the returned `body` is CRLF->LF normalized; on the frontmatter-present
+ *  - the returned `body` is CR/CRLF->LF normalized; on the frontmatter-present
  *    path it is additionally `.trim()`ed (the no-delimiter path leaves the body
  *    normalized-but-untrimmed).
  *

--- a/extensions/pi-claude-marketplace/shared/extension-version.ts
+++ b/extensions/pi-claude-marketplace/shared/extension-version.ts
@@ -13,4 +13,4 @@
 // Consumed by the load-time backfill version gate: it is compared against the
 // persisted `lastReconciledExtensionVersion` stamp to decide whether the
 // supported-kind boundary may have moved since the last reconcile.
-export const EXTENSION_VERSION = "0.11.0";
+export const EXTENSION_VERSION = "0.11.1";

--- a/extensions/pi-claude-marketplace/shared/notify-reasons.ts
+++ b/extensions/pi-claude-marketplace/shared/notify-reasons.ts
@@ -113,6 +113,13 @@ export const FAILURE_REASONS = [
   // unsupported -- it is a malformation of a SUPPORTED feature the resolver
   // parses, so it lives here and NOT in UNSUPPORTED_REASONS.
   "malformed mcp",
+  // CLASS-01 / D-86-01: a skill / command whose source frontmatter could not be
+  // parsed by Pi's own `parseFrontmatter`. Failure-class (a malformation of a
+  // SUPPORTED component the skills/commands bridges stage), NOT unsupported --
+  // the exact `malformed mcp` classification precedent, split per-kind for
+  // truthful attribution.
+  "malformed skill",
+  "malformed command",
   "not in manifest",
   "rollback partial",
   "lock held",

--- a/extensions/pi-claude-marketplace/shared/notify-reasons.ts
+++ b/extensions/pi-claude-marketplace/shared/notify-reasons.ts
@@ -4,14 +4,14 @@ import type { SoftDepStatus } from "../platform/pi-api.ts";
 /**
  * shared/notify-reasons.ts -- the topic-grouped organization of the closed
  * reasons set (D-09). The byte-critical runtime tuple `REASONS` stays declared
- * in `notify.ts` as the SINGLE source of catalog truth (OUT-08: the 35-entry
+ * in `notify.ts` as the SINGLE source of catalog truth (OUT-08: the 37-entry
  * membership AND order must stay byte-identical for catalog stability); this
  * module reorganizes that closed set into shared topic-grouped enums + a
  * structural completeness proof WITHOUT recomposing the `REASONS` tuple (which
  * would risk reordering). The topic groups below are typed views over the same
  * closed `Reason` literals, so a command module can reference an
  * intent-meaningful group (e.g. the failure-class reasons) instead of the flat
- * 35-entry set.
+ * 37-entry set.
  *
  * Each group uses the `as const` tuple + `(typeof X)[number]` literal-union
  * idiom. Membership of every literal is checked at compile time against the

--- a/extensions/pi-claude-marketplace/shared/notify-reasons.ts
+++ b/extensions/pi-claude-marketplace/shared/notify-reasons.ts
@@ -135,6 +135,50 @@ export const FAILURE_REASONS = [
 export type FailureReason = (typeof FAILURE_REASONS)[number];
 
 /**
+ * WARN-01 / CLASS-01 / D-86-03: a component kind that installs in DEGRADED form
+ * when its SOURCE frontmatter cannot be parsed by Pi's own `parseFrontmatter`
+ * (skill -> synthesized `disable-model-invocation` block; command -> neutralized
+ * frontmatter). Both surfaces map a degraded kind to its `(installed)`-row reason
+ * token through `malformedReasonsForKinds`.
+ */
+export type DegradeKind = "skill" | "command";
+
+/**
+ * The closed map from a degraded component kind to its one failure-class token.
+ * A `Record<DegradeKind, FailureReason>` (via `satisfies`) so a new kind added to
+ * `DegradeKind` fails to compile here until it is given a token -- the single
+ * exhaustiveness guard replacing the two hand-maintained per-kind `if` ladders
+ * the install and reconcile surfaces used to keep in sync by convention.
+ */
+const MALFORMED_REASON_BY_KIND = {
+  skill: "malformed skill",
+  command: "malformed command",
+} as const satisfies Record<DegradeKind, FailureReason>;
+
+/** Canonical emit order for the per-kind tokens: skill before command. */
+const DEGRADE_KIND_ORDER = ["skill", "command"] as const satisfies readonly DegradeKind[];
+
+/**
+ * WARN-01 / CLASS-01 / D-86-03: map degraded component kinds onto ordered,
+ * de-duplicated `(installed)`-row reason tokens -- one `malformed skill` /
+ * `malformed command` per kind regardless of how many components of that kind
+ * degraded, and regardless of duplicate or unordered input. Empty / absent in
+ * -> empty out, so a clean install carries no reasons brace (NREG-01).
+ */
+export function malformedReasonsForKinds(
+  kinds: Iterable<DegradeKind> | undefined,
+): readonly FailureReason[] {
+  if (kinds === undefined) {
+    return [];
+  }
+
+  const present = new Set(kinds);
+  return DEGRADE_KIND_ORDER.filter((kind) => present.has(kind)).map(
+    (kind) => MALFORMED_REASON_BY_KIND[kind],
+  );
+}
+
+/**
  * D-09: the shared topic-grouped reasons -- the union of the three groups
  * above. Command-private reasons (`duplicate name` / `stale clone` for
  * `marketplace add`, `not found` / `not installed` for `uninstall`,

--- a/extensions/pi-claude-marketplace/shared/notify.ts
+++ b/extensions/pi-claude-marketplace/shared/notify.ts
@@ -77,7 +77,8 @@ import type { Dependency } from "./concerns/soft-dep.ts";
  * at column 0 with severity `"error"`.
  *
  * D-09 / OUT-08: this tuple is the byte-source of the closed set -- its
- * 35-entry membership AND order are catalog-stable and MUST NOT change. The
+ * 37-entry membership AND order are catalog-stable and MUST NOT change (new
+ * tokens append at the tail; existing entries never reorder). The
  * topic-grouped organization of these literals (idempotent / unsupported-
  * components / failure-class shared groups, plus the command-private reasons)
  * lives in `shared/notify-reasons.ts` as typed VIEWS over this set; that module
@@ -149,6 +150,21 @@ export const REASONS = [
   // `narrowResolverNotes` against the resolver's `malformed mcp reference:`
   // note prefix.
   "malformed mcp",
+  // CLASS-01 / D-86-01: a SKILL whose source frontmatter could not be parsed by
+  // Pi's own `parseFrontmatter` (a malformation of a SUPPORTED component the
+  // skills bridge actively stages). A failure-class member (sibling to
+  // `malformed mcp`), NOT an unsupported KIND; a dedicated per-kind token so the
+  // operator sees WHICH component kind malformed. The token rides the plugin's
+  // `(installed)` row (the skill still installs in degraded form) at `warning`
+  // severity, one per plugin; the per-component parse detail rides the
+  // post-cascade `notifyDiagnostic` channel.
+  "malformed skill",
+  // CLASS-01 / D-86-01: a COMMAND whose source frontmatter could not be parsed
+  // by Pi's own `parseFrontmatter`. The command-kind sibling of `malformed
+  // skill` -- same failure-class classification and `(installed)`-row / one-per-
+  // plugin surfacing; a dedicated token rather than a shared bucket so the reason
+  // row names the malformed component kind truthfully.
+  "malformed command",
 ] as const;
 
 export type Reason = (typeof REASONS)[number];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-claude-marketplace",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-claude-marketplace",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "license": "MIT",
       "dependencies": {
         "isomorphic-git": "^1.38.1",

--- a/package.json
+++ b/package.json
@@ -90,5 +90,5 @@
     "typecheck": "tsc --noEmit"
   },
   "type": "module",
-  "version": "0.11.0"
+  "version": "0.11.1"
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,7 +4,7 @@ sonar.organization=acolomba
 
 # Project metadata.
 sonar.projectName=Pi Claude Marketplace
-sonar.projectVersion=0.11.0
+sonar.projectVersion=0.11.1
 
 # Source code settings.
 sonar.sources=extensions/pi-claude-marketplace

--- a/tests/architecture/notify-closed-set-locks.test.ts
+++ b/tests/architecture/notify-closed-set-locks.test.ts
@@ -26,11 +26,13 @@ import {
   STATUS_TOKENS,
 } from "../../extensions/pi-claude-marketplace/shared/notify.ts";
 
-test("OUT-08: REASONS is the closed 35-entry reason set", () => {
+test("OUT-08: REASONS is the closed 37-entry reason set", () => {
   // D-76-08: +1 for the `authentication required` failure-class member (32 -> 33).
   // PURL-06: +1 for the `dangling reference` failure-class member (33 -> 34).
   // MCPR-03 / D-02: +1 for the malformed mcp failure-class member (34 -> 35).
-  assert.equal(REASONS.length, 35);
+  // CLASS-01 / D-86-01: +2 for the per-kind `malformed skill` / `malformed
+  // command` failure-class members (35 -> 37).
+  assert.equal(REASONS.length, 37);
 });
 
 test("SNM-02: STATUS_TOKENS is the closed 24-entry token set", () => {

--- a/tests/bridges/_fixtures/skill-block-scalar-description/SKILL.md
+++ b/tests/bridges/_fixtures/skill-block-scalar-description/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: block-desc
+description: >-
+  This is a folded block scalar description
+  that spans several source lines and must be
+  replaced as a whole node span.
+version: 2.3.1
+tags: alpha, beta
+---
+
+# Block Scalar Skill
+
+Body prose.

--- a/tests/bridges/_fixtures/skill-heading-codeblock-body/SKILL.md
+++ b/tests/bridges/_fixtures/skill-heading-codeblock-body/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: heading-code
+---
+
+# A Leading Heading
+
+```bash
+echo "this fenced block must be skipped"
+# a comment that looks like a heading but is inside the fence
+```
+
+The first genuine prose paragraph after the heading and code block.
+Second line of that same paragraph.
+
+Trailing paragraph that is not part of the first.

--- a/tests/bridges/_fixtures/skill-no-description/SKILL.md
+++ b/tests/bridges/_fixtures/skill-no-description/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: no-desc
+version: 1.0.0
+---
+
+# No Description Here
+
+This is the first real body paragraph that the fallback should pick up.
+It continues on a second line of the same paragraph.
+
+A later paragraph that must NOT be captured.

--- a/tests/bridges/_fixtures/unparseable-command-plugin/commands/bad-command.md
+++ b/tests/bridges/_fixtures/unparseable-command-plugin/commands/bad-command.md
@@ -1,0 +1,6 @@
+---
+title: Deploy: the whole thing
+description: never reached
+---
+
+Run the deployment for ${CLAUDE_PLUGIN_ROOT}.

--- a/tests/bridges/_fixtures/unparseable-skill-plugin/skills/bad-skill/SKILL.md
+++ b/tests/bridges/_fixtures/unparseable-skill-plugin/skills/bad-skill/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: [unterminated
+description: never reached
+---
+
+# Bad Skill
+
+This body must survive verbatim.

--- a/tests/bridges/commands/stage.test.ts
+++ b/tests/bridges/commands/stage.test.ts
@@ -14,6 +14,7 @@ import {
   rollbackCommandsReplacement,
 } from "../../../extensions/pi-claude-marketplace/bridges/commands/stage.ts";
 import { locationsFor } from "../../../extensions/pi-claude-marketplace/persistence/locations.ts";
+import { parseFrontmatter } from "../../../extensions/pi-claude-marketplace/platform/pi-api.ts";
 import { pathExists } from "../../../extensions/pi-claude-marketplace/shared/fs-utils.ts";
 
 import type { DiscoveredCommand } from "../../../extensions/pi-claude-marketplace/bridges/commands/types.ts";
@@ -24,6 +25,12 @@ import type { ScopedLocations } from "../../../extensions/pi-claude-marketplace/
 
 const FIXTURE_PLUGIN_ROOT = path.resolve(import.meta.dirname, "..", "_fixtures", "test-plugin");
 const FIXTURE_EMPTY_MCP_ROOT = path.resolve(import.meta.dirname, "..", "_fixtures", "empty-mcp");
+const FIXTURE_UNPARSEABLE_COMMAND_ROOT = path.resolve(
+  import.meta.dirname,
+  "..",
+  "_fixtures",
+  "unparseable-command-plugin",
+);
 
 interface TmpScope {
   loc: ScopedLocations;
@@ -798,6 +805,100 @@ test("TR-06 replacePreparedCommands tolerates owned orphan file from prior parti
       replacedBody.length > 0 && !replacedBody.includes("orphan-prompt"),
       "replacement body must not contain the orphan bytes",
     );
+  } finally {
+    await scope.cleanup();
+  }
+});
+
+// CMD-01 / PARSE-01 / PARSE-02 neutralize arm --------------------------
+
+test("CMD-01 / PARSE-01 unparseable command source -> neutralized (whole frontmatter block stripped), degrade record", async () => {
+  const scope = await tmpScope();
+
+  try {
+    const pluginRoot = FIXTURE_UNPARSEABLE_COMMAND_ROOT;
+    const prepared = await prepareStageCommands({
+      locations: scope.loc,
+      marketplaceName: "test-mp",
+      pluginName: "acme",
+      pluginRoot,
+      pluginDataDir: "/tmp/pi-data/test-mp/acme",
+      resolved: makeResolved(pluginRoot, "commands"),
+    });
+    assert.equal(prepared.kind, "staged");
+
+    // Degrade record: exactly one, carrying the generated name + a non-empty
+    // parse error (the actionable detail the install warning surfaces).
+    assert.equal(prepared.result.degraded.length, 1);
+    const record = prepared.result.degraded[0];
+    assert.ok(record, "expected one degrade record");
+    assert.equal(record.generatedName, "acme:bad-command");
+    assert.ok(record.parseError.length > 0, "parse error must be non-empty");
+
+    await commitPreparedCommands(prepared);
+
+    // name-from-filename: the target basename (minus .md) is what Pi's command
+    // loader uses as the command name.
+    const target = path.join(scope.loc.promptsTargetDir, "acme:bad-command.md");
+    assert.equal(await pathExists(target), true);
+    const staged = await readFile(target, "utf8");
+
+    // The entire malformed `---`...`---` block is gone -- no frontmatter, and
+    // none of the ex-frontmatter text survives as a poor first-body-line.
+    assert.ok(!staged.startsWith("---"), "staged output must not open a frontmatter block");
+    assert.ok(!staged.includes("title: Deploy"), "ex-frontmatter junk must not survive");
+    assert.ok(!staged.includes("never reached"), "ex-frontmatter junk must not survive");
+
+    // The real body is intact and is what Pi reads for its first-body-line
+    // description (name-from-filename + description-from-first-body-line).
+    const firstBodyLine = staged.split("\n").find((line) => line.trim());
+    assert.equal(firstBodyLine, `Run the deployment for ${pluginRoot}.`);
+
+    // No synthesized placeholder description and no disable flag -- that is the
+    // skills degrade shape, not the command one (Pi's command loader has no
+    // non-empty-description gate).
+    assert.ok(!/^description:/m.test(staged), "commands get no synthesized description");
+    assert.ok(!staged.includes("disable-model-invocation"), "commands get no disable flag");
+
+    // Substitution ran on the neutralized body.
+    assert.ok(!staged.includes("${CLAUDE_PLUGIN_ROOT}"), "substitution must run on the body");
+    assert.ok(staged.includes(pluginRoot), "substituted pluginRoot must appear in the body");
+
+    // PARSE-02 gate-2 parity: the neutralized staged bytes re-parse (do NOT
+    // throw) and return empty frontmatter -- Pi accepts them.
+    assert.doesNotThrow(() => parseFrontmatter(staged));
+    assert.deepEqual(parseFrontmatter(staged).frontmatter, {});
+  } finally {
+    await scope.cleanup();
+  }
+});
+
+test("NREG-01 valid command is staged byte-for-byte identical except variable substitution (gates mutate nothing)", async () => {
+  const scope = await tmpScope();
+
+  try {
+    const pluginRoot = FIXTURE_PLUGIN_ROOT;
+    const prepared = await prepareStageCommands({
+      locations: scope.loc,
+      marketplaceName: "test-mp",
+      pluginName: "acme",
+      pluginRoot,
+      pluginDataDir: "/tmp/pi-data/test-mp/acme",
+      resolved: makeResolved(pluginRoot, "commands"),
+    });
+    // The all-valid path degrades nothing.
+    assert.equal(prepared.result.degraded.length, 0);
+
+    await commitPreparedCommands(prepared);
+
+    // Build the expected bytes with an INDEPENDENT literal string replacement
+    // -- NOT the production substitute helper -- so the assertion proves the
+    // read-only gates introduced no reformatting or re-quoting.
+    const source = await readFile(path.join(pluginRoot, "commands", "acme-deploy.md"), "utf8");
+    const expected = source.replaceAll("${CLAUDE_PLUGIN_ROOT}", pluginRoot);
+
+    const staged = await readFile(path.join(scope.loc.promptsTargetDir, "acme:deploy.md"), "utf8");
+    assert.equal(staged, expected);
   } finally {
     await scope.cleanup();
   }

--- a/tests/bridges/commands/stage.test.ts
+++ b/tests/bridges/commands/stage.test.ts
@@ -903,3 +903,121 @@ test("NREG-01 valid command is staged byte-for-byte identical except variable su
     await scope.cleanup();
   }
 });
+
+test("CMD-01 lone-CR (\\r-only) unparseable command source degrades instead of hard-failing (line-ending parity with parseFrontmatter)", async () => {
+  const scope = await tmpScope();
+  const srcRoot = await mkdtemp(path.join(os.tmpdir(), "cmd-cr-src-"));
+
+  try {
+    // A classic-Mac (lone-CR) source whose closed `---` block holds malformed
+    // YAML. parseFrontmatter normalizes CR->LF, sees the closed block, and
+    // THROWS -- so neutralize must normalize CR too and find the SAME close,
+    // rather than missing it (raw `\n---` search) and leaving the malformed
+    // block intact for gate-2 to reject and hard-fail the whole install.
+    await mkdir(path.join(srcRoot, "commands"), { recursive: true });
+    const loneCr =
+      "---\rtitle: Deploy: the whole thing\rdescription: never reached\r---\r\rRun it.\r";
+    await writeFile(path.join(srcRoot, "commands", "cr-command.md"), loneCr);
+
+    const prepared = await prepareStageCommands({
+      locations: scope.loc,
+      marketplaceName: "test-mp",
+      pluginName: "acme",
+      pluginRoot: srcRoot,
+      pluginDataDir: "/tmp/pi-data/test-mp/acme",
+      resolved: makeResolved(srcRoot, "commands"),
+    });
+    // Degrade, not hard-fail: staging succeeds with exactly one degrade record.
+    assert.equal(prepared.kind, "staged");
+    assert.equal(prepared.result.degraded.length, 1);
+
+    await commitPreparedCommands(prepared);
+    const staged = await readFile(
+      path.join(scope.loc.promptsTargetDir, "acme:cr-command.md"),
+      "utf8",
+    );
+    // The malformed block is stripped and the neutralized bytes re-parse clean.
+    assert.ok(!staged.startsWith("---"), "frontmatter block must be stripped");
+    assert.ok(!staged.includes("never reached"), "ex-frontmatter junk must not survive");
+    assert.doesNotThrow(() => parseFrontmatter(staged));
+    assert.deepEqual(parseFrontmatter(staged).frontmatter, {});
+  } finally {
+    await rm(srcRoot, { recursive: true, force: true });
+    await scope.cleanup();
+  }
+});
+
+test("CMD-01 command whose body opens with a SECOND malformed block degrades (loop strips both) instead of hard-failing", async () => {
+  const scope = await tmpScope();
+  const srcRoot = await mkdtemp(path.join(os.tmpdir(), "cmd-stacked-src-"));
+
+  try {
+    // Two stacked malformed `---`...`---` blocks. Stripping only the first would
+    // leave the body opening with the second malformed block, which the PARSE-02
+    // backstop would reject -> a hard-fail. The neutralize loop must strip both.
+    await mkdir(path.join(srcRoot, "commands"), { recursive: true });
+    const stacked = "---\nalpha: one: two\n---\n---\nbeta: three: four\n---\nReal body here.\n";
+    await writeFile(path.join(srcRoot, "commands", "two-blocks.md"), stacked);
+
+    const prepared = await prepareStageCommands({
+      locations: scope.loc,
+      marketplaceName: "test-mp",
+      pluginName: "acme",
+      pluginRoot: srcRoot,
+      pluginDataDir: "/tmp/pi-data/test-mp/acme",
+      resolved: makeResolved(srcRoot, "commands"),
+    });
+    // Degrade, not hard-fail: ONE degrade record for the command (per-command,
+    // regardless of how many nested blocks were stripped).
+    assert.equal(prepared.kind, "staged");
+    assert.equal(prepared.result.degraded.length, 1);
+
+    await commitPreparedCommands(prepared);
+    const staged = await readFile(
+      path.join(scope.loc.promptsTargetDir, "acme:two-blocks.md"),
+      "utf8",
+    );
+    assert.ok(!staged.startsWith("---"), "both malformed blocks must be stripped");
+    assert.ok(!staged.includes("alpha:"), "first ex-frontmatter block must not survive");
+    assert.ok(!staged.includes("beta:"), "second ex-frontmatter block must not survive");
+    assert.ok(staged.includes("Real body here."), "the real body must survive");
+    assert.doesNotThrow(() => parseFrontmatter(staged));
+    assert.deepEqual(parseFrontmatter(staged).frontmatter, {});
+  } finally {
+    await rm(srcRoot, { recursive: true, force: true });
+    await scope.cleanup();
+  }
+});
+
+test("CMD-01 frontmatter-only malformed command with no trailing newline neutralizes to empty (afterClose === -1 branch)", async () => {
+  const scope = await tmpScope();
+  const srcRoot = await mkdtemp(path.join(os.tmpdir(), "cmd-fmonly-src-"));
+
+  try {
+    // A closed malformed block with NO body and NO trailing newline: the close
+    // `---` is the last line, so the "\n after the close" lookup returns -1 and
+    // neutralize yields "" (rather than slicing out of range).
+    await mkdir(path.join(srcRoot, "commands"), { recursive: true });
+    const frontmatterOnly = "---\nbad: a: b\n---";
+    await writeFile(path.join(srcRoot, "commands", "fm-only.md"), frontmatterOnly);
+
+    const prepared = await prepareStageCommands({
+      locations: scope.loc,
+      marketplaceName: "test-mp",
+      pluginName: "acme",
+      pluginRoot: srcRoot,
+      pluginDataDir: "/tmp/pi-data/test-mp/acme",
+      resolved: makeResolved(srcRoot, "commands"),
+    });
+    assert.equal(prepared.kind, "staged");
+    assert.equal(prepared.result.degraded.length, 1);
+
+    await commitPreparedCommands(prepared);
+    const staged = await readFile(path.join(scope.loc.promptsTargetDir, "acme:fm-only.md"), "utf8");
+    assert.equal(staged, "");
+    assert.doesNotThrow(() => parseFrontmatter(staged));
+  } finally {
+    await rm(srcRoot, { recursive: true, force: true });
+    await scope.cleanup();
+  }
+});

--- a/tests/bridges/skills/frontmatter-degrade.test.ts
+++ b/tests/bridges/skills/frontmatter-degrade.test.ts
@@ -1,0 +1,182 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import {
+  firstBodyParagraph,
+  foldWhenToUse,
+  setDescriptionScalar,
+  synthesizeUnparseableSkill,
+  truncate1536,
+} from "../../../extensions/pi-claude-marketplace/bridges/skills/frontmatter-degrade.ts";
+import { parseFrontmatter } from "../../../extensions/pi-claude-marketplace/platform/pi-api.ts";
+
+// Resolve fixture root relative to THIS file (worktree-safe; do NOT use cwd).
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURES = path.resolve(__dirname, "..", "_fixtures");
+
+function readFixture(dir: string): Promise<string> {
+  return readFile(path.join(FIXTURES, dir, "SKILL.md"), "utf8");
+}
+
+// ---------------------------------------------------------------------------
+// SKILL-01: synthesizeUnparseableSkill
+// ---------------------------------------------------------------------------
+
+test("SKILL-01: synthesizeUnparseableSkill emits a disable-model-invocation block with the generated name and the body verbatim", () => {
+  const body = "# Real Body\n\nThe original markdown, preserved verbatim.\n";
+  const out = synthesizeUnparseableSkill(body, "acme-helper");
+
+  // The synthesized block re-parses cleanly via Pi's own parser.
+  const { frontmatter, body: parsedBody } = parseFrontmatter<{
+    name: string;
+    description: string;
+    "disable-model-invocation": boolean;
+  }>(out);
+  assert.equal(frontmatter.name, "acme-helper");
+  assert.equal(typeof frontmatter.description, "string");
+  assert.ok(frontmatter.description.length > 0, "placeholder description must be non-empty");
+  assert.equal(frontmatter["disable-model-invocation"], true);
+
+  // Body is preserved verbatim (the parser trims, so compare against trimmed).
+  assert.equal(parsedBody, body.trim());
+  // The raw output carries the body bytes unchanged after the closing delimiter.
+  assert.ok(out.endsWith(body), "body must be appended verbatim");
+});
+
+// ---------------------------------------------------------------------------
+// SKILL-02 / D-86-06: firstBodyParagraph
+// ---------------------------------------------------------------------------
+
+test("SKILL-02 / D-86-06: firstBodyParagraph skips blank lines, ATX headings, and fenced code blocks, then returns the first prose paragraph", async () => {
+  const { body } = parseFrontmatter(await readFixture("skill-heading-codeblock-body"));
+  const para = firstBodyParagraph(body);
+  assert.equal(
+    para,
+    "The first genuine prose paragraph after the heading and code block.\nSecond line of that same paragraph.",
+  );
+});
+
+test("SKILL-02 / D-86-06: firstBodyParagraph stops at the first blank line (does not run into a later paragraph)", async () => {
+  const { body } = parseFrontmatter(await readFixture("skill-no-description"));
+  const para = firstBodyParagraph(body);
+  assert.equal(
+    para,
+    "This is the first real body paragraph that the fallback should pick up.\nIt continues on a second line of the same paragraph.",
+  );
+  assert.ok(!para.includes("later paragraph"), "must not capture a later paragraph");
+});
+
+test("SKILL-02: firstBodyParagraph returns empty string for a body with no prose", () => {
+  assert.equal(firstBodyParagraph(""), "");
+  assert.equal(firstBodyParagraph("\n\n   \n"), "");
+  assert.equal(firstBodyParagraph("# Only a heading\n\n## Another heading\n"), "");
+  assert.equal(firstBodyParagraph("```\nonly a fence\n```\n"), "");
+});
+
+// ---------------------------------------------------------------------------
+// WTU-01: foldWhenToUse
+// ---------------------------------------------------------------------------
+
+test("WTU-01: foldWhenToUse with an empty or absent when_to_use returns the description unchanged (no trailing separator)", () => {
+  assert.equal(foldWhenToUse("a description", ""), "a description");
+  assert.equal(foldWhenToUse("a description", undefined), "a description");
+  // No trailing newline introduced.
+  assert.ok(!foldWhenToUse("a description", "").endsWith("\n"));
+});
+
+test("WTU-01 (A1): foldWhenToUse joins description and when_to_use with a single \\n separator", () => {
+  assert.equal(foldWhenToUse("desc", "use when X"), "desc\nuse when X");
+});
+
+test("WTU-01: foldWhenToUse operates on JS string .length (UTF-16 code units) with no byte reinterpretation", () => {
+  // A non-BMP emoji is two UTF-16 code units; the fold must not reinterpret it.
+  const desc = "d\u{1F600}"; // "d" + emoji
+  const wtu = "w";
+  const folded = foldWhenToUse(desc, wtu);
+  assert.equal(folded, `${desc}\n${wtu}`);
+  assert.equal(folded.length, desc.length + 1 + wtu.length);
+});
+
+// ---------------------------------------------------------------------------
+// WTU-02 (A2): truncate1536
+// ---------------------------------------------------------------------------
+
+test("WTU-02: truncate1536 leaves text of length <= 1536 unchanged", () => {
+  const at1535 = "a".repeat(1535);
+  const at1536 = "a".repeat(1536);
+  assert.equal(truncate1536(at1535), at1535);
+  assert.equal(truncate1536(at1536), at1536);
+  assert.equal(truncate1536(at1536).length, 1536);
+});
+
+test("WTU-02: truncate1536 hard-cuts a 1537-char string to exactly 1536 code units (no ellipsis)", () => {
+  const at1537 = "b".repeat(1537);
+  const cut = truncate1536(at1537);
+  assert.equal(cut.length, 1536);
+  assert.equal(cut, "b".repeat(1536));
+  assert.ok(!cut.endsWith("..."), "no ellipsis on a hard cut");
+});
+
+test("WTU-02: truncate1536 measures 1536 in UTF-16 code units", () => {
+  // 768 non-BMP emoji = 1536 UTF-16 code units exactly -> unchanged.
+  const exactly1536 = "\u{1F600}".repeat(768);
+  assert.equal(exactly1536.length, 1536);
+  assert.equal(truncate1536(exactly1536), exactly1536);
+  // One more emoji pushes to 1538 code units -> cut at 1536.
+  const over = "\u{1F600}".repeat(769);
+  assert.equal(truncate1536(over).length, 1536);
+});
+
+test("WTU-02: truncate1536 on empty combined text returns empty without crashing", () => {
+  assert.equal(truncate1536(""), "");
+});
+
+// ---------------------------------------------------------------------------
+// SKILL-03 class: setDescriptionScalar (full node-span replacement)
+// ---------------------------------------------------------------------------
+
+test("SKILL-03: setDescriptionScalar replaces a `>-` block-scalar description with a single safe scalar and leaves sibling keys unchanged", async () => {
+  const source = await readFixture("skill-block-scalar-description");
+  const out = setDescriptionScalar(source, "A single-line replacement description.");
+
+  const { frontmatter } = parseFrontmatter<{
+    name: string;
+    description: string;
+    version: string;
+    tags: string;
+  }>(out);
+  assert.equal(frontmatter.description, "A single-line replacement description.");
+  // Sibling keys survive the node-span replacement intact.
+  assert.equal(frontmatter.name, "block-desc");
+  assert.equal(frontmatter.version, "2.3.1");
+  assert.equal(frontmatter.tags, "alpha, beta");
+
+  // The multi-line block-scalar continuation lines are gone (no orphaned prose).
+  assert.ok(!out.includes("spans several source lines"), "old scalar body must be removed");
+});
+
+test("SKILL-03: setDescriptionScalar replaces an inline description without touching siblings", () => {
+  const source = "---\nname: inline\ndescription: old inline value\nversion: 9.9.9\n---\n\nBody.\n";
+  const out = setDescriptionScalar(source, "new value");
+  const { frontmatter } = parseFrontmatter<{ name: string; description: string; version: string }>(
+    out,
+  );
+  assert.equal(frontmatter.description, "new value");
+  assert.equal(frontmatter.name, "inline");
+  assert.equal(frontmatter.version, "9.9.9");
+});
+
+test("SKILL-03 (AG-8 class): setDescriptionScalar emits an author value as a safe double-quoted scalar that cannot re-form a new YAML key", () => {
+  const source = "---\nname: safe\ndescription: placeholder\n---\n\nBody.\n";
+  // A value containing a colon+newline that, emitted naively, would re-form a
+  // sibling key. The safe emitter must collapse the newline and quote it.
+  const hostile = "evil: value\nmalicious-key: injected";
+  const out = setDescriptionScalar(source, hostile);
+  const { frontmatter } = parseFrontmatter<Record<string, unknown>>(out);
+  assert.equal(frontmatter.description, "evil: value malicious-key: injected");
+  assert.equal(frontmatter["malicious-key"], undefined, "no injected sibling key");
+  assert.equal(frontmatter.name, "safe");
+});

--- a/tests/bridges/skills/frontmatter-degrade.test.ts
+++ b/tests/bridges/skills/frontmatter-degrade.test.ts
@@ -175,7 +175,7 @@ test("SKILL-03 (AG-8 class): setDescriptionScalar emits an author value as a saf
   // sibling key. The safe emitter must collapse the newline and quote it.
   const hostile = "evil: value\nmalicious-key: injected";
   const out = setDescriptionScalar(source, hostile);
-  const { frontmatter } = parseFrontmatter<Record<string, unknown>>(out);
+  const { frontmatter } = parseFrontmatter(out);
   assert.equal(frontmatter.description, "evil: value malicious-key: injected");
   assert.equal(frontmatter["malicious-key"], undefined, "no injected sibling key");
   assert.equal(frontmatter.name, "safe");

--- a/tests/bridges/skills/frontmatter-degrade.test.ts
+++ b/tests/bridges/skills/frontmatter-degrade.test.ts
@@ -279,3 +279,24 @@ test("CR-01: setDescriptionScalar replaces a multi-line DOUBLE-QUOTED scalar des
   assert.equal(frontmatter.version, "1.2.3");
   assert.ok(!out.includes("  quoted scalar that wraps"), "continuation line must be removed");
 });
+
+test("setDescriptionScalar returns content unchanged when there is no opening `---` fence", () => {
+  const content = "no frontmatter here\n\nbody paragraph.\n";
+  assert.equal(setDescriptionScalar(content, "ignored"), content);
+});
+
+test("setDescriptionScalar replaces the description when the block has no closing `---` (block-end falls back to EOF)", () => {
+  const content = "---\ndescription: old value\nname: acme-skill";
+  const out = setDescriptionScalar(content, "new value");
+  assert.match(out, /^---\ndescription: "new value"\n/);
+  assert.ok(!out.includes("old value"), "old description must be replaced");
+  assert.ok(out.includes("name: acme-skill"), "sibling key survives");
+});
+
+test("setDescriptionScalar spans a description value interrupted by a blank line (blank continuation skipped)", () => {
+  const content = "---\ndescription: old\n\n  wrapped continuation\nname: acme-skill\n---\nbody.\n";
+  const out = setDescriptionScalar(content, "single line");
+  assert.match(out, /description: "single line"/);
+  assert.ok(!out.includes("wrapped continuation"), "the absorbed continuation line is removed");
+  assert.ok(out.includes("name: acme-skill"), "the first column-0 sibling key survives");
+});

--- a/tests/bridges/skills/frontmatter-degrade.test.ts
+++ b/tests/bridges/skills/frontmatter-degrade.test.ts
@@ -180,3 +180,56 @@ test("SKILL-03 (AG-8 class): setDescriptionScalar emits an author value as a saf
   assert.equal(frontmatter["malicious-key"], undefined, "no injected sibling key");
   assert.equal(frontmatter.name, "safe");
 });
+
+test("CR-01: setDescriptionScalar replaces a multi-line PLAIN scalar description spanning its full node (no orphaned continuation lines)", () => {
+  // A valid, gate-1-parseable source whose `description` is a multi-line PLAIN
+  // scalar (indented continuation). Augmentation fires (folded when_to_use), so
+  // the description value changes. A lone `description:` line replace would
+  // orphan `  plain scalar that wraps`, producing invalid YAML that gate-2
+  // rejects and that hard-fails an otherwise-valid install.
+  const source =
+    "---\nname: my-skill\ndescription: This is a fairly long\n  plain scalar that wraps\n" +
+    "when_to_use: Use for X\n---\n\nBody.\n";
+  const out = setDescriptionScalar(
+    source,
+    "This is a fairly long plain scalar that wraps\nUse for X",
+  );
+
+  // Gate-2: the staged bytes re-parse cleanly (no throw on orphaned lines).
+  assert.doesNotThrow(() => parseFrontmatter(out));
+
+  const { frontmatter } = parseFrontmatter<{
+    name: string;
+    description: string;
+    when_to_use: string;
+  }>(out);
+  // The folded description is emitted as a single safe scalar (newline collapsed).
+  assert.equal(frontmatter.description, "This is a fairly long plain scalar that wraps Use for X");
+  // Sibling keys survive intact.
+  assert.equal(frontmatter.name, "my-skill");
+  assert.equal(frontmatter.when_to_use, "Use for X");
+  // The plain-scalar continuation line is gone (no orphaned prose).
+  assert.ok(!out.includes("  plain scalar that wraps"), "continuation line must be removed");
+});
+
+test("CR-01: setDescriptionScalar replaces a multi-line DOUBLE-QUOTED scalar description spanning its full node", () => {
+  // A multi-line double-quoted `description` scalar. Same defect class as the
+  // plain-scalar case: the inline value starts with `"` (not `>`/`|`), so a
+  // block-scalar-only span detector would orphan the continuation line.
+  const source =
+    '---\nname: quoted-skill\ndescription: "This is a fairly long\n  quoted scalar that wraps"\n' +
+    "version: 1.2.3\n---\n\nBody.\n";
+  const out = setDescriptionScalar(source, "A single-line replacement.");
+
+  assert.doesNotThrow(() => parseFrontmatter(out));
+
+  const { frontmatter } = parseFrontmatter<{
+    name: string;
+    description: string;
+    version: string;
+  }>(out);
+  assert.equal(frontmatter.description, "A single-line replacement.");
+  assert.equal(frontmatter.name, "quoted-skill");
+  assert.equal(frontmatter.version, "1.2.3");
+  assert.ok(!out.includes("  quoted scalar that wraps"), "continuation line must be removed");
+});

--- a/tests/bridges/skills/frontmatter-degrade.test.ts
+++ b/tests/bridges/skills/frontmatter-degrade.test.ts
@@ -76,6 +76,16 @@ test("SKILL-02: firstBodyParagraph returns empty string for a body with no prose
   assert.equal(firstBodyParagraph("```\nonly a fence\n```\n"), "");
 });
 
+test("SKILL-02: firstBodyParagraph skips a ~~~ (tilde) fenced block and returns the first prose after it", () => {
+  const body = "~~~\ncode in a tilde fence\n~~~\n\nReal prose here.\n";
+  assert.equal(firstBodyParagraph(body), "Real prose here.");
+});
+
+test("SKILL-02: firstBodyParagraph returns empty when an unterminated fence swallows the rest of the body", () => {
+  const body = "```\nnever closed\nstill inside the fence\n";
+  assert.equal(firstBodyParagraph(body), "");
+});
+
 // ---------------------------------------------------------------------------
 // WTU-01: foldWhenToUse
 // ---------------------------------------------------------------------------
@@ -89,6 +99,10 @@ test("WTU-01: foldWhenToUse with an empty or absent when_to_use returns the desc
 
 test("WTU-01 (A1): foldWhenToUse joins description and when_to_use with a single \\n separator", () => {
   assert.equal(foldWhenToUse("desc", "use when X"), "desc\nuse when X");
+});
+
+test("WTU-01: foldWhenToUse with an empty description and a non-empty when_to_use yields a leading-\\n join", () => {
+  assert.equal(foldWhenToUse("", "use when X"), "\nuse when X");
 });
 
 test("WTU-01: foldWhenToUse operates on JS string .length (UTF-16 code units) with no byte reinterpretation", () => {
@@ -132,6 +146,18 @@ test("WTU-02: truncate1536 measures 1536 in UTF-16 code units", () => {
 
 test("WTU-02: truncate1536 on empty combined text returns empty without crashing", () => {
   assert.equal(truncate1536(""), "");
+});
+
+test("WTU-02: truncate1536 cutting through a surrogate pair yields exactly 1536 code units", () => {
+  // 1535 BMP chars + one astral char (U+1F600 = 2 code units at indices 1535,1536).
+  // The 1536-code-unit hard cut keeps index 1535 (the HIGH surrogate) and drops its
+  // LOW half -- a lone surrogate, length exactly 1536, no throw.
+  const text = "a".repeat(1535) + "\u{1F600}";
+  assert.equal(text.length, 1537);
+  const cut = truncate1536(text);
+  assert.equal(cut.length, 1536);
+  const lastUnit = cut.charCodeAt(1535);
+  assert.ok(lastUnit >= 0xd800 && lastUnit <= 0xdbff, "trailing unit is a lone high surrogate");
 });
 
 // ---------------------------------------------------------------------------
@@ -179,6 +205,26 @@ test("SKILL-03 (AG-8 class): setDescriptionScalar emits an author value as a saf
   assert.equal(frontmatter.description, "evil: value malicious-key: injected");
   assert.equal(frontmatter["malicious-key"], undefined, "no injected sibling key");
   assert.equal(frontmatter.name, "safe");
+});
+
+test("SKILL-03 (AG-8 class): setDescriptionScalar escapes embedded quotes and backslashes so the value round-trips through parseFrontmatter", () => {
+  const source = "---\nname: safe\ndescription: placeholder\nversion: 1\n---\n\nBody.\n";
+  // The two characters emitSafeDoubleQuotedScalar exists to escape: a literal
+  // double-quote, a literal backslash (e.g. a Windows path), and the pre-formed
+  // `\"` sequence -- the last proves backslash is escaped BEFORE quote (so the
+  // author `"` is not double-processed). Each must decode back byte-identically.
+  for (const value of ['He said "hi" to me', "a path\\to\\thing", 'mix \\" of both']) {
+    const out = setDescriptionScalar(source, value);
+    const { frontmatter } = parseFrontmatter<{
+      name: string;
+      description: string;
+      version: number;
+    }>(out);
+    assert.equal(frontmatter.description, value);
+    // No injected sibling key and existing siblings intact.
+    assert.equal(frontmatter.name, "safe");
+    assert.equal(frontmatter.version, 1);
+  }
 });
 
 test("CR-01: setDescriptionScalar replaces a multi-line PLAIN scalar description spanning its full node (no orphaned continuation lines)", () => {

--- a/tests/bridges/skills/rewrite-frontmatter.test.ts
+++ b/tests/bridges/skills/rewrite-frontmatter.test.ts
@@ -77,6 +77,36 @@ test("SKILL-03 folded multi-line source name is rewritten to the generated name 
   assert.ok(out.includes("body text"));
 });
 
+test("WR-01: multi-line PLAIN source name is rewritten to the generated name (no orphaned continuation lines)", () => {
+  // A valid multi-line PLAIN `name:` scalar (indented continuation). The inline
+  // value does not start with `>`/`|`, so a block-scalar-only span detector
+  // would orphan `  continued`, folding it into the parsed name and tripping the
+  // SKILL-03 verify -- hard-failing an otherwise-valid skill install.
+  const input = "---\nname: my\n  continued\ndescription: kept\nversion: 7\n---\n\nbody text";
+  const out = rewriteFrontmatterName(input, "acme-plain");
+
+  const { frontmatter } = parseFrontmatter<{
+    name: string;
+    description: string;
+    version: number;
+  }>(out);
+  assert.equal(frontmatter.name, "acme-plain");
+  assert.equal(frontmatter.description, "kept");
+  assert.equal(frontmatter.version, 7);
+  assert.ok(!out.includes("  continued"), "plain continuation line must be removed");
+  assert.ok(out.includes("body text"));
+});
+
+test("WR-01: multi-line DOUBLE-QUOTED source name is rewritten to the generated name", () => {
+  const input = '---\nname: "my\n  quoted name"\ndescription: kept\n---\n\nbody text';
+  const out = rewriteFrontmatterName(input, "acme-quoted");
+
+  const { frontmatter } = parseFrontmatter<{ name: string; description: string }>(out);
+  assert.equal(frontmatter.name, "acme-quoted");
+  assert.equal(frontmatter.description, "kept");
+  assert.ok(!out.includes("  quoted name"), "quoted continuation line must be removed");
+});
+
 test("SKILL-03 absent source name is inserted as the generated name", () => {
   const input = "---\ndescription: only a description\nlicense: MIT\n---\n\nbody";
   const out = rewriteFrontmatterName(input, "acme-added");

--- a/tests/bridges/skills/rewrite-frontmatter.test.ts
+++ b/tests/bridges/skills/rewrite-frontmatter.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import { rewriteFrontmatterName } from "../../../extensions/pi-claude-marketplace/bridges/skills/rewrite-frontmatter.ts";
+import { parseFrontmatter } from "../../../extensions/pi-claude-marketplace/platform/pi-api.ts";
 
 // SK-3: rewriteFrontmatterName.
 
@@ -52,4 +53,40 @@ test("SK-3 rewriteFrontmatterName handles malformed frontmatter (--- with no clo
   const out = rewriteFrontmatterName(input, "rescued");
   // Behavior: treat as malformed and prepend a fresh frontmatter block.
   assert.match(out, /^---\nname: rescued\n---\n\n/);
+});
+
+test("SKILL-03 folded multi-line source name is rewritten to the generated name (no orphaned continuation lines)", () => {
+  // A `>` folded `name:` scalar spanning several source lines. A blind
+  // `^name:` line replace would leave the continuation lines orphaned and
+  // corrupt the parsed name (e.g. `renamed folded name`).
+  const input = "---\nname: >\n  folded\n  name\ndescription: kept\nversion: 9\n---\n\nbody text";
+  const out = rewriteFrontmatterName(input, "acme-folded");
+
+  const { frontmatter } = parseFrontmatter<{
+    name: string;
+    description: string;
+    version: number;
+  }>(out);
+  // The re-parsed name is EXACTLY the generated name -- no `acme-folded folded name`.
+  assert.equal(frontmatter.name, "acme-folded");
+  // Sibling keys survive the full-node-span replacement.
+  assert.equal(frontmatter.description, "kept");
+  assert.equal(frontmatter.version, 9);
+  // The orphaned continuation prose is gone.
+  assert.ok(!out.includes("  folded"), "folded continuation line must be removed");
+  assert.ok(out.includes("body text"));
+});
+
+test("SKILL-03 absent source name is inserted as the generated name", () => {
+  const input = "---\ndescription: only a description\nlicense: MIT\n---\n\nbody";
+  const out = rewriteFrontmatterName(input, "acme-added");
+
+  const { frontmatter } = parseFrontmatter<{
+    name: string;
+    description: string;
+    license: string;
+  }>(out);
+  assert.equal(frontmatter.name, "acme-added");
+  assert.equal(frontmatter.description, "only a description");
+  assert.equal(frontmatter.license, "MIT");
 });

--- a/tests/bridges/skills/rewrite-frontmatter.test.ts
+++ b/tests/bridges/skills/rewrite-frontmatter.test.ts
@@ -120,3 +120,15 @@ test("SKILL-03 absent source name is inserted as the generated name", () => {
   assert.equal(frontmatter.description, "only a description");
   assert.equal(frontmatter.license, "MIT");
 });
+
+test("SK-3 rewriteFrontmatterName tolerates an exotic close delimiter (`---x`), rewriting the name across the full block", () => {
+  // The opening `---` is closed by a `\n---x` prefix (which Pi's parser accepts as
+  // the close) rather than a bare `---` line -- this exercises the block-end scan
+  // falling through to EOF instead of matching a `trim() === "---"` line.
+  const input = "---\nname: old\n---x\nbody text";
+  const out = rewriteFrontmatterName(input, "acme-gen");
+  const { frontmatter } = parseFrontmatter<{ name: string }>(out);
+  assert.equal(frontmatter.name, "acme-gen");
+  assert.ok(out.includes("body text"));
+  assert.ok(!out.includes("name: old"));
+});

--- a/tests/bridges/skills/stage.test.ts
+++ b/tests/bridges/skills/stage.test.ts
@@ -15,6 +15,7 @@ import {
   rollbackSkillsReplacement,
 } from "../../../extensions/pi-claude-marketplace/bridges/skills/stage.ts";
 import { locationsFor } from "../../../extensions/pi-claude-marketplace/persistence/locations.ts";
+import { parseFrontmatter } from "../../../extensions/pi-claude-marketplace/platform/pi-api.ts";
 import { cleanupStaging } from "../../../extensions/pi-claude-marketplace/shared/fs-utils.ts";
 
 import type { DiscoveredSkill } from "../../../extensions/pi-claude-marketplace/bridges/skills/types.ts";
@@ -619,5 +620,46 @@ test("TR-06 replacePreparedSkills tolerates owned orphan dir from prior partial 
       null,
       "orphan leftover.txt must be gone (helper rm -r the whole owned orphan dir)",
     );
+  });
+});
+
+test("SKILL-01 / PARSE-01 unparseable source frontmatter -> synthesized disable-model-invocation block, body verbatim, degrade record", async () => {
+  await withTmpScope(async ({ locations }) => {
+    const pluginRoot = path.join(FIXTURES, "unparseable-skill-plugin");
+    const skillsDir = path.join(pluginRoot, "skills");
+    const resolved = makeResolved("acme", pluginRoot, skillsDir);
+
+    const prepared = await prepareStageSkills({
+      locations,
+      marketplaceName: "mp",
+      pluginName: "acme",
+      pluginRoot,
+      pluginDataDir: path.join(locations.dataRoot, "mp", "acme"),
+      resolved,
+    });
+    assert.equal(prepared.kind, "staged");
+
+    // Degrade record: exactly one, carrying the generated name + a non-empty
+    // parse error (the actionable detail the install warning surfaces).
+    assert.equal(prepared.result.degraded.length, 1);
+    const record = prepared.result.degraded[0]!;
+    assert.ok(record.generatedName.length > 0);
+    assert.ok(record.parseError.length > 0, "parse error must be non-empty");
+
+    await commitPreparedSkills(prepared);
+
+    const staged = await readFile(
+      path.join(locations.skillsTargetDir, record.generatedName, "SKILL.md"),
+      "utf8",
+    );
+    // Synthesized frontmatter: generated name, disable-model-invocation, and the
+    // fixed placeholder description.
+    assert.match(staged, new RegExp(`^name: ${record.generatedName}$`, "m"));
+    assert.match(staged, /^disable-model-invocation: true$/m);
+    assert.match(staged, /^description: /m);
+    // Body preserved verbatim (the malformed frontmatter is discarded, not the body).
+    assert.ok(staged.includes("# Bad Skill\n\nThis body must survive verbatim."));
+    // Gate-2 parity: the staged bytes re-parse (do NOT throw) -- Pi accepts them.
+    assert.doesNotThrow(() => parseFrontmatter(staged));
   });
 });

--- a/tests/bridges/skills/stage.test.ts
+++ b/tests/bridges/skills/stage.test.ts
@@ -704,3 +704,181 @@ test("NREG-01 valid skill is staged byte-for-byte identical to a name-rewrite + 
     assert.equal(staged, expected);
   });
 });
+
+// SKILL-02 / WTU-01 / WTU-02 augment arm (gate-1 RETURN branch) ------------
+
+/**
+ * Stage a single dynamically-authored source skill and return the staged
+ * SKILL.md bytes. The source `name` is `s`, so the generated name is `acme-s`.
+ */
+async function stageAugmentSource(
+  locations: ReturnType<typeof locationsFor>,
+  dataRoot: string,
+  sourceSkillMd: string,
+): Promise<string> {
+  const srcRoot = await mkdtemp(path.join(os.tmpdir(), "augment-src-"));
+  try {
+    const skillsDir = path.join(srcRoot, "skills");
+    await mkdir(path.join(skillsDir, "s"), { recursive: true });
+    await writeFile(path.join(skillsDir, "s", "SKILL.md"), sourceSkillMd);
+
+    const resolved = makeResolved("acme", srcRoot, skillsDir);
+    const prepared = await prepareStageSkills({
+      locations,
+      marketplaceName: "mp",
+      pluginName: "acme",
+      pluginRoot: srcRoot,
+      pluginDataDir: dataRoot,
+      resolved,
+    });
+    await commitPreparedSkills(prepared);
+
+    return await readFile(path.join(locations.skillsTargetDir, "acme-s", "SKILL.md"), "utf8");
+  } finally {
+    await cleanupStaging(srcRoot, "test-cleanup");
+  }
+}
+
+test("SKILL-02 description-less skill stages a first-body-paragraph description and stays model-invocable", async () => {
+  await withTmpScope(async ({ locations }) => {
+    const source =
+      "---\nname: no-desc\nversion: 1.0.0\n---\n\n" +
+      "# A Heading\n\n" +
+      "The first genuine prose paragraph.\nSecond line of that paragraph.\n\n" +
+      "A later paragraph that must not be captured.\n";
+
+    const staged = await stageAugmentSource(
+      locations,
+      path.join(locations.dataRoot, "mp", "acme"),
+      source,
+    );
+
+    const { frontmatter } = parseFrontmatter<{
+      name: string;
+      description: string;
+      "disable-model-invocation"?: boolean;
+    }>(staged);
+    assert.equal(frontmatter.name, "acme-s");
+    // The first-body paragraph spans two source lines; the safe single-line
+    // double-quoted scalar emitter collapses its internal newline to a space.
+    assert.equal(
+      frontmatter.description,
+      "The first genuine prose paragraph. Second line of that paragraph.",
+    );
+    // SKILL-02: filled skills stay model-invocable (no disable flag inserted).
+    assert.equal(frontmatter["disable-model-invocation"], undefined);
+    assert.ok(!staged.includes("disable-model-invocation"));
+    // The later paragraph is not part of the description.
+    assert.ok(!(frontmatter.description ?? "").includes("later paragraph"));
+  });
+});
+
+test("SKILL-02 empty probe: a description-less skill with no prose body still stages a non-empty description", async () => {
+  await withTmpScope(async ({ locations }) => {
+    // Frontmatter parses cleanly; there is no description and no prose body.
+    const source = "---\nname: empty-body\n---\n";
+
+    const staged = await stageAugmentSource(
+      locations,
+      path.join(locations.dataRoot, "mp", "acme"),
+      source,
+    );
+
+    const { frontmatter } = parseFrontmatter<{ description: string }>(staged);
+    assert.ok(
+      typeof frontmatter.description === "string" && frontmatter.description.trim().length > 0,
+      "empty-body skill must still carry a non-empty description (Pi drops empty-desc skills)",
+    );
+    assert.doesNotThrow(() => parseFrontmatter(staged));
+  });
+});
+
+test("WTU-01 / WTU-02 when_to_use is folded into the description and hard-cut at 1,536", async () => {
+  await withTmpScope(async ({ locations }) => {
+    // Source combined length = 1000 + 1 (\n) + 536 = 1537 -> hard cut to 1536.
+    const description = "a".repeat(1000);
+    const whenToUse = "b".repeat(536);
+    const source = `---\nname: wtu\ndescription: ${description}\nwhen_to_use: ${whenToUse}\n---\n\nBody.\n`;
+
+    const staged = await stageAugmentSource(
+      locations,
+      path.join(locations.dataRoot, "mp", "acme"),
+      source,
+    );
+
+    const { frontmatter } = parseFrontmatter<{ description: string }>(staged);
+    // Hard cut to exactly 1,536 UTF-16 code units (no ellipsis).
+    assert.equal(frontmatter.description.length, 1536);
+    // The description carries the source description and the folded when_to_use
+    // tail (the single `\n` fold separator collapses to a space in the emitted
+    // double-quoted scalar).
+    assert.ok(frontmatter.description.startsWith("a".repeat(1000)));
+    assert.ok(frontmatter.description.includes("b"), "folded when_to_use tail present");
+    assert.ok(frontmatter.description.endsWith("b"), "tail is the when_to_use text");
+  });
+});
+
+test("WTU-02 / D-86-05 a >1024 combined description still parses to a non-empty description (Pi loads it)", async () => {
+  await withTmpScope(async ({ locations }) => {
+    // Combined length = 1000 + 1 + 200 = 1201 (in the 1025..1536 range): no cut.
+    const description = "a".repeat(1000);
+    const whenToUse = "b".repeat(200);
+    const source = `---\nname: long\ndescription: ${description}\nwhen_to_use: ${whenToUse}\n---\n\nBody.\n`;
+
+    const staged = await stageAugmentSource(
+      locations,
+      path.join(locations.dataRoot, "mp", "acme"),
+      source,
+    );
+
+    // The staged bytes re-parse (do NOT throw) to a non-empty, >1024 description
+    // -- NOT secretly truncated to Pi's 1,024 warning threshold (D-86-05).
+    let parsed: { frontmatter: { description?: unknown } } | undefined;
+    assert.doesNotThrow(() => {
+      parsed = parseFrontmatter(staged);
+    });
+    const description2 = parsed?.frontmatter.description;
+    assert.ok(typeof description2 === "string" && description2.length > 1024);
+  });
+});
+
+test("SKILL-03 / WTU-01 a `>-` block-scalar description is replaced as a full node span, siblings byte-identical", async () => {
+  await withTmpScope(async ({ locations }) => {
+    const source =
+      "---\n" +
+      "name: block\n" +
+      "description: >-\n" +
+      "  A folded block scalar description\n" +
+      "  spanning several source lines.\n" +
+      "version: 2.3.1\n" +
+      "tags: alpha, beta\n" +
+      "when_to_use: Use it when triggered.\n" +
+      "---\n\n" +
+      "Body prose.\n";
+
+    const staged = await stageAugmentSource(
+      locations,
+      path.join(locations.dataRoot, "mp", "acme"),
+      source,
+    );
+
+    // Gate-2 parity: the staged bytes re-parse (do NOT throw).
+    assert.doesNotThrow(() => parseFrontmatter(staged));
+    const { frontmatter } = parseFrontmatter<{
+      description: string;
+      version: string;
+      tags: string;
+    }>(staged);
+    // The folded scalar was folded WITH when_to_use into a single scalar.
+    assert.ok(frontmatter.description.includes("A folded block scalar description"));
+    assert.ok(frontmatter.description.endsWith("Use it when triggered."));
+    // Sibling keys survive byte-identically (still their exact source lines).
+    assert.ok(staged.includes("version: 2.3.1"), "version sibling byte-identical");
+    assert.ok(staged.includes("tags: alpha, beta"), "tags sibling byte-identical");
+    // The multi-line continuation lines are gone (collapsed into one scalar).
+    assert.ok(
+      !staged.includes("  spanning several source lines."),
+      "block-scalar continuation lines removed",
+    );
+  });
+});

--- a/tests/bridges/skills/stage.test.ts
+++ b/tests/bridges/skills/stage.test.ts
@@ -663,3 +663,44 @@ test("SKILL-01 / PARSE-01 unparseable source frontmatter -> synthesized disable-
     assert.doesNotThrow(() => parseFrontmatter(staged));
   });
 });
+
+test("NREG-01 valid skill is staged byte-for-byte identical to a name-rewrite + var-substitution of the source (gates mutate nothing)", async () => {
+  await withTmpScope(async ({ locations }) => {
+    const pluginRoot = path.join(FIXTURES, "test-plugin");
+    const skillsDir = path.join(pluginRoot, "skills");
+    const resolved = makeResolved("acme", pluginRoot, skillsDir);
+
+    const pluginDataDir = path.join(locations.dataRoot, "mp", "acme");
+    const prepared = await prepareStageSkills({
+      locations,
+      marketplaceName: "mp",
+      pluginName: "acme",
+      pluginRoot,
+      pluginDataDir,
+      resolved,
+    });
+    // The all-valid path degrades nothing.
+    assert.equal(prepared.result.degraded.length, 0);
+
+    await commitPreparedSkills(prepared);
+
+    // The `helper` source has `name: helper` (rewritten to `acme-helper`) and a
+    // `${CLAUDE_PLUGIN_DATA}` body reference. Build the expected bytes with
+    // INDEPENDENT literal string replacements -- NOT the production rewrite /
+    // substitute helpers -- so the assertion proves the read-only gates
+    // introduced no reformatting, re-quoting, or field reordering.
+    const source = await readFile(path.join(skillsDir, "helper", "SKILL.md"), "utf8");
+    const expected = source
+      .replace("name: helper", "name: acme-helper")
+      .replaceAll("${CLAUDE_PLUGIN_ROOT}", pluginRoot)
+      .replaceAll("${CLAUDE_PLUGIN_DATA}", pluginDataDir);
+
+    const staged = await readFile(
+      path.join(locations.skillsTargetDir, "acme-helper", "SKILL.md"),
+      "utf8",
+    );
+    // Byte-for-byte: the only differences from source are the name rewrite and
+    // the two variable substitutions.
+    assert.equal(staged, expected);
+  });
+});

--- a/tests/bridges/skills/stage.test.ts
+++ b/tests/bridges/skills/stage.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { chmod, mkdir, mkdtemp, readFile, stat, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -213,6 +213,54 @@ test("SK-4 substituted SKILL.md contains the resolved pluginRoot path verbatim",
     );
     assert.ok(knowledge.includes(pluginRoot), "substituted body should contain pluginRoot path");
     assert.ok(knowledge.includes(pluginDataDir), "substituted body should contain pluginData path");
+  });
+});
+
+test("SK-4 / AG-8: a ${CLAUDE_PLUGIN_ROOT} in a body-synthesized description survives a backslash (Windows) plugin root (substitute-then-escape)", async () => {
+  await withTmpScope(async ({ locations }) => {
+    const srcRoot = await mkdtemp(path.join(os.tmpdir(), "skills-winpath-src-"));
+    try {
+      // No `description` -> the augment arm fills it from the first body paragraph,
+      // which references ${CLAUDE_PLUGIN_ROOT}, and re-emits it as a double-quoted
+      // scalar. If substitution happened AFTER escaping, a Windows path's backslashes
+      // would splice in raw and form an invalid `\U...` escape that the PARSE-02
+      // gate-2 backstop rejects -- hard-failing the whole prepare.
+      const skillsDir = path.join(srcRoot, "skills");
+      await mkdir(path.join(skillsDir, "winpath"), { recursive: true });
+      await writeFile(
+        path.join(skillsDir, "winpath", "SKILL.md"),
+        "---\nname: winpath\n---\nUses ${CLAUDE_PLUGIN_ROOT} at runtime.\n",
+      );
+
+      // A Windows-style plugin root (only used for substitution; the real source
+      // tree lives at srcRoot). Backslashes are the escape hazard under test.
+      const winPluginRoot = "C:\\Users\\me\\acme-plugin";
+
+      const prepared = await prepareStageSkills({
+        locations,
+        marketplaceName: "mp",
+        pluginName: "acme",
+        pluginRoot: winPluginRoot,
+        pluginDataDir: "D:\\pi-data\\mp\\acme",
+        resolved: makeResolved("acme", srcRoot, skillsDir),
+      });
+
+      // Gate-2 did NOT throw: the value re-emitted with escaped backslashes.
+      assert.equal(prepared.kind, "staged");
+      assert.equal(prepared.result.degraded.length, 0);
+
+      await commitPreparedSkills(prepared);
+      const staged = await readFile(
+        path.join(locations.skillsTargetDir, "acme-winpath", "SKILL.md"),
+        "utf8",
+      );
+
+      assert.ok(!staged.includes("${CLAUDE_PLUGIN_ROOT}"), "the var must be substituted");
+      const { frontmatter } = parseFrontmatter(staged);
+      assert.equal(frontmatter.description, "Uses C:\\Users\\me\\acme-plugin at runtime.");
+    } finally {
+      await rm(srcRoot, { recursive: true, force: true });
+    }
   });
 });
 
@@ -880,5 +928,55 @@ test("SKILL-03 / WTU-01 a `>-` block-scalar description is replaced as a full no
       !staged.includes("  spanning several source lines."),
       "block-scalar continuation lines removed",
     );
+  });
+});
+
+test("SKILL-01 lone-CR (\\r-only) unparseable source: the malformed frontmatter is not leaked into the synthesized body (line-ending parity with parseFrontmatter)", async () => {
+  await withTmpScope(async ({ locations }) => {
+    const srcRoot = await mkdtemp(path.join(os.tmpdir(), "skill-cr-src-"));
+    try {
+      // A classic-Mac (lone-CR) source whose closed `---` block holds malformed
+      // YAML. parseFrontmatter normalizes CR->LF and THROWS; the body extractor
+      // must normalize CR the same way so it locates the close and does NOT
+      // embed the malformed frontmatter block in the synthesized skill body.
+      const skillsDir = path.join(srcRoot, "skills");
+      await mkdir(path.join(skillsDir, "bad"), { recursive: true });
+      const loneCr =
+        "---\rname: [unterminated\rdescription: never reached\r---\r\r" +
+        "# Bad Skill\r\rThis body must survive verbatim.\r";
+      await writeFile(path.join(skillsDir, "bad", "SKILL.md"), loneCr);
+
+      const resolved = makeResolved("acme", srcRoot, skillsDir);
+      const prepared = await prepareStageSkills({
+        locations,
+        marketplaceName: "mp",
+        pluginName: "acme",
+        pluginRoot: srcRoot,
+        pluginDataDir: path.join(locations.dataRoot, "mp", "acme"),
+        resolved,
+      });
+      assert.equal(prepared.kind, "staged");
+      assert.equal(prepared.result.degraded.length, 1);
+
+      await commitPreparedSkills(prepared);
+      const staged = await readFile(
+        path.join(locations.skillsTargetDir, "acme-bad", "SKILL.md"),
+        "utf8",
+      );
+
+      // The malformed frontmatter must NOT survive inside the synthesized body.
+      assert.ok(!staged.includes("[unterminated"), "malformed frontmatter must not leak into body");
+      assert.ok(!staged.includes("never reached"), "malformed frontmatter must not leak into body");
+      // The real body survives and the synthesized block re-parses cleanly.
+      assert.ok(staged.includes("This body must survive verbatim."));
+      const { frontmatter } = parseFrontmatter<{
+        name: string;
+        "disable-model-invocation": boolean;
+      }>(staged);
+      assert.equal(frontmatter.name, "acme-bad");
+      assert.equal(frontmatter["disable-model-invocation"], true);
+    } finally {
+      await cleanupStaging(srcRoot, "test-cleanup");
+    }
   });
 });

--- a/tests/orchestrators/plugin/install.test.ts
+++ b/tests/orchestrators/plugin/install.test.ts
@@ -999,6 +999,55 @@ test("PI-12 / RH-4: staged mcp + pi.getAllTools has no 'mcp' -> success message 
 });
 
 // ───────────────────────────────────────────────────────────────────────────
+// SKILL-01 / WARN-01 -- unparseable skill degrades but installs
+// ───────────────────────────────────────────────────────────────────────────
+
+test("SKILL-01 / WARN-01: standalone install of a plugin with one unparseable skill -> (installed) {malformed skill} at warning severity, no hard-fail", async () => {
+  await withHermeticHome(async () => {
+    const cwd = await mkdtemp(path.join(tmpdir(), "install-malformed-skill-"));
+    try {
+      // `name: [unterminated` is a closed `---` block whose inner YAML is
+      // malformed -> parseFrontmatter throws at gate 1 -> the skill is
+      // synthesized into a disable-model-invocation block and still installs.
+      await seedPathMarketplaceWithPlugin({
+        cwd,
+        marketplaceRoot: path.join(cwd, "mp-src"),
+        marketplaceName: "mp",
+        pluginName: "hello",
+        pluginVersion: "1.0.0",
+        skills: [{ sourceName: "bad", frontmatterName: "[unterminated", body: "# Bad\nBody.\n" }],
+      });
+
+      const { ctx, pi, notifications } = makeCtx();
+      const outcome = await installPlugin({
+        ctx,
+        pi,
+        scope: "project",
+        cwd,
+        marketplace: "mp",
+        plugin: "hello",
+      });
+
+      // Not a hard fail: the degraded skill still installs.
+      assert.equal(outcome.status, "installed");
+      // D-86-03: the degrade surfaces the `{malformed skill}` reason token on
+      // the `(installed)` row (NOT partially-installed -- the component is
+      // installed in degraded form, not dropped) at warning severity.
+      assert.equal(notifications.length, 1);
+      assert.equal(notifications[0]?.severity, "warning");
+      assert.match(notifications[0]?.message ?? "", /\(installed\)/);
+      assert.match(notifications[0]?.message ?? "", /\{malformed skill\}/);
+      // The installed outcome carries the `degradedKinds` seam the orchestrated
+      // reconcile composer consumes.
+      assert.ok(outcome.status === "installed");
+      assert.deepEqual([...(outcome.degradedKinds ?? [])], ["skill"]);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
 // PI-13 -- dependencies declaration -> manual-install note
 // ───────────────────────────────────────────────────────────────────────────
 

--- a/tests/orchestrators/plugin/install.test.ts
+++ b/tests/orchestrators/plugin/install.test.ts
@@ -1047,6 +1047,49 @@ test("SKILL-01 / WARN-01: standalone install of a plugin with one unparseable sk
   });
 });
 
+test("CMD-01 / WARN-01: standalone install of a plugin with one unparseable command -> (installed) {malformed command} at warning severity, no hard-fail", async () => {
+  await withHermeticHome(async () => {
+    const cwd = await mkdtemp(path.join(tmpdir(), "install-malformed-command-"));
+    try {
+      // A closed `---` block whose inner YAML is malformed (`title: A: B` -> a
+      // mapping value where none is allowed) -> parseFrontmatter throws at gate 1
+      // -> the command frontmatter is neutralized (stripped) and it still installs.
+      await seedPathMarketplaceWithPlugin({
+        cwd,
+        marketplaceRoot: path.join(cwd, "mp-src"),
+        marketplaceName: "mp",
+        pluginName: "hello",
+        pluginVersion: "1.0.0",
+        commands: [{ sourceName: "bad", body: "---\ntitle: A: B: C\n---\nRun it.\n" }],
+      });
+
+      const { ctx, pi, notifications } = makeCtx();
+      const outcome = await installPlugin({
+        ctx,
+        pi,
+        scope: "project",
+        cwd,
+        marketplace: "mp",
+        plugin: "hello",
+      });
+
+      // Not a hard fail: the degraded command still installs.
+      assert.equal(outcome.status, "installed");
+      // D-86-03: the degrade surfaces the `{malformed command}` reason token on
+      // the `(installed)` row at warning severity (the command-vertical analogue
+      // of the skill degrade E2E above).
+      assert.equal(notifications.length, 1);
+      assert.equal(notifications[0]?.severity, "warning");
+      assert.match(notifications[0]?.message ?? "", /\(installed\)/);
+      assert.match(notifications[0]?.message ?? "", /\{malformed command\}/);
+      assert.ok(outcome.status === "installed");
+      assert.deepEqual([...(outcome.degradedKinds ?? [])], ["command"]);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
 // ───────────────────────────────────────────────────────────────────────────
 // PI-13 -- dependencies declaration -> manual-install note
 // ───────────────────────────────────────────────────────────────────────────

--- a/tests/orchestrators/reconcile/apply.test.ts
+++ b/tests/orchestrators/reconcile/apply.test.ts
@@ -32,7 +32,10 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import test, { mock } from "node:test";
 
-import { applyReconcile } from "../../../extensions/pi-claude-marketplace/orchestrators/reconcile/apply.ts";
+import {
+  applyReconcile,
+  surfacePostCommitWarnings,
+} from "../../../extensions/pi-claude-marketplace/orchestrators/reconcile/apply.ts";
 import { isDeclaredEnabled } from "../../../extensions/pi-claude-marketplace/persistence/config-io.ts";
 import { loadState } from "../../../extensions/pi-claude-marketplace/persistence/state-io.ts";
 import { EXTENSION_VERSION } from "../../../extensions/pi-claude-marketplace/shared/extension-version.ts";
@@ -823,6 +826,58 @@ test("S2 / PR #51: reconcile cascade surfaces InstallPluginOutcome.postCommitWar
   assert.ok(outcome.postCommitWarnings);
   assert.equal(outcome.postCommitWarnings.length, 1);
   assert.match(outcome.postCommitWarnings[0]!, /data dir/);
+});
+
+test("WARN-01 / D-86-03 / T-86-03: a degraded plugin-installed outcome carries degradedKinds onto the rendered cascade row AND surfaces its per-component detail through notifyDiagnostic with the absolute source path redacted to its basename", async () => {
+  // The apply pass propagates `InstallPluginOutcome.degradedKinds` verbatim
+  // onto the `PluginInstalledOutcome` (mirroring the postCommitWarnings spread);
+  // this test pins the shape apply.ts produces and asserts the two consumer
+  // surfaces: (1) the projection renders `(installed) {malformed skill}` at
+  // warning severity, and (2) `surfacePostCommitWarnings` routes the
+  // `<plugin>/<component>: <parse error>` detail through `redactAbsolutePaths`
+  // before `notifyDiagnostic` so an absolute source path never leaks (NFR-9).
+  const { buildReconcileAppliedCascade } =
+    await import("../../../extensions/pi-claude-marketplace/orchestrators/reconcile/notify.ts");
+  const outcome: import("../../../extensions/pi-claude-marketplace/orchestrators/reconcile/apply-outcomes.ts").PluginInstalledOutcome =
+    {
+      kind: "plugin-installed",
+      scope: "project",
+      marketplace: "mp-a",
+      plugin: "plugin-a",
+      dependencies: [],
+      degradedKinds: ["skill"],
+      postCommitWarnings: [
+        "plugin-a/bad-skill: could not parse frontmatter of /home/user/plugins/plugin-a/skills/bad-skill/SKILL.md",
+      ],
+    };
+
+  // (1) The projection consumes degradedKinds -> warning row + reason token.
+  const msg = buildReconcileAppliedCascade([outcome]);
+  const block = msg.marketplaces[0];
+  assert.ok(block);
+  const row = block.plugins[0];
+  assert.ok(row);
+  assert.equal(row.status, "installed");
+  assert.equal(row.severity, "warning");
+  assert.deepEqual(row.status === "installed" ? [...(row.reasons ?? [])] : "absent", [
+    "malformed skill",
+  ]);
+
+  // (2) The detail surfaces via notifyDiagnostic (warning) with the absolute
+  // path collapsed to its basename.
+  const ctx = makeCtx();
+  surfacePostCommitWarnings(
+    { ctx: ctx as unknown as ExtensionContext } as Parameters<typeof surfacePostCommitWarnings>[0],
+    [outcome],
+  );
+  assert.equal(ctx.ui.notify.mock.calls.length, 1);
+  const args = ctx.ui.notify.mock.calls[0]!.arguments as [string, string?];
+  assert.equal(args[1], "warning");
+  assert.ok(args[0].includes("SKILL.md"), `expected the basename to survive; got:\n${args[0]}`);
+  assert.ok(
+    !args[0].includes("/home/user/plugins/plugin-a/skills/bad-skill/SKILL.md"),
+    `T-86-03: the absolute source path must be redacted; got:\n${args[0]}`,
+  );
 });
 
 test("S3 / PR #51: read-pass throw on saveConfig (claude-plugins.json EACCES) attributes the failed row to claude-plugins.json basename, not state.json", async () => {

--- a/tests/orchestrators/reconcile/notify.test.ts
+++ b/tests/orchestrators/reconcile/notify.test.ts
@@ -523,6 +523,84 @@ test("RECON-04: a cascade with an install row + a backfill row yields ONE messag
   );
 });
 
+test("WARN-01 / D-86-03: a plugin-installed outcome with degradedKinds=[skill] renders an (installed) row carrying {malformed skill} at warning severity (NOT partially-installed)", () => {
+  // A skill whose SOURCE frontmatter could not be parsed installs in degraded
+  // form. The orchestrated reconcile row keeps status `installed` (the skill
+  // still installed) but raises to `warning` and carries the failure-class
+  // token -- it is NOT a `partially-installed` row (that is for DROPPED
+  // supported components).
+  const outcome: PerEntryOutcome = {
+    kind: "plugin-installed",
+    scope: "project",
+    marketplace: "mp",
+    plugin: "cr",
+    dependencies: [],
+    degradedKinds: ["skill"],
+  };
+  const msg = buildReconcileAppliedCascade([outcome]);
+  assert.equal(msg.marketplaces.length, 1);
+  const block = msg.marketplaces[0];
+  assert.ok(block);
+  assert.equal(block.plugins.length, 1);
+  const row = block.plugins[0];
+  assert.ok(row);
+  assert.equal(row.status, "installed");
+  assert.equal(row.name, "cr");
+  assert.equal(row.severity, "warning");
+  assert.equal(row.needsReload, true);
+  assert.deepEqual(row.status === "installed" ? [...(row.reasons ?? [])] : "absent", [
+    "malformed skill",
+  ]);
+});
+
+test("WARN-01 / D-86-03: degradedKinds=[skill,command] rides ONE row with BOTH tokens (one per kind)", () => {
+  // One `malformed skill` + one `malformed command` token share the single
+  // installed row regardless of how many components of each kind degraded.
+  const outcome: PerEntryOutcome = {
+    kind: "plugin-installed",
+    scope: "project",
+    marketplace: "mp",
+    plugin: "cr",
+    dependencies: [],
+    degradedKinds: ["skill", "command"],
+  };
+  const msg = buildReconcileAppliedCascade([outcome]);
+  const block = msg.marketplaces[0];
+  assert.ok(block);
+  assert.equal(block.plugins.length, 1);
+  const row = block.plugins[0];
+  assert.ok(row);
+  assert.equal(row.status, "installed");
+  assert.equal(row.severity, "warning");
+  assert.deepEqual(row.status === "installed" ? [...(row.reasons ?? [])] : "absent", [
+    "malformed skill",
+    "malformed command",
+  ]);
+});
+
+test("WARN-01 / NREG-01: a plugin-installed outcome with no degradedKinds is unchanged -- info severity, no reasons brace", () => {
+  // A clean install must render byte-identically to today: no empty brace, no
+  // stray warning.
+  const outcome: PerEntryOutcome = {
+    kind: "plugin-installed",
+    scope: "project",
+    marketplace: "mp",
+    plugin: "cr",
+    dependencies: [],
+  };
+  const msg = buildReconcileAppliedCascade([outcome]);
+  const block = msg.marketplaces[0];
+  assert.ok(block);
+  const row = block.plugins[0];
+  assert.ok(row);
+  assert.equal(row.status, "installed");
+  assert.equal(row.severity, "info");
+  assert.equal(
+    row.status === "installed" ? "reasons" in row && row.reasons !== undefined : "wrong-status",
+    false,
+  );
+});
+
 test("dangling-reference mismatch (plugin attributed) -> child (failed) {dangling reference} plugin row (WR-03 / PURL-06)", () => {
   const plan: ReconcilePlan = {
     ...emptyPlan("project"),

--- a/tests/platform/pi-api.test.ts
+++ b/tests/platform/pi-api.test.ts
@@ -10,6 +10,7 @@ import test from "node:test";
 import {
   hasLoadedPiMcpAdapter,
   hasLoadedPiSubagents,
+  parseFrontmatter,
   softDepStatus,
 } from "../../extensions/pi-claude-marketplace/platform/pi-api.ts";
 
@@ -172,4 +173,40 @@ test("platform pi-api: probes do not crash on tool.name === undefined; fall thro
   // Mcp adapter probe: undefined name, but sourceInfo.source contains the
   // substring -- the fallback fires and the probe returns true.
   assert.equal(hasLoadedPiMcpAdapter(makePi([{ sourceInfo: { source: "pi-mcp-adapter" } }])), true);
+});
+
+// -----------------------------------------------------------------------------
+// PARSE-01: the `parseFrontmatter` re-export pins the throw/return semantics the
+// skills/commands staging gates branch on. A CLOSED, malformed `---` block is
+// the degrade trigger (throws); a missing/unclosed delimiter is the empty-
+// metadata branch (returns without throwing).
+// -----------------------------------------------------------------------------
+
+test("PARSE-01: parseFrontmatter reads a valid closed block and normalizes the body", () => {
+  const { frontmatter, body } = parseFrontmatter<{ name: string; description: string }>(
+    "---\r\nname: helper\r\ndescription: does a thing\r\n---\r\nBody line one\r\n\r\n",
+  );
+  assert.equal(frontmatter.name, "helper");
+  assert.equal(frontmatter.description, "does a thing");
+  // CRLF -> LF normalized and trailing whitespace trimmed.
+  assert.equal(body, "Body line one");
+});
+
+test("PARSE-01: parseFrontmatter returns empty frontmatter (no throw) when the `---` delimiter is absent", () => {
+  const { frontmatter, body } = parseFrontmatter("# Just a heading\n\nSome prose.\n");
+  assert.deepEqual(frontmatter, {});
+  // No-delimiter path: body is CRLF->LF normalized but NOT trimmed (only the
+  // frontmatter-present path trims the post-block body).
+  assert.equal(body, "# Just a heading\n\nSome prose.\n");
+});
+
+test("PARSE-01: parseFrontmatter returns empty frontmatter (no throw) when the opening `---` is never closed", () => {
+  const { frontmatter } = parseFrontmatter("---\nname: helper\nno closing delimiter here\n");
+  assert.deepEqual(frontmatter, {});
+});
+
+test("PARSE-01: parseFrontmatter THROWS on a closed block whose inner YAML is malformed", () => {
+  // An unquoted `: ` mid-scalar is the js-yaml/`yaml` strict-parse rejection the
+  // degrade path (SKILL-01 / CMD-01) triggers on.
+  assert.throws(() => parseFrontmatter("---\ndescription: a: b: c value\n---\nbody\n"));
 });

--- a/tests/shared/notify-v2.test.ts
+++ b/tests/shared/notify-v2.test.ts
@@ -5015,3 +5015,44 @@ test("SURF-05 / D-63-08: installed row renders `(installed) {orphan rewake}` via
     `● official [user]\n  ● helper v1.0.0 (installed) {orphan rewake}\n\n/reload to pick up changes`,
   ]);
 });
+
+test("CLASS-01 / D-86-01: REASONS tuple carries 'malformed skill' and 'malformed command' as its last two members", () => {
+  // Byte-stability of the tail append (OUT-08): the two new per-kind tokens sit
+  // immediately after `malformed mcp`, and `malformed mcp` keeps its position.
+  const last3 = (REASONS as readonly string[]).slice(-3);
+  assert.deepEqual(last3, ["malformed mcp", "malformed skill", "malformed command"]);
+});
+
+test("CLASS-01 / D-86-01: installed row renders `(installed) {malformed skill}` at warning severity", () => {
+  // A degraded-but-installed skill surfaces its failure-class token on the
+  // otherwise-successful `(installed)` row via the existing reasons brace, one
+  // per plugin -- mirroring the `orphan rewake` component-defect precedent. The
+  // caller stamps `warning` (carried out but short of ideal).
+  const ctx = makeCtx();
+  const pi = piWithBothLoaded();
+  const msg: NotificationMessage = {
+    marketplaces: [
+      {
+        name: "official",
+        scope: "user",
+        plugins: [
+          {
+            status: "installed",
+            severity: "warning",
+            needsReload: true,
+            name: "helper",
+            version: "1.0.0",
+            dependencies: [],
+            reasons: ["malformed skill"],
+          },
+        ],
+      },
+    ],
+  };
+  notify(ctx as never, pi as never, msg);
+  assert.equal(ctx.ui.notify.mock.calls.length, 1);
+  assert.deepEqual(ctx.ui.notify.mock.calls[0]!.arguments, [
+    `A plugin operation needs attention.\n\n● official [user]\n  ● helper v1.0.0 (installed) {malformed skill}\n\n/reload to pick up changes`,
+    "warning",
+  ]);
+});


### PR DESCRIPTION
Closes #101 — a plugin whose `SKILL.md` (or command) frontmatter Pi can't parse used to install cleanly and then throw a YAML error at the next startup, as @fank reported. It now degrades and installs instead. The diagnosis is written up in `docs/research/issue-101-skill-frontmatter-diagnosis.md`.

## What this does

Skill and command sources whose YAML frontmatter can't be parsed by Pi's own `parseFrontmatter` no longer fail the install. They degrade instead, and the plugin still installs.

- An unparseable skill is rewritten into a valid `disable-model-invocation` block. Its body is kept exactly as written, it stays invocable by name, and it is never auto-invoked.
- An unparseable command has its malformed frontmatter block stripped, so Pi reads the name from the filename and the description from the first body line.
- The plugin's row shows `{malformed skill}` or `{malformed command}` at warning severity. The actual parse error rides the install warning channel.

It also augments generated skill descriptions so they load and show up in the Pi listing:

- An empty or missing `description` is filled from the first real body paragraph.
- A `when_to_use` field is folded in, and the result is capped at 1,536 characters (Claude Code's listing budget).
- Path variables (`${CLAUDE_PLUGIN_ROOT}`, `${CLAUDE_PLUGIN_DATA}`) are substituted before the value is quoted, so a Windows path can't break the emitted YAML.

## Review hardening in this branch

The last few commits close findings from a code-review pass:

- Lone-CR (`\r`) line endings are normalized the same way Pi's parser does them, so a classic-Mac source degrades instead of hard-failing.
- Command neutralize loops until the remainder parses, so a body that itself opens with a second malformed block also degrades.
- The skill body split now matches Pi's `\n---` close-delimiter rule byte-for-byte (the PARSE-01 contract).
- The install and reconcile surfaces share one exhaustive `malformedReasonsForKinds` mapper instead of two hand-kept per-kind branches.

## Testing

`npm run check` passes locally for typecheck, lint, prettier, and the unit suite (3064 tests).

The two `pi-subagents` integration tests (`provenance-invisibility`, `skill-path-resolution`) resolve that optional peer from the global npm install and skip when it isn't there. They only fail against a stale global `pi-subagents` older than the required `>=0.35.0`, which is a local environment issue this branch doesn't touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LWkwq6ATrWWeMuDPyz7GP9
