### PR TITLE
Accept Codex-layout marketplaces and suffix-less git URLs

### DIFF
--- a/extensions/pi-claude-marketplace/domain/manifest.ts
+++ b/extensions/pi-claude-marketplace/domain/manifest.ts
@@ -6,7 +6,8 @@
 // D-05 + D-07: TypeBox JIT compilation runs at module load. The import path
 // is `typebox/compile` (the package is `typebox` with no scope).
 
-import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { readFile, stat } from "node:fs/promises";
 
 import Type from "typebox";
 import { Compile } from "typebox/compile";
@@ -35,6 +36,30 @@ const MARKETPLACE_SCHEMA = Type.Object({
 });
 
 export type MarketplaceManifest = Type.Static<typeof MARKETPLACE_SCHEMA>;
+
+/**
+ * Marketplace manifest location candidates, in priority order. Stock Claude
+ * layout first; the Codex plugin-marketplace layout (`.agents/plugins/`) is
+ * accepted as a fallback so git-served Codex marketplaces (e.g. Bifrost's
+ * /serve/codex endpoint) load unmodified. When none exist, the Claude path
+ * is returned so missing-manifest errors keep their original shape.
+ */
+export const MARKETPLACE_MANIFEST_CANDIDATES: readonly (readonly string[])[] = [
+  [".claude-plugin", "marketplace.json"],
+  [".agents", "plugins", "marketplace.json"],
+];
+
+export async function findMarketplaceManifestPath(root: string): Promise<string> {
+  for (const rel of MARKETPLACE_MANIFEST_CANDIDATES) {
+    const candidate = path.join(root, ...rel);
+    try {
+      if ((await stat(candidate)).isFile()) return candidate;
+    } catch {
+      // keep looking
+    }
+  }
+  return path.join(root, ".claude-plugin", "marketplace.json");
+}
 
 /** JIT-compiled validator (D-07). Call its `Check` (or coercing `Parse`) method. */
 export const MARKETPLACE_VALIDATOR = Compile(MARKETPLACE_SCHEMA);

