### PR TITLE
fix(ci): give publish.yml a concurrency group of its own

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,8 +8,14 @@ on:
 permissions:
   contents: read
 
+# The group MUST NOT collide with the one ci.yml declares. Inside a called
+# workflow, `github.workflow` resolves to the CALLER's name and `github.ref` to
+# the caller's ref, so ci.yml's own group evaluates to the same string this one
+# would if it used `github.workflow`. The callee then waits on a group its own
+# caller holds, and the run dies before either job starts -- which is what
+# happened to the first v0.14.0 tag push.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: publish-npm-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
The first `v0.14.0` tag push failed after seven seconds. The called
workflow produced no jobs, the `publish` job was skipped, and nothing
reached npm — the registry still serves `0.13.0`.

## Cause

`publish.yml` declared its concurrency group as
`${{ github.workflow }}-${{ github.ref }}`, then called `ci.yml`, which
declares a group built the same way. Inside a called workflow,
`github.workflow` resolves to the **caller's** name and `github.ref` to
the caller's ref, so both expressions produced the same string:
`Publish-refs/tags/v0.14.0`.

The callee therefore asked for the concurrency group its own caller was
holding. With `cancel-in-progress: false` the request can never be
granted, and the run dies before either job starts.

## Why it surfaced now

`publish.yml` arrived in 68db2225 (2026-08-07), which moved the `publish`
job out of `ci.yml` and turned `ci.yml` into a reusable workflow, dropping
its own `tags: ["v*"]` trigger. `0.13.0` shipped on 2026-08-05 under the
old single-workflow design. `v0.14.0` is the first tag this code has ever
handled.

## Fix

The group becomes the literal prefix `publish-npm-`, which no other
workflow can produce. A comment records why it has to stay that way.

No version bump: `package.json` is already at `0.14.0`, and the `v0.14.0`
tag will be re-pointed at this commit once it lands so the tag-triggered
run reads the corrected file.
