### PR TITLE
chore(gsd): branch per milestone and stop tagging at milestone close

### DIFF
--- a/.planning/config.json
+++ b/.planning/config.json
@@ -7,10 +7,11 @@
   "firecrawl": false,
   "exa_search": false,
   "git": {
-    "branching_strategy": "none",
+    "branching_strategy": "milestone",
     "phase_branch_template": "gsd/phase-{phase}-{slug}",
     "milestone_branch_template": "gsd/{milestone}-{slug}",
-    "quick_branch_template": null
+    "quick_branch_template": null,
+    "create_tag": false
   },
   "workflow": {
     "context_guard_mode": "auto",


### PR DESCRIPTION
Two GSD config keys in `.planning/config.json`.

`git.branching_strategy` goes from `none` to `milestone`, so GSD cuts one branch per milestone instead of committing to whatever branch happens to be checked out.

`git.create_tag` is set to `false`. It was unset, and unset defaults to on. Tags in this repo track npm releases (v0.x.y), not GSD milestone numbers (v1.x), so leaving it on would eventually tag a version that does not exist on npm.

No source changed, so no version bump and no CHANGELOG entry.

One thing this does not fix: `git.milestone_branch_template` is still `gsd/{milestone}-{slug}`, which conflicts with the `main` / `features/*` / `releases/*` convention in CLAUDE.md. Now that branching is on, that template will start producing real branches. Worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FF7Rkkfz5oqrWy9F98mq1C