--- a/extensions/pi-claude-marketplace/domain/resolver.ts
+++ b/extensions/pi-claude-marketplace/domain/resolver.ts
@@ -607,9 +607,14 @@ async function readManifest(
   ctx: ResolveContext,
   pluginRoot: string,
 ): Promise<{ ok: true; manifest: Record<string, unknown> | null } | { ok: false; reason: string }> {
-  const manifestPath = path.join(pluginRoot, ".claude-plugin", "plugin.json");
+  let manifestPath = path.join(pluginRoot, ".claude-plugin", "plugin.json");
   if ((await statKindOf(ctx)(manifestPath)) !== "file") {
-    return { ok: true, manifest: null };
+    const codexManifestPath = path.join(pluginRoot, ".codex-plugin", "plugin.json");
+    if ((await statKindOf(ctx)(codexManifestPath)) === "file") {
+      manifestPath = codexManifestPath;
+    } else {
+      return { ok: true, manifest: null };
+    }
   }
 
   try {

--- a/extensions/pi-claude-marketplace/orchestrators/marketplace/add.ts
+++ b/extensions/pi-claude-marketplace/orchestrators/marketplace/add.ts
@@ -50,7 +50,7 @@ import { mkdir, rename, stat } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
-import { loadMarketplaceManifest } from "../../domain/manifest.ts";
+import { findMarketplaceManifestPath, loadMarketplaceManifest } from "../../domain/manifest.ts";
 import { ensureGitSuffix, parsePluginSource } from "../../domain/source.ts";
 import { loadConfig } from "../../persistence/config-io.ts";
 import { writeMarketplaceConfigEntry } from "../../persistence/config-write-back.ts";
@@ -648,7 +648,7 @@ async function addGitClonedInGuard(args: {
   let finalDir: string | undefined;
   try {
     // 2. Read + validate manifest.
-    const manifestPath = path.join(stagingDir, ".claude-plugin", "marketplace.json");
+    const manifestPath = await findMarketplaceManifestPath(stagingDir);
     const parsed = await loadMarketplaceManifest(manifestPath);
 
     const derivedName = (parsed as { name: string }).name;
@@ -679,7 +679,7 @@ async function addGitClonedInGuard(args: {
       scope: locations.scope,
       source,
       addedFromCwd: cwd,
-      manifestPath: path.join(finalDir, ".claude-plugin", "marketplace.json"),
+      manifestPath: await findMarketplaceManifestPath(finalDir),
       marketplaceRoot: finalDir,
       lastUpdatedAt: new Date().toISOString(),
       plugins: {},
@@ -807,7 +807,7 @@ async function addPathInGuard(args: {
   let marketplaceRoot: string;
   if (probe.isDirectory()) {
     marketplaceRoot = onDiskPath;
-    manifestPath = path.join(marketplaceRoot, ".claude-plugin", "marketplace.json");
+    manifestPath = await findMarketplaceManifestPath(marketplaceRoot);
   } else if (probe.isFile()) {
     manifestPath = onDiskPath;
     // Walk up two levels: <root>/.claude-plugin/marketplace.json -> <root>

--- a/extensions/pi-claude-marketplace/orchestrators/marketplace/update.ts
+++ b/extensions/pi-claude-marketplace/orchestrators/marketplace/update.ts
@@ -92,9 +92,8 @@
 //  D-14 sequence: fetch + (symbolic HEAD) forceUpdateRef + checkout, OR
 //  (detached HEAD) checkout directly. NO `pull`.
 
-import path from "node:path";
 
-import { loadMarketplaceManifest } from "../../domain/manifest.ts";
+import { findMarketplaceManifestPath, loadMarketplaceManifest } from "../../domain/manifest.ts";
 import { loadMergedScopeConfig } from "../../persistence/config-merge.ts";
 import { locationsFor } from "../../persistence/locations.ts";
 import { loadState } from "../../persistence/state-io.ts";
@@ -854,7 +853,7 @@ async function validateManifestAtRoot(
   record: ExtensionState["marketplaces"][string],
   marketplaceRoot: string,
 ): Promise<void> {
-  const manifestPath = path.join(marketplaceRoot, ".claude-plugin", "marketplace.json");
+  const manifestPath = await findMarketplaceManifestPath(marketplaceRoot);
   await loadMarketplaceManifest(manifestPath);
 
   if (record.manifestPath !== manifestPath) {

--- a/extensions/pi-claude-marketplace/orchestrators/plugin/shared.ts
+++ b/extensions/pi-claude-marketplace/orchestrators/plugin/shared.ts
@@ -819,18 +819,20 @@ export async function resolvePluginVersion(
 ): Promise<string> {
   // Tier 1: the plugin's own plugin.json `version`. Re-read in place; any
   // failure falls through to the next tier (D-23-02 / D-23-03).
-  try {
-    const manifestPath = path.join(installable.pluginRoot, ".claude-plugin", "plugin.json");
-    const raw = await readFile(manifestPath, "utf8");
-    const parsed: unknown = JSON.parse(raw);
-    const pluginJsonVersion = (parsed as { version?: unknown }).version;
-    if (typeof pluginJsonVersion === "string" && pluginJsonVersion.length > 0) {
-      return pluginJsonVersion;
+  for (const manifestDir of [".claude-plugin", ".codex-plugin"]) {
+    try {
+      const raw = await readFile(path.join(installable.pluginRoot, manifestDir, "plugin.json"), "utf8");
+      const parsed: unknown = JSON.parse(raw);
+      const pluginJsonVersion = (parsed as { version?: unknown }).version;
+      if (typeof pluginJsonVersion === "string" && pluginJsonVersion.length > 0) {
+        return pluginJsonVersion;
+      }
+    } catch {
+      // try next layout
     }
-  } catch {
-    // Fall through -- plugin.json is absent, unparseable, or carries no usable
-    // version; tier 2 / tier 3 cover it.
   }
+  // Fall through -- plugin.json is absent, unparseable, or carries no usable
+  // version; tier 2 / tier 3 cover it.
 
   // Tier 2: the marketplace entry version.
   if (typeof entry.version === "string" && entry.version.length > 0) {

--- a/extensions/pi-claude-marketplace/platform/git.ts
+++ b/extensions/pi-claude-marketplace/platform/git.ts
@@ -133,6 +133,16 @@ export interface ListRemotesOptions {
   gitdir?: string;
 }
 
+/**
+ * Some smart-HTTP git servers (e.g. Bifrost's /skills/serve/* endpoints) only
+ * answer at the verbatim URL and 404 the conventional `.git` suffix. Callers
+ * pass the conventional suffixed form; try the suffix-less form first and
+ * fall back to the URL as given.
+ */
+function desuffixGitUrl(url: string): string {
+  return url.endsWith(".git") ? url.slice(0, -".git".length) : url;
+}
+
 export async function clone(opts: CloneOptions): Promise<void> {
   // When opts.auth is provided, build the isomorphic-git callbacks
   // up-front and conditionally spread them. When omitted, the public-only
@@ -148,19 +158,32 @@ export async function clone(opts: CloneOptions): Promise<void> {
   // it only takes the `url: string` parameter -- no contravariant
   // GitAuth-typed slot.
   const authCbs = opts.auth === undefined ? undefined : buildAuthCallbacks(opts.auth);
-  await git.clone({
-    fs,
-    http,
-    dir: opts.dir,
-    url: opts.url,
-    ...(opts.ref !== undefined && { ref: opts.ref }),
-    ...(opts.singleBranch !== undefined && { singleBranch: opts.singleBranch }),
-    ...(authCbs !== undefined && {
-      onAuth: authCbs.onAuth,
-      onAuthFailure: authCbs.onAuthFailure as git.AuthFailureCallback,
-    }),
-    // No depth (full history is kept). No corsProxy (Node only).
-  });
+  const doClone = (url: string) =>
+    git.clone({
+      fs,
+      http,
+      dir: opts.dir,
+      url,
+      ...(opts.ref !== undefined && { ref: opts.ref }),
+      ...(opts.singleBranch !== undefined && { singleBranch: opts.singleBranch }),
+      ...(authCbs !== undefined && {
+        onAuth: authCbs.onAuth,
+        onAuthFailure: authCbs.onAuthFailure as git.AuthFailureCallback,
+      }),
+      // No depth (full history is kept). No corsProxy (Node only).
+    });
+
+  const bare = desuffixGitUrl(opts.url);
+  if (bare !== opts.url) {
+    try {
+      await doClone(bare);
+      return;
+    } catch {
+      // Verbatim URL failed -- clean any partial clone and retry as given.
+      await fs.promises.rm(opts.dir, { recursive: true, force: true }).catch(() => {});
+    }
+  }
+  await doClone(opts.url);
 }
 
 export async function fetch(opts: FetchOptions): Promise<void> {
@@ -226,17 +249,31 @@ export async function resolveRemoteRef(opts: ResolveRemoteRefOptions): Promise<s
   // top of this file: build the callbacks only when opts.auth is defined so the
   // public-only resolution stays byte-identical.
   const authCbs = opts.auth === undefined ? undefined : buildAuthCallbacks(opts.auth);
-  const refs = await git.listServerRefs({
-    http,
-    url: opts.url,
-    protocolVersion: 2,
-    symrefs: true,
-    peelTags: true,
-    ...(authCbs !== undefined && {
-      onAuth: authCbs.onAuth,
-      onAuthFailure: authCbs.onAuthFailure as git.AuthFailureCallback,
-    }),
-  });
+  const listRefs = (url: string) =>
+    git.listServerRefs({
+      http,
+      url,
+      protocolVersion: 2,
+      symrefs: true,
+      peelTags: true,
+      ...(authCbs !== undefined && {
+        onAuth: authCbs.onAuth,
+        onAuthFailure: authCbs.onAuthFailure as git.AuthFailureCallback,
+      }),
+    });
+
+  const bare = desuffixGitUrl(opts.url);
+  let refs;
+  if (bare !== opts.url) {
+    try {
+      refs = await listRefs(bare);
+    } catch {
+      refs = undefined;
+    }
+  }
+  if (refs === undefined) {
+    refs = await listRefs(opts.url);
+  }
 
   if (opts.ref === undefined) {
     const head = refs.find((r) => r.ref === "HEAD");


### PR DESCRIPTION
## What

Three additive fallbacks, no behavior change for existing sources:

1. **Marketplace manifest lookup** (`add`/`update`): if `.claude-plugin/marketplace.json` is absent in a cloned repo, try `.agents/plugins/marketplace.json` (Codex plugin-marketplace layout).
2. **Plugin manifest lookup** (`resolver.readManifest`, `resolvePluginVersion`): if `.claude-plugin/plugin.json` is absent, try `.codex-plugin/plugin.json`.
3. **Git clone / resolveRemoteRef**: try the verbatim URL before the conventional `.git`-suffixed form. Some smart-HTTP servers only answer at the exact path and 404 the suffix.

## Why

[Bifrost](https://github.com/Maximillian-bifrost)-style skill gateways serve marketplaces as smart-HTTP git endpoints in Codex layout. With these fallbacks, pi-claude-marketplace consumes them directly:

```
/claude:plugin marketplace add https://bifrost.nucleix.io/api/skills/serve/codex
/claude:plugin install bifrost-mcp-gateway@bifrost-skills
```

Previously this failed at clone (`.git` suffix 404) and would then have failed manifest lookup (wrong manifest path).

## Tests

- `tsc --noEmit` clean (one pre-existing error in `hook-tool-names.ts` on main, unrelated: missing `powershell` key for newer pi types)
- 249 marketplace+platform tests pass, 1216 domain+plugin tests pass
- Live E2E against a Codex-layout git-served marketplace: add + install + skill materialization verified