### PR TITLE
chore: add /merge-dependabot-prs command

### DIFF
--- a/.claude/commands/merge-dependabot-prs.md
+++ b/.claude/commands/merge-dependabot-prs.md
@@ -1,0 +1,62 @@
+---
+description: Drive every open Dependabot PR to main, one at a time — sync from main via GitHub, wait for its checks (fixing failures until green), squash-merge, wait for CI on main, then move to the next PR. Invoke manually.
+argument-hint: "[PR number] (defaults to every open Dependabot PR, oldest first)"
+allowed-tools: Bash, Read, Edit, Write, Grep, Glob, Task
+---
+
+# Merge Dependabot PRs
+
+Land the routine dependency-bump PRs Dependabot opens against this repo, one at a time, without a human doing the sync/wait/fix/merge loop by hand. Each PR goes through the same four phases before moving to the next.
+
+## Phase 0 — Build the queue
+
+`gh pr list --search "author:app/dependabot" --state open --json number,title,headRefName,isDraft`.
+
+`$ARGUMENTS`, if it names a PR number, restricts the queue to that one PR; otherwise process every open Dependabot PR, lowest PR number (oldest) first. Skip drafts. If the queue is empty, say so and stop.
+
+Re-derive this list at the start of every iteration, not just once — merging one PR can cause Dependabot or GitHub to close, rebase, or update others (e.g. two PRs touching the same lockfile), and a stale in-memory list can point at a PR that no longer needs handling.
+
+## Phase 1 — Sync from main (GitHub-side)
+
+`gh pr update-branch <PR#>`. This merges `main` into the PR branch server-side and is a no-op if already up to date. Never pass `--rebase` — this project's convention is merge, not rebase, and rewriting history on a bot-owned branch fights Dependabot's own next push. If it reports a conflict, `gh pr checkout <PR#>`, `git merge main` locally, resolve, push — still no rebase.
+
+## Phase 2 — Wait for checks; fix on failure
+
+1. `gh pr checks <PR#> --watch --json name,bucket,workflowName,link` — blocks until every check completes.
+2. If everything is `pass` or `skipping` (SonarCloud is expected to skip on Dependabot PRs — no secrets access — that's not a failure), go to Phase 3.
+3. On any `fail`:
+   - `gh pr checkout <PR#>`.
+   - Find the failing run (`gh run list --branch <headRefName> --limit 5`, or the check's `link`) and read it: `gh run view <run-id> --log-failed`.
+   - Diagnose the real cause — usually the bump changed an API, a type, or tripped a lint rule. Fix the code, not the pin: don't quietly hold the dependency back to dodge the failure. If a genuine fix isn't mechanical, stop and report this PR instead of merging a workaround.
+   - Before committing: `npm run check`, then `pre-commit run --all-files` — fix, restage, re-run until clean. Never `--no-verify`.
+   - Commit (Conventional Commits) and push to the PR branch.
+   - Back to step 1.
+4. Cap at 4 fix rounds. If a round doesn't shrink the failing-check count, or a fix reappears, stop, leave this PR unmerged, and move to the next one in the queue.
+
+For a nontrivial fix, delegate the diagnose-and-fix work to a subagent (Task tool) so its transcript doesn't balloon this orchestrating conversation across a multi-PR run.
+
+## Phase 3 — Squash-merge
+
+`gh pr merge <PR#> --squash --delete-branch`. This repo only allows squash merges and doesn't auto-delete branches on merge (`delete_branch_on_merge: false`) — `--delete-branch` cleans up; Dependabot recreates the branch fresh on its next check-in. Capture the merge commit SHA (`gh pr view <PR#> --json mergeCommit`).
+
+## Phase 4 — Wait for CI on main
+
+`git checkout main && git pull`. Then `gh run list --commit <merge-sha> --json databaseId,workflowName,conclusion,status` and `gh run watch <id> --exit-status` on each run until all complete.
+
+If anything on main fails after the merge, stop the whole run and report — don't merge the next PR on top of a red main. A post-merge failure (versus a pre-merge PR-branch failure in Phase 2) means something interacted unexpectedly and needs a closer look before continuing.
+
+## Loop
+
+Back to Phase 0. Continue until the queue is empty or a Phase 4 failure stops the run.
+
+## Guards
+
+- **Autonomous but bounded.** No stopping to ask per PR — that's the point. This repo has no branch protection (`branches/main/protection` → 404), so the fix-round cap and the stop-on-red-main rule are the real safety net, same posture as `/babysit-pr`.
+- **Never bypass hooks or checks.** No `--no-verify`, no disabling a check, no won't-fix flip to force a merge through.
+- **Fix the code, not the pin.** A bump's whole point is to land; don't revert the version change to make CI pass.
+- **Never rebase, never rewrite history.** Sync and conflict resolution are always a merge.
+- **Stop on red main.** One Phase 4 failure halts the run rather than compounding it.
+
+## Finish
+
+Report per PR: merged / parked-with-reason, what fixes were needed (if any), and the final state of main's CI. Name anything left unmerged and why.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,5 +3,10 @@
     "typescript-lsp@claude-plugins-official": true,
     "humanizer@humanizer": true,
     "pr-review-toolkit@claude-plugins-official": true
+  },
+  "statusLine": {
+    "type": "command",
+    "command": "test -f \"$CLAUDE_PROJECT_DIR/.claude/hooks/gsd-statusline.js\" && node \"$CLAUDE_PROJECT_DIR/.claude/hooks/gsd-statusline.js\"",
+    "padding": 0
   }
 }

