### PR TITLE
chore(deps): pin dependabot off typescript major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,14 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      # typescript-eslint's peer dependency caps typescript at <6.1.0; a
+      # TypeScript 7 bump fails npm install (ERESOLVE) until
+      # typescript-eslint adds TS 7 support, which is blocked upstream on
+      # TypeScript 7.1 shipping a stable programmatic compiler API.
+      # https://github.com/typescript-eslint/typescript-eslint/issues/12518
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
     labels:
       - "dependencies"
       - "npm"


### PR DESCRIPTION
## Summary
- Stop Dependabot from proposing typescript major-version updates.
- typescript-eslint's peer dependency does not allow typescript 6.1 or later. A typescript 7 update breaks `npm install` with an ERESOLVE error (see #95).
- TypeScript 7 support in typescript-eslint depends on TypeScript 7.1's compiler API. typescript-eslint closed the TS 7 request as not planned: https://github.com/typescript-eslint/typescript-eslint/issues/12518

## Test plan
- [x] `pre-commit run --files .github/dependabot.yml` passes (yamllint, yamlfmt, gitlint)
- [ ] After merge, confirm Dependabot does not reopen a typescript major-version PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B27vNenc6wUxpuYNBwkXAk