--- a/.planning/BACKLOG.md
+++ b/.planning/BACKLOG.md
@@ -2444,6 +2444,35 @@ BLOCKERs -- per-pair coverage is not evidence of assertion strength.
 Code seams: named per-finding throughout the corpus; the two synthesis
 documents carry `file:line` for every claim.
 
+## HKPS-01: if-field `PowerShell(...)` rule prefix support (now unblocked)
+
+Deferred as an idea in the archived `61-if-field-permission-rule-matcher/
+61-CONTEXT.md` (v1.13): "Pi has no PowerShell tool. v1.14+ may add a Pi
+PowerShell tool + corresponding bridge support." `@earendil-works/
+pi-coding-agent` 0.84.4 (2026-09-04 dependency bump, PR #158) adds exactly
+that -- a native `powershell` tool (`PowerShellToolCallEvent`,
+`createPowerShellTool`) -- so the blocker is resolved and this item is now
+actionable.
+
+That same dependency bump forced `hook-tool-names.ts`'s
+`satisfies Record<PiToolName, string>` exhaustiveness gate to add the eighth
+literal (PR #158). That fix is the identity-mapping layer only --
+`powershell <-> "PowerShell"` in `PI_TO_CLAUDE_TOOL_NAMES` /
+`CLAUDE_TO_PI_TOOL_NAMES` -- which already wires the top-level `matcher`
+field (`hooks/matcher.ts`) and the payload translators
+(`mapPiToClaudeToolName`) end to end.
+
+**What's still missing:** the `if:` field's per-tool predicate compiler.
+`IF_PREFIX_TARGETS` (`hook-if-targets.ts`) is a locked closed set -- `Bash` /
+`Read` / `Edit` / `Write` -- and `PowerShell(...)` still falls into
+`compileIfPredicate`'s unknown-prefix fail-open arm (D-61-02): it silently
+matches every event rather than filtering on the command, the same state
+`Bash(...)` was in before D-61 shipped. Landing this means a
+`compilePowerShellGlob` sibling to `compileBashGlob`
+(`bridges/hooks/if-field/index.ts`), a `PowerShell` entry in
+`IF_PREFIX_TARGETS` mapping to `{"powershell"}`, and test coverage mirroring
+the existing `Bash(...)` predicate suite.
+
 <!--
 Pruned 2026-06-08: both prior items shipped in v1.10 Error Attribution.
 - "Install error misattribution when marketplace is missing" -> closed by ATTR-01..10


### PR DESCRIPTION
## Summary

- Adds `.claude/commands/merge-dependabot-prs.md`, a Claude Code slash command.
- The command drives every open Dependabot PR to `main`, one at a time.
- For each PR: sync from `main` through `gh pr update-branch`, wait for its checks, fix any failure until checks pass, squash-merge, then wait for CI on `main` before moving to the next PR.
- It follows the same autonomous, capped pattern as the existing `/babysit-pr` command: no branch protection on this repo, so a fix-round cap and a stop-on-red-`main` rule are the safety net.

## Test plan

- [ ] Read through the command file for correctness (no code path to unit-test — it is a runbook, not executable code).
- [ ] Run `/merge-dependabot-prs` against the current open Dependabot PRs and confirm it syncs, waits, merges, and stops cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U6kq3K26M56xgdi7wvch9s